### PR TITLE
Update autohint.py

### DIFF
--- a/FDK/Tools/SharedData/FDKScripts/autohint.py
+++ b/FDK/Tools/SharedData/FDKScripts/autohint.py
@@ -3,7 +3,7 @@ __copyright__ = """Copyright 2014 Adobe Systems Incorporated (http://www.adobe.c
 """
 
 __usage__ = """
-autohint  AutoHinting program v1.46 Feb 10 2105
+autohint  AutoHinting program v1.46 Feb 10 2015
 autohint -h
 autohint -u
 autohint -hfd


### PR DESCRIPTION
Typo found while verifying which version of the FDK I had installed. Though, I'd love to see the 2105 version of auto hint, perhaps by then it will be a single line: pass.