### PR TITLE
Fix libautohintlib path in Xcode project.

### DIFF
--- a/FDK/Tools/Programs/autohint/build/osx/xcode4/autohintexe.xcodeproj/project.pbxproj
+++ b/FDK/Tools/Programs/autohint/build/osx/xcode4/autohintexe.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		56AE0BA81A633867000ECBEE /* libautohintlib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 56AE0BA71A633867000ECBEE /* libautohintlib.a */; };
+		BB2B3E751B3CFAF600641593 /* libautohintlib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 56AE0BAD1A633B80000ECBEE /* libautohintlib.a */; };
 		BD5BF4170D9AD1F80015F645 /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = BD5BF4160D9AD1F80015F645 /* main.c */; };
 /* End PBXBuildFile section */
 
@@ -63,7 +63,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				56AE0BA81A633867000ECBEE /* libautohintlib.a in Frameworks */,
+				BB2B3E751B3CFAF600641593 /* libautohintlib.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
For some reason, the Xcode project for autohint was looking for libautohintlib using an explicit path to a DerivedData directory under ~/Library. This caused a build failure for anyone who didn't have the library compiled in that exact place.

This should hopefully fix that, by changing the build to find that library via its subproject.