### PR TITLE
Do not require Mac name ID's for feature names

### DIFF
--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/GPOS.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/GPOS.c
@@ -1276,7 +1276,6 @@ static void fillSizeFeature(hotCtx g, GPOSCtx h, Subtable *sub) {
 	 * if so, then there is no special sub family menu name.
 	 */
 	if ((sub->feature == size_) && (params[kSizeSubFamilyID] != 0)) {
-		int nameIDPresent;
 		unsigned short nameid =  h->featNameID;
 
 		params[kSizeMenuNameID] = nameid;
@@ -1284,15 +1283,11 @@ static void fillSizeFeature(hotCtx g, GPOSCtx h, Subtable *sub) {
 		/* If there is a sub family menu name id, check if the default names are present,
 		 * and complain if they are not.
 		 */
-		nameIDPresent = 0;
 		if (nameid != 0) {
-			nameIDPresent = nameVerifyDefaultNames(g, nameid);
-		}
-
-		if (nameIDPresent != 0) {
-			if (nameIDPresent & MISSING_WIN_DEFAULT_NAME) {
-				hotMsg(g, hotFATAL, "Missing Windows default name for size feature menu name nameid %i",  nameid);
-			}
+		    unsigned short nameIDPresent = nameVerifyDefaultNames(g, nameid);
+		    if (nameIDPresent && nameIDPresent & MISSING_WIN_DEFAULT_NAME) {
+			hotMsg(g, hotFATAL, "Missing Windows default name for for feature name  nameid %i",  nameid);
+		    }
 		}
 	}
 	else {

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/GPOS.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/GPOS.c
@@ -1290,14 +1290,8 @@ static void fillSizeFeature(hotCtx g, GPOSCtx h, Subtable *sub) {
 		}
 
 		if (nameIDPresent != 0) {
-			if ((nameIDPresent & MISSING_WIN_DEFAULT_NAME) && (nameIDPresent & MISSING_MAC_DEFAULT_NAME)) {
-				hotMsg(g, hotFATAL, "Missing both Mac and Windows default names for size feature menu name nameid %i",  nameid);
-			}
-			else if (nameIDPresent & MISSING_WIN_DEFAULT_NAME) {
+			if (nameIDPresent & MISSING_WIN_DEFAULT_NAME) {
 				hotMsg(g, hotFATAL, "Missing Windows default name for size feature menu name nameid %i",  nameid);
-			}
-			else if (nameIDPresent & MISSING_MAC_DEFAULT_NAME) {
-				hotMsg(g, hotFATAL, "Missing Mac default name for size feature menu name nameid %i",  nameid);
 			}
 		}
 	}

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/GSUB.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/GSUB.c
@@ -763,15 +763,8 @@ static void fillGSUBFeatureNameParam(hotCtx g, GSUBCtx h, Subtable *sub) {
 	}
 
 	if (nameIDPresent != 0) {
-		if ((nameIDPresent & MISSING_WIN_DEFAULT_NAME)
-		    && (nameIDPresent & MISSING_MAC_DEFAULT_NAME)) {
-			hotMsg(g, hotFATAL, "Missing both Mac and Windows default names for feature name  nameid %i",  nameid);
-		}
-		else if (nameIDPresent & MISSING_WIN_DEFAULT_NAME) {
+		if (nameIDPresent & MISSING_WIN_DEFAULT_NAME) {
 			hotMsg(g, hotFATAL, "Missing Windows default name for for feature name  nameid %i",  nameid);
-		}
-		else if (nameIDPresent & MISSING_MAC_DEFAULT_NAME) {
-			hotMsg(g, hotFATAL, "Missing Mac default name for for feature name  nameid %i",  nameid);
 		}
 	}
 }
@@ -821,15 +814,8 @@ static void fillGSUBCVParam(hotCtx g, GSUBCtx h, Subtable *sub) {
         if (nameid != 0) {
             unsigned short nameIDPresent = nameVerifyDefaultNames(g, nameid);
             if (nameIDPresent != 0) {
-                if ((nameIDPresent & MISSING_WIN_DEFAULT_NAME)
-                    && (nameIDPresent & MISSING_MAC_DEFAULT_NAME)) {
-                    hotMsg(g, hotFATAL, "Missing both Mac and Windows default names for feature name  nameid %i",  nameid);
-                }
-                else if (nameIDPresent & MISSING_WIN_DEFAULT_NAME) {
+                if (nameIDPresent & MISSING_WIN_DEFAULT_NAME) {
                     hotMsg(g, hotFATAL, "Missing Windows default name for for feature name  nameid %i",  nameid);
-                }
-                else if (nameIDPresent & MISSING_MAC_DEFAULT_NAME) {
-                    hotMsg(g, hotFATAL, "Missing Mac default name for for feature name  nameid %i",  nameid);
                 }
             }
         }

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/GSUB.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/GSUB.c
@@ -754,19 +754,14 @@ void GSUBSetFeatureNameID(hotCtx g, Tag feat, unsigned short nameID) {
 
 static void fillGSUBFeatureNameParam(hotCtx g, GSUBCtx h, Subtable *sub) {
 	FeatureNameParameterFormat *feat_param = (FeatureNameParameterFormat *)sub->tbl;
-	int nameIDPresent = 0;
 	unsigned short nameid = feat_param->nameID;
 
-	nameIDPresent = 0;
-	if (nameid != 0) {
-		nameIDPresent = nameVerifyDefaultNames(g, nameid);
-	}
-
-	if (nameIDPresent != 0) {
-		if (nameIDPresent & MISSING_WIN_DEFAULT_NAME) {
-			hotMsg(g, hotFATAL, "Missing Windows default name for for feature name  nameid %i",  nameid);
-		}
-	}
+        if (nameid != 0) {
+            unsigned short nameIDPresent = nameVerifyDefaultNames(g, nameid);
+            if (nameIDPresent && nameIDPresent & MISSING_WIN_DEFAULT_NAME) {
+                hotMsg(g, hotFATAL, "Missing Windows default name for for feature name  nameid %i",  nameid);
+            }
+        }
 }
 
 static void writeGSUBFeatNameParam(GSUBCtx h, Subtable *sub) {
@@ -813,10 +808,8 @@ static void fillGSUBCVParam(hotCtx g, GSUBCtx h, Subtable *sub) {
         unsigned short nameid = nameIDs[i++];
         if (nameid != 0) {
             unsigned short nameIDPresent = nameVerifyDefaultNames(g, nameid);
-            if (nameIDPresent != 0) {
-                if (nameIDPresent & MISSING_WIN_DEFAULT_NAME) {
-                    hotMsg(g, hotFATAL, "Missing Windows default name for for feature name  nameid %i",  nameid);
-                }
+            if (nameIDPresent && nameIDPresent & MISSING_WIN_DEFAULT_NAME) {
+                hotMsg(g, hotFATAL, "Missing Windows default name for for feature name  nameid %i",  nameid);
             }
         }
         


### PR DESCRIPTION
Do not require Mac name ID's for feature names and size feature as well, see #58.