### PR TITLE
Revert "Remove 32bit architecture dependence"

### DIFF
--- a/FDK/Tools/Programs/public/config/linux/gcc/gcc.mak
+++ b/FDK/Tools/Programs/public/config/linux/gcc/gcc.mak
@@ -14,7 +14,7 @@ PLATFORM = linux
 HARDWARE = i86
 COMPILER = gcc
 SYS_LIBS = -lm
-XFLAGS =
+XFLAGS = -m32
 
 # Directories (relative to build directory)
 CT_LIB_DIR = $(ROOT_DIR)/../public/lib/lib/$(PLATFORM)/$(CONFIG)

--- a/FDK/Tools/Programs/public/lib/config/linux/gcc/gcc.mak
+++ b/FDK/Tools/Programs/public/lib/config/linux/gcc/gcc.mak
@@ -13,7 +13,7 @@
 PLATFORM = linux
 HARDWARE = i86
 COMPILER = gcc
-XFLAGS =
+XFLAGS = -m32
 # Directories (relative to build directory)
 LIB_DIR = $(ROOT_DIR)/lib/$(PLATFORM)/$(CONFIG)
 

--- a/FDK/Tools/Programs/public/lib/config/linux/gcc/gcc_tx.mak
+++ b/FDK/Tools/Programs/public/lib/config/linux/gcc/gcc_tx.mak
@@ -13,7 +13,7 @@
 PLATFORM = linux
 HARDWARE = i86
 COMPILER = gcc
-XFLAGS =
+XFLAGS = -m32
 
 # Directories (relative to build directory)
 LIB_DIR = $(ROOT_DIR)/lib/$(PLATFORM)/$(CONFIG)

--- a/FDK/Tools/Programs/sfntdiff/build/linux/gcc/debug/Makefile
+++ b/FDK/Tools/Programs/sfntdiff/build/linux/gcc/debug/Makefile
@@ -7,7 +7,7 @@ CONFIG = debug
 ROOT_DIR = ../../../..
 OBJECT_DIR = .
 
-CFLAGS = $(STD_OPTS) -g -I$(ROOT_DIR)/../spot/sfnt_includes
+CFLAGS = $(STD_OPTS) -m32 -g -I$(ROOT_DIR)/../spot/sfnt_includes
 
 # Program
 PRG_SRCS = $(SRC_DIR)/Dmain.c \

--- a/FDK/Tools/Programs/sfntdiff/build/linux/gcc/release/Makefile
+++ b/FDK/Tools/Programs/sfntdiff/build/linux/gcc/release/Makefile
@@ -7,7 +7,7 @@ CONFIG = release
 ROOT_DIR = ../../../..
 OBJECT_DIR = .
 
-CFLAGS = $(STD_OPTS) -I$(ROOT_DIR)/../spot/sfnt_includes
+CFLAGS = $(STD_OPTS) -m32 -I$(ROOT_DIR)/../spot/sfnt_includes
 
 # Program
 PRG_SRCS = $(SRC_DIR)/Dmain.c \

--- a/FDK/Tools/Programs/sfntedit/build/linux/gcc/debug/Makefile
+++ b/FDK/Tools/Programs/sfntedit/build/linux/gcc/debug/Makefile
@@ -7,7 +7,7 @@ CONFIG = debug
 ROOT_DIR = ../../../..
 OBJECT_DIR = .
 
-CFLAGS = $(STD_OPTS) -g -I$(ROOT_DIR)/../spot/sfnt_includes
+CFLAGS = $(STD_OPTS) -m32  -g -I$(ROOT_DIR)/../spot/sfnt_includes
 
 # Program
 PRG_SRCS = $(SRC_DIR)/Eda.c \

--- a/FDK/Tools/Programs/sfntedit/build/linux/gcc/release/Makefile
+++ b/FDK/Tools/Programs/sfntedit/build/linux/gcc/release/Makefile
@@ -7,7 +7,7 @@ CONFIG = release
 ROOT_DIR = ../../../..
 OBJECT_DIR = .
 
-CFLAGS = $(STD_OPTS) -I$(ROOT_DIR)/../spot/sfnt_includes
+CFLAGS = $(STD_OPTS) -m32 -I$(ROOT_DIR)/../spot/sfnt_includes
 
 # Program
 PRG_SRCS = $(SRC_DIR)/Eda.c \

--- a/FDK/Tools/Programs/spot/build/linux/gcc/debug/Makefile
+++ b/FDK/Tools/Programs/spot/build/linux/gcc/debug/Makefile
@@ -13,7 +13,7 @@ PRG_TARGET = $(EXE_DIR)/spot
 # Build targets
 TARGETS = $(PRG_TARGET)
 
-CFLAGS = $(STD_OPTS) -g -I$(ROOT_DIR)/sfnt_includes -I$(SRC_DIR) -DEXECUTABLE=1 -g
+CFLAGS = $(STD_OPTS) -m32 -g -I$(ROOT_DIR)/sfnt_includes -I$(SRC_DIR) -DEXECUTABLE=1 -g
 
 # Program
 PRG_SRCS = $(SRC_DIR)/BASE.c \

--- a/FDK/Tools/Programs/spot/build/linux/gcc/release/Makefile
+++ b/FDK/Tools/Programs/spot/build/linux/gcc/release/Makefile
@@ -13,7 +13,7 @@ PRG_TARGET = $(EXE_DIR)/spot
 # Build targets
 TARGETS = $(PRG_TARGET)
 
-CFLAGS = $(STD_OPTS) -g -I$(ROOT_DIR)/sfnt_includes -I$(SRC_DIR) -DEXECUTABLE=1
+CFLAGS = $(STD_OPTS) -m32 -g -I$(ROOT_DIR)/sfnt_includes -I$(SRC_DIR) -DEXECUTABLE=1
 
 # Program
 PRG_SRCS = $(SRC_DIR)/BASE.c \


### PR DESCRIPTION
Code in the FDK depends on the assumption that it will be compiled on a 32 bit platform. Until someone decides to actually remove all the 32bit-dependent code from the FDK, these flags should remain.

Fixes issue #48