### PR TITLE
Fix broken ufonormalizer call

### DIFF
--- a/FDK/Tools/SharedData/FDKScripts/makeInstancesUFO.py
+++ b/FDK/Tools/SharedData/FDKScripts/makeInstancesUFO.py
@@ -433,7 +433,7 @@ def run(args):
 	if options.doOverlapRemoval or options.doAutoHint: # The defcon library renames glyphs. Need to fix them again.
 		for instancePath in newInstancesList:
 			if haveUfONormalizer and options.doNormalize:
-				ufonormalizerLib.normalizeUFO(instancePath, outputPath=None, onlyModified=False)
+				ufonormalizer.normalizeUFO(instancePath, outputPath=None, onlyModified=False)
 
 if __name__=='__main__':
 	try:


### PR DESCRIPTION
The `ufonormalizerLib` import name changed to `ufonormalizer` in commit 28c50d7.
Line 419 was changed accordingly, but the call on 436 was missed. This commit fixes that.