### PR TITLE
vertical width was not referred when proofing group-based vkrn lookups

### DIFF
--- a/FDK/Tools/Programs/spot/source/GPOS.c
+++ b/FDK/Tools/Programs/spot/source/GPOS.c
@@ -1863,9 +1863,9 @@ static void proofPosPair1(PosPairFormat1 *fmt, IntX glyphtoproof1, IntX glyphtop
 						  if (isVert)
 					  		{
 					  		  if (yadv)
-					  	  		options.newwidth = -(abs(vwidth) + yadv);
+					  	  		options.newvwidth = -(abs(vwidth) + yadv);
 					  		  else
-						  		options.newwidth = -(abs(vwidth) + xadv);					  	  
+						  		options.newvwidth = -(abs(vwidth) + xadv);					  	  
 					  		}
 						  else
 					  		{
@@ -2128,7 +2128,10 @@ static void proofPosPair2(PosPairFormat2 *fmt, IntX glyphtoproof1, IntX glyphtop
 							  else
 								proofCheckAdvance(proofctx, width + width2);
 							  proofClearOptions(&options);
-							  options.newwidth = width + xadv;
+                                                          if (isVert)
+                                                                  options.newvwidth = vwidth + yadv;
+                                                          else
+                                                                  options.newwidth = width + xadv;
 							  proofDrawGlyph(proofctx, 
 											 g1, ANNOT_SHOWIT, /* glyphId,glyphflags */
 											 nam1, ANNOT_SHOWIT|(isVert ? ANNOT_ATRIGHT : ANNOT_ATBOTTOM),   /* glyphname,glyphnameflags */

--- a/FDK/Tools/Programs/spot/source/proof.c
+++ b/FDK/Tools/Programs/spot/source/proof.c
@@ -1753,10 +1753,20 @@ void proofDrawGlyph(ProofContextPtr ctx,
 	   proofThinspace(ctx, 1);
 	 }
 	 else {
-	   if (options && options->newwidth)
-		advance(ctx, options->newwidth);
-	   else
-		advance(ctx, width);
+	   if (isVert)
+		 {
+		   if (options && options->newvwidth)
+			 advance(ctx, options->newvwidth);
+		   else
+			 advance(ctx, width);
+		 }
+  	   else
+		 {
+		   if (options && options->newwidth)
+			 advance(ctx, options->newwidth);
+		   else
+			 advance(ctx, width);
+		 }
 	 }
 	 if (ctx->thinspace) {
 	   if (isVert)


### PR DESCRIPTION
Proofing command: 'spot -Pvkrn GroupKern.otf > GroupKern.ps'
result (left: current version, right: after modified) : 
![screenshot](https://cloud.githubusercontent.com/assets/5572285/10684636/99f0f7ba-798a-11e5-8628-fb77d89ab850.png)
