### PR TITLE
Use platform-specific path separator in makeRelativePath function

### DIFF
--- a/FDK/Tools/SharedData/FDKScripts/MakeOTF.py
+++ b/FDK/Tools/SharedData/FDKScripts/MakeOTF.py
@@ -2072,7 +2072,7 @@ def makeRelativePath(curDir, targetPath):
 			cDir = cDir[1:]
 		dirList = re.findall(r"([^\\/]+)", cDir)
 		numDir = len(dirList)
-		relDir = "../"*numDir
+		relDir = (".."+os.path.sep)*numDir
 		targetPath = os.path.join(relDir, targetBaseName)
 	else:
 		if cDir[0] in ["/", "\\"]:
@@ -2083,7 +2083,7 @@ def makeRelativePath(curDir, targetPath):
 		# First build the reative path up.
 		dirList = re.findall(r"([^\\/]+)", cDir)
 		numDir = len(dirList)
-		relDir = "../"*numDir
+		relDir = (".."+os.path.sep)*numDir
 		targetPath = os.path.join(relDir, targetBaseName)
 		targetPath = os.path.join(relDir, tdir, targetBaseName)
 		


### PR DESCRIPTION
I have discussed this issue on the AFDKO mailing list:
https://groups.google.com/forum/#!topic/uafdkoml/2Xpq5ZzAUU8

Basically, the `makeRelativePath` function in MakeOTF.py is enforcing UNIX forward slashes `/` instead of picking the required OS-specific path separator. This makes the ttx command fail when compiling TTF/OTF fonts on Windows -- where a backslash `\` is required instead.

Cheers,

Cosimo
