### PR TITLE
Check correct output path for makeotf failure

### DIFF
--- a/FDK/Tools/SharedData/FDKScripts/MakeOTF.py
+++ b/FDK/Tools/SharedData/FDKScripts/MakeOTF.py
@@ -2488,10 +2488,10 @@ def runMakeOTF(makeOTFParams):
 		if tempGOADBPath:
 			os.remove(tempGOADBPath)
 		
-	if not os.path.exists(tempOutPath) or (os.path.getsize(tempOutPath) < 500):
-		print "makeotf [Error] Failed to build output font file '%s'." % (tempOutPath)
-		if os.path.exists(tempOutPath):
-			os.remove(tempOutPath)
+	if not os.path.exists(outputPath) or (os.path.getsize(outputPath) < 500):
+		print "makeotf [Error] Failed to build output font file '%s'." % (outputPath)
+		if os.path.exists(outputPath):
+			os.remove(outputPath)
 		raise MakeOTFRunError
 
 	# The following check is here because of the internal Adobe production process for CID fonts, where a


### PR DESCRIPTION
This is checking the wrong path. For CFF fonts it doesn't make a
difference, tempOutPath and outputPath are the same. But for TrueType
fonts tempOutPath points to a temporary CFF font which should have
been deleted, thus it always thinks TTF generation has failed.