### PR TITLE
fix reading of underline position from TTF files

### DIFF
--- a/FDK/Tools/Programs/public/lib/source/ttread/ttread.c
+++ b/FDK/Tools/Programs/public/lib/source/ttread/ttread.c
@@ -1877,7 +1877,7 @@ static void fillClientData(ttrCtx h)
 		{
 		top->isFixedPitch		= h->post.isFixedPitch;
 		top->ItalicAngle		= FIX2FLT(h->post.italicAngle);
-		top->UnderlinePosition	= h->post.underlinePosition;
+		top->UnderlinePosition  = h->post.underlinePosition - floor(h->post.underlineThickness * 0.5);
 		top->UnderlineThickness = h->post.underlineThickness;
 		}
 	else


### PR DESCRIPTION
This then gives the same result from CFF based files
