### PR TITLE
Update MutatorMath installation instructions

### DIFF
--- a/FDK/FDK Build Notes.txt
+++ b/FDK/FDK Build Notes.txt
@@ -100,7 +100,6 @@ directory and the LICENSE.txt file.
 
 defcon-ufo3: ufo3 branch of defcon library at https://github.com/typesupply/defcon/tree/ufo3.
 Install with "AFDKOPython setup.py install"
-The install script has a bug, in that it does not copy any of the subdirectories of defcon. Copy these manually.
 
 MutatorMath: master branch of MutatorMath at https://github.com/LettError/MutatorMath
 Install with "AFDKOPython setup.py install"


### PR DESCRIPTION
Build notes on MutatorMath mention a bug in the setup script of defcon. It has been fixed since on both master (typesupply/defcon@9f747f1e23110e38c525632fd8aa8ee077e314c3) and ufo3 branch (typesupply/defcon@4f8777c25d9a52965227b488bc505dfce991adf9). 