### PR TITLE
[otf2ofc.py] pad table data to multiple of four bytes in accordance with OT specs

### DIFF
--- a/FDK/Tools/SharedData/FDKScripts/otf2otc.py
+++ b/FDK/Tools/SharedData/FDKScripts/otf2otc.py
@@ -197,7 +197,8 @@ def writeTTC(fontList, tableList, ttcFilePath):
 	for tableEntryList in tableList:
 		for tableEntry in tableEntryList:
 			tableEntry.offset = fontOffset
-			fontOffset += tableEntry.length
+			paddedLength = (tableEntry.length + 3) & ~3
+			fontOffset += paddedLength
 			
 	# save the font sfnt directories
 	for fontEntry in fontList:
@@ -210,7 +211,9 @@ def writeTTC(fontList, tableList, ttcFilePath):
 	# save the tables.
 	for tableEntryList in tableList:
 		for tableEntry in tableEntryList:
-			dataList.append(tableEntry.data)
+			paddedLength = (tableEntry.length + 3) & ~3
+			paddedData = tableEntry.data + b"\0" * (paddedLength - tableEntry.length)
+			dataList.append(paddedData)
 	
 	fontData = "".join(dataList)
 	


### PR DESCRIPTION
The current otf2otc.py script produces misaligned sfnt tables because it does not align offsets to 4-byte boundaries.
Here's an excerpt from http://www.microsoft.com/typography/otspec/otff.htm

> the length of a table must be a multiple of four bytes. In fact, a font is not considered structurally proper without the correct padding. All tables must begin on four byte boundaries, and any remaining space between tables is padded with zeros. The length of all tables should be recorded in the table record with their actual length (not their padded length).

I modified it to add padding where required.
Cheers,

Cosimo