### PR TITLE
64bit andfixes

### DIFF
--- a/FDK/Tools/Programs/makeotf/makeotf_lib/api/cffread.h
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/api/cffread.h
@@ -5,6 +5,7 @@ This software is licensed as OpenSource, under the Apache License, Version 2.0. 
 #define CFFREAD_H
 
 #include <stddef.h>             /* For size_t */
+#include <stdint.h>             /* For size_t */
 
 #define CFF_VERSION 0x010005    /* Library version */
 
@@ -124,7 +125,7 @@ struct cffStdCallbacks_
        input functions. */
     };
 
-typedef long cffFixed;          /* 16.16 fixed point */
+typedef int32_t cffFixed;          /* 16.16 fixed point */
 
 void cffSetUDV(cffCtx h, int nAxes, cffFixed *UDV);
 void cffSetWV(cffCtx h, int nMasters, cffFixed *WV);

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/api/hotconv.h
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/api/hotconv.h
@@ -5,6 +5,7 @@ This software is licensed as OpenSource, under the Apache License, Version 2.0. 
 #define HOT_H
 
 #include <stddef.h>             /* For size_t */
+#include <stdint.h>             /* For int32_t */
 
 #ifdef __cplusplus
 extern "C" {
@@ -628,7 +629,7 @@ void hotAddUnencChar(hotCtx g, int iChar, char *name);
    glyphs of a kern pair with a name when one or both glyphs are unencoded.
    This name is subsequently converted into a glyph id by the library. */
 
-typedef long hotFixed;          /* 16.16 fixed point */
+typedef int32_t hotFixed;          /* 16.16 fixed point */
 void hotAddAxisData(hotCtx g, int iAxis,
                     char *type, char *longLabel, char *shortLabel,
                     hotFixed minRange, hotFixed maxRange);

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/api/pstoken.h
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/api/pstoken.h
@@ -9,7 +9,7 @@
 
 #ifndef PSTOKEN_H
 #define PSTOKEN_H
-
+#include <stdint.h>
 #include <stddef.h>
 
 #include "dynarr.h"
@@ -122,17 +122,17 @@ psToken *psFindToken(psCtx h, int type, char *value);
 int psMatchValue(psCtx h, psToken *token, char *strng);
 char *psGetValue(psCtx h, psToken *token);
 
-long psGetInteger(psCtx h);
+int32_t psGetInteger(psCtx h);
 double psGetReal(psCtx h);
 char *psGetString(psCtx h, unsigned *length);
 int psGetHexLength(psCtx h, psToken *token);
-unsigned long psGetHexString(psCtx h, int *length);
+uint32_t psGetHexString(psCtx h, int *length);
 
-long psConvInteger(psCtx h, psToken *token);
+int32_t psConvInteger(psCtx h, psToken *token);
 double psConvReal(psCtx h, psToken *token);
 char *psConvString(psCtx h, psToken *token, unsigned *length);
 char *psConvLiteral(psCtx h, psToken *token, unsigned *length);
-unsigned long psConvHexString(psCtx h, psToken *token);
+uint32_t psConvHexString(psCtx h, psToken *token);
 
 /* Exception handling */
 void CDECL psWarning(psCtx h, char *fmt, ...);

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/cffread/cffread.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/cffread/cffread.c
@@ -2199,7 +2199,9 @@ static void cffRead(cffCtx h) {
 	}
 	else {
 		/* Read Private DICT */
-		DICTRead(h, h->dict.Private.length, h->dict.Private.offset, 1);
+                if (h->dict.Private.length > 0) {
+    		    DICTRead(h, h->dict.Private.length, h->dict.Private.offset, 1);
+                }
 
 		/* Read Subrs index */
 		if (h->dict.Subrs != 0) {

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/cffread/cffread.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/cffread/cffread.c
@@ -34,7 +34,7 @@ static short exenc[] = {
 #define ABS(v)            ((v) < 0 ? -(v) : (v))
 
 /* 16.16 fixed point arithmetic */
-typedef long Fixed;
+typedef int32_t Fixed;
 #define fixedScale    65536.0
 #define FixedMax    ((Fixed)0x7FFFFFFF)
 #define FixedMin    ((Fixed)0x80000000)

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/GPOS.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/GPOS.c
@@ -895,7 +895,7 @@ void GPOSFeatureEnd(hotCtx g) {
 #define ValueYIdAdvance     (1 << 11)
 
 #define VAL_REC_UNDEF       (-1)
-typedef long ValueRecord;   /* Stores index into h->values, which is read at write time. If -1, then write 0; */
+typedef int32_t ValueRecord;   /* Stores index into h->values, which is read at write time. If -1, then write 0; */
 
 
 

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/GPOS.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/GPOS.c
@@ -1494,8 +1494,8 @@ static void fillSinglePos(hotCtx g, GPOSCtx h) {
 	size2 = fillAllSinglePos2(g, h, 1 /* simulate */, &nSub2);
 
 #if 1
-	DF(2, (stderr, "### singlePos1 size=%lu (%d subtables)\n", size1, nSub1));
-	DF(2, (stderr, "### singlePos2 size=%lu (%d subtables)\n", size2, nSub2));
+	DF(2, (stderr, "### singlePos1 size=%u (%d subtables)\n", size1, nSub1));
+	DF(2, (stderr, "### singlePos2 size=%u (%d subtables)\n", size2, nSub2));
 #endif
 
 	/* Select subtable format */
@@ -2749,7 +2749,7 @@ static void fillPairPos2(hotCtx g, GPOSCtx h) {
 	                      numValues(fmt->ValueFormat2));
 #if HOT_DEBUG
 	DF(1, (stderr, "#Cl kern: %d of %u(%hux%u) array is filled "
-		   "(%4.2f%%), excl ClassDef2's class 0. Subtbl size: %lu\n",
+		   "(%4.2f%%), excl ClassDef2's class 0. Subtbl size: %u\n",
 		   nFilled,
 		   fmt->Class1Count * (fmt->Class2Count - 1),
 		   fmt->Class1Count,
@@ -4752,7 +4752,7 @@ static void writeExtension(hotCtx g, GPOSCtx h, Subtable *sub) {
 	/* Adjust offset */
 	fmt->ExtensionOffset += h->offset.extensionSection - sub->offset;
 
-	DF(1, (stderr, "  GPOS Extension: fmt=%1d, lkpType=%2d, offset=%08lx\n",
+	DF(1, (stderr, "  GPOS Extension: fmt=%1d, lkpType=%2d, offset=%08ux\n",
 	       fmt->PosFormat, fmt->ExtensionLookupType, fmt->ExtensionOffset));
 
 	OUT2(fmt->PosFormat);

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/GSUB.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/GSUB.c
@@ -2955,7 +2955,7 @@ static void writeExtension(hotCtx g, GSUBCtx h, Subtable *sub) {
 	/* Adjust offset */
 	fmt->ExtensionOffset += h->offset.extensionSection - sub->offset;
 
-	DF(1, (stderr, "  GSUB Extension: fmt=%1d, lkpType=%2d, offset=%08lx\n",
+	DF(1, (stderr, "  GSUB Extension: fmt=%1d, lkpType=%2d, offset=%08ux\n",
 	       fmt->SubstFormat, fmt->ExtensionLookupType, fmt->ExtensionOffset));
 
 	OUT2(fmt->SubstFormat);

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/OS_2.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/OS_2.c
@@ -55,10 +55,10 @@ typedef struct {
 #define PANOSE3_VERY_EXPANDED   7
 #define PANOSE3_VERY_CONDENSED  8
 #define PANOSE3_MONOSPACED      9
-	unsigned long ulUnicodeRange1;
-	unsigned long ulUnicodeRange2;
-	unsigned long ulUnicodeRange3;
-	unsigned long ulUnicodeRange4;
+	uint32_t ulUnicodeRange1;
+	uint32_t ulUnicodeRange2;
+	uint32_t ulUnicodeRange3;
+	uint32_t ulUnicodeRange4;
 	char achVendId[VEND_ID_SIZE];
 	unsigned short fsSelection;
 #define SEL_ITALIC  (1 << 0)
@@ -73,8 +73,8 @@ typedef struct {
 	short sTypoLineGap;
 	unsigned short usWinAscent;
 	unsigned short usWinDescent;
-	unsigned long ulCodePageRange1; /* Version 1 */
-	unsigned long ulCodePageRange2; /* Version 1 */
+	uint32_t ulCodePageRange1; /* Version 1 */
+	uint32_t ulCodePageRange2; /* Version 1 */
 	short sXHeight;                 /* Version 2 */
 	short sCapHeight;               /* Version 2 */
 	unsigned short usDefaultChar;   /* Version 2 */
@@ -379,7 +379,7 @@ int OS_2Fill(hotCtx g) {
 		/* If any of the OS/2 v 4 fsSelection bits are on.*/
 		h->tbl.version = g->font.os2Version = 4;
 	}
-    else if ((h->tbl.ulUnicodeRange3 >= (unsigned long)(1<<29)) || (h->tbl.ulUnicodeRange4 != 0))
+    else if ((h->tbl.ulUnicodeRange3 >= (uint32_t)(1<<29)) || (h->tbl.ulUnicodeRange4 != 0))
     {
          h->tbl.version = g->font.os2Version = 4;
     }
@@ -467,10 +467,10 @@ void OS_2Free(hotCtx g) {
 /* ------------------------ Supplementary Functions ------------------------ */
 
 void OS_2SetUnicodeRanges(hotCtx        g,
-                          unsigned long ulUnicodeRange1,
-                          unsigned long ulUnicodeRange2,
-                          unsigned long ulUnicodeRange3,
-                          unsigned long ulUnicodeRange4) {
+                          uint32_t ulUnicodeRange1,
+                          uint32_t ulUnicodeRange2,
+                          uint32_t ulUnicodeRange3,
+                          uint32_t ulUnicodeRange4) {
 	OS_2Ctx h = g->ctx.OS_2;
 	h->tbl.ulUnicodeRange1 = ulUnicodeRange1;
 	h->tbl.ulUnicodeRange2 = ulUnicodeRange2;
@@ -480,8 +480,8 @@ void OS_2SetUnicodeRanges(hotCtx        g,
 }
 
 void OS_2SetCodePageRanges(hotCtx        g,
-                           unsigned long ulCodePageRange1,
-                           unsigned long ulCodePageRange2) {
+                           uint32_t ulCodePageRange1,
+                           uint32_t ulCodePageRange2) {
 	OS_2Ctx h = g->ctx.OS_2;
 	h->tbl.ulCodePageRange1 = ulCodePageRange1;
 	h->tbl.ulCodePageRange2 = ulCodePageRange2;

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/OS_2.h
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/OS_2.h
@@ -17,13 +17,13 @@ void OS_2Free(hotCtx g);
 
 /* Supplementary functions */
 void OS_2SetUnicodeRanges(hotCtx        g,
-                          unsigned long ulUnicodeRange1,
-                          unsigned long ulUnicodeRange2,
-                          unsigned long ulUnicodeRange3,
-                          unsigned long ulUnicodeRange4);
+                          uint32_t ulUnicodeRange1,
+                          uint32_t ulUnicodeRange2,
+                          uint32_t ulUnicodeRange3,
+                          uint32_t ulUnicodeRange4);
 void OS_2SetCodePageRanges(hotCtx        g,
-                           unsigned long ulCodePageRange1,
-                           unsigned long ulCodePageRange2);
+                           uint32_t lCodePageRange1,
+                           uint32_t ulCodePageRange2);
 void OS_2SetCharIndexRange(hotCtx         g,
                            unsigned short usFirstCharIndex,
                            unsigned short usLastCharIndex);

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/cmap.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/cmap.c
@@ -20,23 +20,23 @@
 
 /* Common header for formats 0, 2, 4, 6. Access by the GET_* macros below */
 typedef struct {
-	unsigned short format;
-	unsigned short length;
-	unsigned short language;
+	uint16_t format;
+	uint16_t length;
+	uint16_t language;
 } FormatHdr;
 
 /* Common header for the extended formats: 8, 10, 12. Access by the GET_* macros below */
 typedef struct {
-	unsigned short format;
-	unsigned short reserved;
-	unsigned long length;
-	unsigned long language;
+	uint16_t format;
+	uint16_t reserved;
+	uint32_t length;
+	uint32_t language;
 } FormatHdrExt;
 
 typedef struct {
-	unsigned short format;
-	unsigned long length;
-	unsigned long numUVS;
+	uint16_t format;
+	uint32_t length;
+	uint32_t numUVS;
 } FormatHdr14;
 
 #define IS_EXT_FORMAT(f) ((f) == 8 || (f) == 10 || (f) == 12) /* Extended formats */
@@ -44,9 +44,9 @@ typedef struct {
 #define GET_FORMAT(p)   (*((unsigned short *)p))
 
 typedef struct {
-	unsigned short format;
-	unsigned short length;
-	unsigned short language;
+	uint16_t format;
+	uint16_t length;
+	uint16_t language;
 	unsigned char glyphId[256];
 } Format0;
 #define FORMAT0_SIZE (uint16 * 3 + uint8 * 256)
@@ -100,31 +100,31 @@ typedef struct {
 
 /* Segment for formats 8 and 12: */
 typedef struct {
-	unsigned long startCharCode;
-	unsigned long endCharCode;
-	unsigned long startGlyphID;
+	uint32_t startCharCode;
+	uint32_t endCharCode;
+	uint32_t startGlyphID;
 } Segment8_12;
 #define SEGMENT8_12_SIZE (3 * uint32)
 
 typedef struct {
-	unsigned short format;
-	unsigned short reserved;
-	unsigned long length;
-	unsigned long language;
-	unsigned long nGroups;
+	uint16_t format;
+	uint16_t reserved;
+	uint32_t length;
+	uint32_t language;
+	uint32_t nGroups;
 	dnaDCL(Segment8_12, segment);
 } Format12;
 
 #define FORMAT12_SIZE(nSegs) (2 * uint16 + 3 * uint32 + SEGMENT8_12_SIZE * (nSegs))
 
 typedef struct {
-	unsigned long uv;
-	unsigned short addtlCnt;
+	uint32_t uv;
+	uint32_t addtlCnt;
 } DefaultUVSEntryRange;
 
 typedef struct {
-	unsigned long uv;
-	unsigned short glyphID;
+	uint32_t uv;
+	uint16_t glyphID;
 } ExtUVSEntry;
 
 typedef struct {
@@ -134,28 +134,28 @@ typedef struct {
 } UVSRecord;
 
 typedef struct {
-	unsigned short format;
-	unsigned long length;
-	unsigned long numUVS;
+	uint16_t format;
+	uint32_t length;
+	uint32_t numUVS;
 } Format14;
 
 #define FORMAT14_SIZE(nUVSRecs) (uint16 + 2 * uint32 + nUVSRecs * (uint24 + 2 * uint32))
 
 typedef struct {
-	short id;   /* Internal use. All Encoding's that have the same id will end
+	int16_t id;   /* Internal use. All Encoding's that have the same id will end
 	               up pointing to the same subtable in the OTF. Of all the
 	               Encoding's with the same id, exactly one will have a
 	               non-NULL format field. */
-	unsigned short platformId;
-	unsigned short scriptId;
-	unsigned long offset;
+	uint16_t platformId;
+	uint16_t scriptId;
+	uint32_t offset;
 	void *format;
 } Encoding;
 #define ENCODING_SIZE (uint16 * 2 + uint32 * 1)
 
 typedef struct {
-	unsigned short version;
-	unsigned short nEncodings;
+	uint16_t version;
+	uint16_t nEncodings;
 	dnaDCL(Encoding, encoding);
 } cmapTbl;
 #define TBL_HDR_SIZE (uint16 * 2)

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/common.h
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/common.h
@@ -439,8 +439,8 @@ void CDECL hotMsg(hotCtx g, int level, char *fmt, ...);
 void hotQuitOnError(hotCtx g);
 
 void hotOut2(hotCtx g, short value);
-void hotOut3(hotCtx g, long value);
-void hotOut4(hotCtx g, long value);
+void hotOut3(hotCtx g, int32_t value);
+void hotOut4(hotCtx g, int32_t value);
 
 void hotCalcSearchParams(unsigned unitSize, long nUnits,
                          unsigned short *searchRange,

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/common.h
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/common.h
@@ -38,7 +38,7 @@
 /* Apple's TrueType definitions */
 typedef short FWord;            /* Signed metric in font (em) units */
 typedef unsigned short uFWord;  /* Unsigned metric in font (em) units */
-#define VERSION(a, b) (((long)(a) << 16) | (b) << 12) /* Table version */
+#define VERSION(a, b) (((int32_t)(a) << 16) | (b) << 12) /* Table version */
 
 /* Size of types (bytes) */
 #define int8    1
@@ -56,7 +56,7 @@ typedef unsigned short uFWord;  /* Unsigned metric in font (em) units */
    OFFSET macros allow a simple declaration of both the byte offset field and a
    structure containing the data for that offset. (In header definitions the
    symbol |-> is used as a shorthand for "relative to".) */
-typedef unsigned long LOffset;
+typedef uint32_t LOffset;
 typedef unsigned short Offset;
 #define NULL_OFFSET 0
 #define DCL_OFFSET(type, name) \
@@ -67,7 +67,7 @@ typedef unsigned short Offset;
 	type *name ## _
 
 /* Tag support */
-typedef unsigned long Tag;
+typedef uint32_t Tag;
 #define TAG(a, b, c, d) ((Tag)(a) << 24 | (Tag)(b) << 16 | (c) << 8 | (d))
 #define TAG_ARG(t) (char)((t) >> 24 & 0xff), (char)((t) >> 16 & 0xff), \
 	(char)((t) >> 8 & 0xff), (char)((t) & 0xff)
@@ -89,7 +89,7 @@ typedef unsigned long Tag;
 #define IN4(v)              (v) = hotIn4(h->g)
 
 /* Specify scale normalized em units (1000/em) to font units */
-#define EM_SCALE(u)         (g->font.unitsPerEm * (long)(u) / 1000)
+#define EM_SCALE(u)         (g->font.unitsPerEm * (int32_t)(u) / 1000)
 #define ARRAY_LEN(t)        (sizeof(t) / sizeof((t)[0]))
 #define RAD_DEG             57.2958
 #define INT2FIX(i)          ((Fixed)(i) << 16)
@@ -97,7 +97,7 @@ typedef unsigned long Tag;
 #define FIX2INT(f)          ((short)(((f) + 0x00008000) >> 16)) /* xxx Doesn't
 	                                                               round correctly for -ve numbers, but OK since used only with MMs */
 
-#define RND(d)              ((long)(((d) > 0) ? (d) + 0.5 : (d) - 0.5))
+#define RND(d)              ((int32_t)(((d) > 0) ? (d) + 0.5 : (d) - 0.5))
 #define ABS(v)              ((v) < 0 ? -(v) : (v))
 #define MIN(a, b)            ((a) < (b) ? (a) : (b))
 #define MAX(a, b)            ((a) > (b) ? (a) : (b))
@@ -115,7 +115,7 @@ typedef unsigned long Tag;
 
 /* -------------------------------- Typedefs ------------------------------- */
 
-typedef long Fixed;
+typedef int32_t Fixed;
 
 /* Glyph index */
 typedef unsigned short GID;
@@ -130,7 +130,7 @@ typedef unsigned short SID;
 typedef unsigned short CID;
 
 /* Unicode value */
-typedef unsigned long UV;                   /* Unicode scalar value */
+typedef uint32_t UV;                   /* Unicode scalar value */
 typedef unsigned short UV_BMP;              /* Unicode BMP value */
 #define UV_UNDEF          ((unsigned)0xFFFF)        /* Indicates undefined UV */
 #define UV_SURR_HI_BEG    ((unsigned)0xD800)        /* High surrogate range begin */
@@ -148,7 +148,7 @@ typedef unsigned short UV_BMP;              /* Unicode BMP value */
 	(((((c) & ((unsigned)0xFFFF)) == ((unsigned)0xFFFE) || ((c) & ((unsigned)0xFFFF)) == ((unsigned)0xFFFF)) && ((c) >> 16) <= 0x10) \
 	 || IN_RANGE((c), ((unsigned)0xFDD0), ((unsigned)0xFDEF)))
 
-#define IS_SUPP_UV(c) ((c) > ((unsigned long)0xFFFF)) /* Is "c" a supplementary (ie non-BMP) UV?*/
+#define IS_SUPP_UV(c) ((c) > ((uint32_t)0xFFFF)) /* Is "c" a supplementary (ie non-BMP) UV?*/
 
 /* Various heuristic glyphs */
 #define UV_CAP_HEIGHT     ((unsigned)0x0048)  /* "H" */
@@ -240,7 +240,7 @@ typedef struct {            /* Glyph information */
 
 	/* --- Additional fields: */
 	union {
-		long inx;           /* (tmp) Index into string da in mapCtx */
+		int32_t inx;           /* (tmp) Index into string da in mapCtx */
 		char *str;          /* Actual pointer to glyph name */
 	} gname;
 	short flags;
@@ -334,8 +334,8 @@ typedef struct {            /* Font information */
 	} win;
 	struct {
 		/* Mac-specific data */
-		long cmapScript;    /* Platform-specific field for Mac cmap */
-		long cmapLanguage;  /* Language field for Mac cmap */
+		int32_t cmapScript;    /* Platform-specific field for Mac cmap */
+		int32_t cmapLanguage;  /* Language field for Mac cmap */
 	} mac;
 	struct {                /* --- Kerning data */
 		dnaDCL(KernPair_, pairs);
@@ -431,7 +431,7 @@ struct hotCtx_ {
 	dnaDCL(char, note);     /* Buffer for messages */
 
 	short hadError;         /* Flags if error occurred */
-	unsigned long convertFlags;     /* flags for building final OTF. */
+	uint32_t convertFlags;     /* flags for building final OTF. */
 };
 
 /* Functions */

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/feat.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/feat.c
@@ -3925,7 +3925,7 @@ static void addPos(GNode *targ, int type, int enumerate) {
 		}
 		if (next_targ->lookupLabel >= 0) {
 			lookupLabelCnt++;
-			if (!next_targ->flags & FEAT_MARKED) {
+			if (!(next_targ->flags & FEAT_MARKED)) {
 				featMsg(hotERROR, "the glyph which precedes the 'lookup' keyword must be marked as part of the contextual input sequence");
 			}
 		}

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/hot.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/hot.c
@@ -1825,14 +1825,14 @@ void hotOut2(hotCtx g, short value) {
 }
 
 /* Output OTF data as 3-byte number in big-endian order */
-void hotOut3(hotCtx g, long value) {
+void hotOut3(hotCtx g, int32_t value) {
 	g->cb.otfWrite1(g->cb.ctx, value >> 16);
 	g->cb.otfWrite1(g->cb.ctx, value >> 8);
 	g->cb.otfWrite1(g->cb.ctx, value);
 }
 
 /* Output OTF data as 4-byte number in big-endian order */
-void hotOut4(hotCtx g, long value) {
+void hotOut4(hotCtx g, int32_t value) {
 	g->cb.otfWrite1(g->cb.ctx, value >> 24);
 	g->cb.otfWrite1(g->cb.ctx, value >> 16);
 	g->cb.otfWrite1(g->cb.ctx, value >> 8);

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/hot.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/hot.c
@@ -405,7 +405,9 @@ char *hotReadFont(hotCtx g, int flags, int *psinfo,  hotReadFontOverrides *fontO
 	tcSetWeightOverride(g->ctx.tc,  fontOverride->syntheticWeight);
 	tcCompactFont(g->ctx.tc, tcflags);
 
-	g->cb.tmpClose(g->cb.ctx); /* temporary hack to write out tmp cff file. */
+	if (g->cb.tmpClose) {
+          g->cb.tmpClose(g->cb.ctx); /* temporary hack to write out tmp cff file. */
+        }
 
 	/* Parse CFF data and get global font information */
 	cb.ctx = g;

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/map.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/map.c
@@ -1446,9 +1446,9 @@ static UnicodeChar *getUVFromAGL(hotCtx g, char *glyphName, int fatalErr) {
 
 /* Checks if gname is of the form uni<CODE> or u<CODE>. If it is, returns 1 and
    sets *usv to the <CODE> */
-static int checkUniGName(hotCtx g, char *gn, unsigned long *usv) {
+static int checkUniGName(hotCtx g, char *gn, uint32_t *usv) {
 #define IS_HEX(h) (isxdigit(h) && !islower(h))
-	unsigned long code;
+	uint32_t code;
 	char *pHexStart;
 	char *p;
 	long numHexDig;
@@ -1494,7 +1494,7 @@ static int checkUniGName(hotCtx g, char *gn, unsigned long *usv) {
 	}
 
 	/* Check code */
-	sscanf(pHexStart, "%lx", &code);
+	sscanf(pHexStart, "%ux", &code);
 
 #if 0
 	if (IN_RANGE(code, UV_SURR_BEG, UV_SURR_END)) {
@@ -2484,10 +2484,10 @@ static void dbgUniBlock(hotCtx g) {
 
 static void dbgPrintUV(UV uv) {
 	if (IS_SUPP_UV(uv)) {
-		fprintf(stderr, "%lX", uv);
+		fprintf(stderr, "%uX", uv);
 	}
 	else {
-		fprintf(stderr, "%04lX", uv);
+		fprintf(stderr, "%04uX", uv);
 	}
 }
 
@@ -2522,7 +2522,7 @@ static void dbgPrintInfo(hotCtx g) {
 		        "------------------------------\n",
 		        (nGlyphs > SUBSET_MAX) ? " [only multiple uv maps listed]\n"
 				: "");
-		for (i = 0; i < (long)nGlyphs; i++) {
+		for (i = 0; i < nGlyphs; i++) {
 			AddlUV *addlUV;
 			hotGlyphInfo *gi = &g->font.glyphs.array[i];
 
@@ -2581,8 +2581,7 @@ static void dbgPrintInfo(hotCtx g) {
 				fprintf(stderr, ",%3d", sup->code);
 			}
 		}
-
-		fprintf(stderr, " %4d ", GET_GID(gi));
+		fprintf(stderr, " %4td ", GET_GID(gi));
 		if (GET_GID(gi) != gi->id) {
 			fprintf(stderr, "%4d", gi->id);
 		}
@@ -2662,8 +2661,8 @@ int mapFill(hotCtx g) {
 /* Initialize both CID and non-CID fonts */
 static void initGlyphs(hotCtx g) {
 	mapCtx h = g->ctx.map;
-	long i;
-	long nGlyphs = g->font.glyphs.cnt;
+	int32_t i;
+	int32_t nGlyphs = g->font.glyphs.cnt;
 
 	dnaSET_CNT(h->sort.gname, nGlyphs); /* Includes .notdef/CID 0 */
 

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/map.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/map.c
@@ -38,7 +38,7 @@ static void dbgPrintUV(UV uv);
 
 #endif /* HOT_DEBUG	*/
 
-typedef long SInx;              /* Index into char da */
+typedef int32_t SInx;              /* Index into char da */
 #define SINX_UNDEF      (-1)    /* Indicates invalid SInx */
 #define STR(i)          (&h->str.array[i])
 

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/name.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/name.c
@@ -326,6 +326,7 @@ static void addStdNames(nameCtx h, int win, int mac) {
 	}
 
     /* Don't add if one has already been provided from the feature file */
+    index = 0; //ensure we start from beginning of array.
     index = enumNames(h, index,
                       MATCH_ANY,
                       MATCH_ANY,

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/otl.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/otl.c
@@ -359,17 +359,17 @@ void otlDumpSizes(hotCtx g, otlTbl t, LOffset subtableSize,
 
 	s = otlGetHeaderSize(t);
 	tot += s;
-	DF(1, (stderr, "  Scr,Fea,Lkp lists:     size %5ld, tot %5ld\n", s, tot));
+	DF(1, (stderr, "  Scr,Fea,Lkp lists:     size %5u, tot %5u\n", s, tot));
 
 	s = subtableSize;
 	tot += s;
-	DF(1, (stderr, "  Main subtable section: size %5ld, tot %5ld\n", s, tot));
+	DF(1, (stderr, "  Main subtable section: size %5u, tot %5u\n", s, tot));
 
 	s = otlGetCoverageSize(t);
 	tot += s;
-	DF(1, (stderr, "  Main coverage section: size %5ld, tot ", s));
+	DF(1, (stderr, "  Main coverage section: size %5u, tot ", s));
 	if (s != 0) {
-		DF(1, (stderr, "%5ld\n", tot));
+		DF(1, (stderr, "%5u\n", tot));
 	}
 	else {
 		DF(1, (stderr, "    \"\n"));
@@ -377,9 +377,9 @@ void otlDumpSizes(hotCtx g, otlTbl t, LOffset subtableSize,
 
 	s = otlGetClassSize(t);
 	tot += s;
-	DF(1, (stderr, "  Main class section:    size %5ld, tot ", s));
+	DF(1, (stderr, "  Main class section:    size %5u, tot ", s));
 	if (s != 0) {
-		DF(1, (stderr, "%5ld\n", tot));
+		DF(1, (stderr, "%5u\n", tot));
 	}
 	else {
 		DF(1, (stderr, "    \"\n"));
@@ -387,9 +387,9 @@ void otlDumpSizes(hotCtx g, otlTbl t, LOffset subtableSize,
 
 	s = extensionSectionSize;
 	tot += s;
-	DF(1, (stderr, "  Extension section:     size %5ld, tot ", s));
+	DF(1, (stderr, "  Extension section:     size %5u, tot ", s));
 	if (s != 0) {
-		DF(1, (stderr, "%5ld\n", tot));
+		DF(1, (stderr, "%5u\n", tot));
 	}
 	else {
 		DF(1, (stderr, "    \"\n"));

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/sfnt.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/sfnt.c
@@ -73,19 +73,19 @@ static Funcs funcs[] = {
 /* ---------------------------- Table Definition --------------------------- */
 
 typedef struct {
-	unsigned long tag;
-	unsigned long checksum;
-	unsigned long offset;
-	unsigned long length;
+	int32_t tag;
+	uint32_t checksum;
+	uint32_t offset;
+	uint32_t length;
 } Entry;
 #define ENTRY_SIZE (uint32 * 4)
 
 typedef struct {
 	Fixed version;
-	unsigned short numTables;
-	unsigned short searchRange;
-	unsigned short entrySelector;
-	unsigned short rangeShift;
+	uint16_t numTables;
+	uint16_t searchRange;
+	uint16_t entrySelector;
+	uint16_t rangeShift;
 	dnaDCL(Entry, directory);   /* [numTables] */
 } sfntTbl;
 #define DIR_HDR_SIZE (int32 + uint16 * 4)

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/pstoken/pstoken.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/pstoken/pstoken.c
@@ -676,9 +676,9 @@ char *psGetValue(psCtx h, psToken *token) {
 }
 
 /* Convert integer token to integer value. Already validated */
-long psConvInteger(psCtx h, psToken *token) {
-	int base = 10;
-	long value = 0;
+int32_t psConvInteger(psCtx h, psToken *token) {
+	int32_t base = 10;
+	int32_t value = 0;
 	char *p = &h->cb.buf->array[token->index];
 	char *end = p + token->length;
 	int neg = *p == '-';
@@ -703,7 +703,7 @@ long psConvInteger(psCtx h, psToken *token) {
 }
 
 /* Get next token as an integer and convert its value */
-long psGetInteger(psCtx h) {
+int32_t psGetInteger(psCtx h) {
 	psToken *value = psGetToken(h);
 
 	if (value->type != PS_INTEGER) {
@@ -753,10 +753,10 @@ char *psConvLiteral(psCtx h, psToken *token, unsigned *length) {
 }
 
 /* Convert hexadecimal string to integer value. Already validated */
-unsigned long psConvHexString(psCtx h, psToken *token) {
+uint32_t psConvHexString(psCtx h, psToken *token) {
 	char *p = &h->cb.buf->array[token->index + 1];
 	int digits = 0;
-	long value = 0;
+	uint32_t value = 0;
 
 	do {
 		if (ISHEX(*p)) {
@@ -790,7 +790,7 @@ int psGetHexLength(psCtx h, psToken *token) {
 }
 
 /* Get next token as a hexadecimal string and convert its value */
-unsigned long psGetHexString(psCtx h, int *length) {
+uint32_t psGetHexString(psCtx h, int *length) {
 	psToken *value = psGetToken(h);
 
 	if (value->type != PS_HEXSTRING) {

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/pstoken/pstoken.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/pstoken/pstoken.c
@@ -645,7 +645,7 @@ finish:
 
 /* Match token */
 int psMatchToken(psCtx h, psToken *token, int type, char *value) {
-	long length = strlen(value);
+	size_t length = strlen(value);
 	return token->type == type && token->length == length &&
 	       memcmp(&h->cb.buf->array[token->index], value, length) == 0;
 }
@@ -665,7 +665,7 @@ psToken *psFindToken(psCtx h, int type, char *value) {
 
 /* Match token's value */
 int psMatchValue(psCtx h, psToken *token, char *value) {
-	long length = strlen(value);
+	size_t length = strlen(value);
 	return token->length == length &&
 	       memcmp(&h->cb.buf->array[token->index], value, length) == 0;
 }

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/common.h
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/common.h
@@ -9,11 +9,12 @@
 
 #include "dynarr.h"
 #include "typecomp.h"
+#include "stdint.h"
 
 /* Types */
 /*typedef long Fixed;	*/			/* 16.16 fixed point */
 typedef unsigned char OffSize;  /* Offset size indicator */
-typedef unsigned long Offset;   /* 1, 2, 3, or 4-byte offset */
+typedef uint32_t Offset;   /* 1, 2, 3, or 4-byte offset */
 typedef unsigned short SID;     /* String id */
 typedef struct {                /* INDEX table header */
 	unsigned short count;
@@ -135,12 +136,12 @@ typedef struct {
 /* Package context */
 struct tcCtx_ {
 	tcCallbacks cb;     /* Client callbacks */
-	long flags;         /* Compression specification flags */
-	long status;        /* Program status flags */
+	int32_t flags;         /* Compression specification flags */
+	int32_t status;        /* Program status flags */
 #define TC_MESSAGE      (1 << 0)  /* Flags message for font already posted */
 #define TC_EURO_ADDED   (1 << 1)  /* Flags Euro glyph added to font */
 	short nMasters;     /* Number of masters */
-	unsigned long maxNumSubrs;
+	uint32_t maxNumSubrs;
 	SubrParseData *spd; /* Subroutinizer parse data */
 	struct {            /* --- Module contexts */
 		dnaCtx dnaCtx;

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/common.h
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/common.h
@@ -12,7 +12,7 @@
 #include "stdint.h"
 
 /* Types */
-/*typedef long Fixed;	*/			/* 16.16 fixed point */
+typedef int32_t Fixed;			/* 16.16 fixed point */
 typedef unsigned char OffSize;  /* Offset size indicator */
 typedef uint32_t Offset;   /* 1, 2, 3, or 4-byte offset */
 typedef unsigned short SID;     /* String id */
@@ -122,7 +122,7 @@ typedef struct tcprivCtx_ *tcprivCtx;
 typedef struct {
 	int (*oplen)(unsigned char *);
 	unsigned char *(*cstrcpy)(unsigned char *, unsigned char *, unsigned);
-	int (*encInteger)(long, char *);
+	int (*encInteger)(int32_t, char *);
 	short maxCallStack;
 	short hintmask;
 	short cntrmask;

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/cs.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/cs.c
@@ -290,7 +290,7 @@ void csSetConvProcs(tcCtx g, csConvProcs *procs) {
 }
 
 /* Encode integer and return length */
-int csEncInteger(long i, char *t) {
+int csEncInteger(int32_t i, char *t) {
 	if (-107 <= i && i <= 107) {
 		/* Single byte number */
 		t[0] = (char)(i + 139);
@@ -542,10 +542,10 @@ unsigned csDump(long length, unsigned char *cstr, int nMasters, int t1) {
 
 			case 255: {
 				/* 5 byte number */
-				long value = (long)cstr[i + 1] << 24 | (long)cstr[i + 2] << 16 |
-				    (long)cstr[i + 3] << 8 | (long)cstr[i + 4];
+				int32_t value = (int32_t)cstr[i + 1] << 24 | (int32_t)cstr[i + 2] << 16 |
+				    (int32_t)cstr[i + 3] << 8 | (int32_t)cstr[i + 4];
 				if (t1) {
-					printf("%ld ", value);
+					printf("%d ", value);
 				}
 				else {
 					printf("%.4g ", value / 65536.0);
@@ -570,7 +570,7 @@ unsigned csDump(long length, unsigned char *cstr, int nMasters, int t1) {
 
 void csDumpSubrs(tcCtx g, Font *font) {
 	long i;
-	long bias;
+	int32_t bias;
 	long offset;
 
 	printf("--- subrs (count=%hu)\n", font->subrs.nStrings);

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/cs.h
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/cs.h
@@ -64,7 +64,7 @@ void csAddChar(tcCtx g, unsigned length, char *cstr,
 void csEndFont(tcCtx g, unsigned nChars, unsigned short *recode);
 void csSetConvProcs(tcCtx g, csConvProcs *procs);
 
-int csEncInteger(long i, char *t);
+int csEncInteger(int32_t i, char *t);
 int csEncFixed(Fixed f, char *t);
 
 long csSizeChars(tcCtx g, Font *font);

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/cs.h
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/cs.h
@@ -14,8 +14,6 @@
 #include "pstoken.h"
 #include <stdint.h>
 
-typedef int32_t Fixed;
-
 #define CS_MAX_SIZE 65535   /* Max charstring size (bytes) */
 
 /* Single char/subr reference */

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/cs.h
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/cs.h
@@ -12,8 +12,9 @@
 
 #include "common.h"
 #include "pstoken.h"
+#include <stdint.h>
 
-typedef long Fixed;
+typedef int32_t Fixed;
 
 #define CS_MAX_SIZE 65535   /* Max charstring size (bytes) */
 

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/parse.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/parse.c
@@ -3029,7 +3029,6 @@ static void cidReadChars(parseCtx h) {
 	unsigned nChars = 0;
 	int tableBytes = h->cid.GDBytes + h->cid.FDBytes;
 	SID *sid = MEM_NEW(g, sizeof(SID) * h->cid.Count);
-	unsigned short *subsetSID = NULL;
 	unsigned short *pSubsetSID = NULL;
 
 

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/parse.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/parse.c
@@ -1646,7 +1646,7 @@ static void readFontName(parseCtx h) {
 }
 
 /* Read integer-valued dict key */
-static long readIntKey(parseCtx h, int iKey) {
+static int32_t readIntKey(parseCtx h, int iKey) {
 	psToken *token = psGetToken(h->ps);
 	if (token->type != PS_INTEGER) {
 		badKeyValue(h, iKey);
@@ -1657,7 +1657,7 @@ static long readIntKey(parseCtx h, int iKey) {
 /* Process literal */
 static void doLiteral(parseCtx h, psToken *literal) {
 	tcCtx g = h->g;
-	long type;
+	int32_t type;
 	String key;
 	DictKeyMap *map;
 
@@ -1899,7 +1899,7 @@ static void calcUDV(parseCtx h, double *BDM, double *BDP,
 }
 
 /* Get integer value from dict key */
-static long getKeyInt(parseCtx h, int iKey, int required) {
+static int32_t getKeyInt(parseCtx h, int iKey, int required) {
 	psToken *token = &h->keys[iKey].value;
 
 	if (!SEEN_KEY(iKey)) {
@@ -2004,7 +2004,7 @@ static void saveMM(parseCtx h, DICT *dict, int iKey) {
 			order[i] = 0;
 			for (j = 0; j < nAxes; j++) {
 				double d = BDP[k++];
-				long n = (long)d;
+				int32_t n = (int32_t)d;
 
 				if (n != d || (n != 0 && n != 1)) {
 					/* Non-integer master coordinates must have CDV support */
@@ -2234,7 +2234,7 @@ static void saveNumber(parseCtx h, DICT *dict, int iKey) {
 	psToken *token = &key->value;
 
 	if (token->type == PS_INTEGER) {
-		long i = psConvInteger(h->ps, token);
+		int32_t i = psConvInteger(h->ps, token);
 		if (key->dflt != NULL && i == strtol(key->dflt, NULL, 0)) {
 			return; /* Matched default */
 		}
@@ -2713,7 +2713,7 @@ static int defaultNumber(parseCtx h, int iKey) {
 	psToken *token = &key->value;
 
 	if (token->type == PS_INTEGER) {
-		long i = psConvInteger(h->ps, token);
+		int32_t i = psConvInteger(h->ps, token);
 		if (key->dflt != NULL && i == strtol(key->dflt, NULL, 0)) {
 			return 1; /* Matched default */
 		}
@@ -2748,7 +2748,7 @@ static void saveDicts(parseCtx h) {
 
 	if (!SEEN_KEY(iStdVW)) {
 		/* StdVW not found (old font) so use 16th erode proc token! */
-		long StdVW = getStdVWFromErodeProc(h);
+		int32_t StdVW = getStdVWFromErodeProc(h);
 		if (StdVW != -1) {
 			dictSaveInt(&h->font->Private, StdVW);
 			DICTSAVEOP(h->font->Private, cff_StdVW);

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/parse.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/parse.c
@@ -460,7 +460,7 @@ static void readEncoding(parseCtx h) {
 	if (!h->encoding.std) {
 		int i;
 		char *p;
-		int length;
+		int length = 0;
 		long index[256]; /* Glyph name index, b31-8 buf. index, b7-0 length */
 
 		/* Initialize index */
@@ -1522,6 +1522,8 @@ void parseFont(tcCtx g, Font *font) {
 	h->subrs.cnt = 0;
 	h->component.chars.cnt = 0;
 	h->component.inorder = 0;
+	h->subset.nGlyphs = 0;
+
 	h->font->synthetic.oblique_term = 0.0;
 
 	if (g->flags & TC_NOOLDOPS) {
@@ -2090,6 +2092,7 @@ static void saveString(parseCtx h, DICT *dict, int iKey) {
 		strng = psConvLiteral(h->ps, token, &length);
 	}
 	else {
+                length = 0;
 		badKeyValue(h, iKey);
 	}
 

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/recode.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/recode.c
@@ -244,7 +244,7 @@ typedef enum {                  /* Char id type */
 #define DEG_2_RAD   (3.141592653589793 / 180)
 
 /* Round double and convert to Fixed */
-#define RND2FIX(d)  ((Fixed)((long)((double)(d) + 0.5) * 65536.0))
+#define RND2FIX(d)  ((Fixed)((int32_t)((double)(d) + 0.5) * 65536.0))
 
 /* --- template glyph data for auto glyph addition --- */
 typedef struct {
@@ -1756,8 +1756,8 @@ static int t1parse(recodeCtx h, unsigned length, unsigned char *cstr,
 
 			case 255: {
 				/* 5 byte number */
-				long value = (long)cstr[i + 1] << 24 | (long)cstr[i + 2] << 16 |
-				    (long)cstr[i + 3] << 8 | (long)cstr[i + 4];
+				int32_t value = (int32_t)cstr[i + 1] << 24 | (int32_t)cstr[i + 2] << 16 |
+				    (int32_t)cstr[i + 3] << 8 | (int32_t)cstr[i + 4];
 				if (-32000 <= value && value <= 32000) {
 					value <<= 16;
 				}

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/recode.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/recode.c
@@ -913,7 +913,7 @@ static void addWidth(recodeCtx h, Fixed width) {
 
 			/* Write width and copy rest of charstring */
 			bytes = csEncInteger(this->width, dst);
-			memcpy(dst + bytes,
+			memmove(dst + bytes,
 			       &h->cstrs.array[this->icstr + DUMMY_WIDTH_SIZE], length);
 
 			length += bytes;

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/recode.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/recode.c
@@ -2359,7 +2359,7 @@ static Blend *setCntrMask(recodeCtx h, Blend *p, int vert, HintMask cntrmask) {
 #endif
 			{
 				/* Stem list full; just find the best match */
-				Fixed smallest = LONG_MAX;
+				Fixed smallest = INT32_MAX;
 
 				for (i = 0; i < h->stem.list.cnt; i++) {
 					int j;
@@ -2907,7 +2907,7 @@ static void recodePath(recodeCtx h) {
 	setBlend(h, h->path.y, 0);
 
 	/* Handle charstring width */
-	if (h->path.width[0] == LONG_MIN) {
+	if (h->path.width[0] == INT32_MIN) {
 		if (h->idType != SubrType) {
 			badChar(h); /* Charstring has no width! */
 		}
@@ -3349,7 +3349,7 @@ static void cstrRecode(tcCtx g, unsigned length, unsigned char *cstr,
 	h->pend.move = 1;
 	h->pend.trans = 0;
 
-	h->path.width[0] = LONG_MIN;
+	h->path.width[0] = INT32_MIN;
 	h->path.segs.cnt = 0;
 	h->path.ops.cnt = 0;
 	h->path.args.cnt = 0;
@@ -4220,7 +4220,7 @@ static void saveTemplateGlyphData(recodeCtx h, TemplateGlyphData *templateGlyph)
 
 	for (h->newGlyph.iMaster = 0; h->newGlyph.iMaster < h->nMasters; h->newGlyph.iMaster++) {
 		int iMaster = h->newGlyph.iMaster;
-		templateGlyph->bbox.left[iMaster] = LONG_MAX;
+		templateGlyph->bbox.left[iMaster] = INT32_MAX;
 		templateGlyph->bbox.bottom[iMaster] = 0;
 		templateGlyph->bbox.right[iMaster] = 0;
 		templateGlyph->bbox.top[iMaster] = 0;

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/subr.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/subr.c
@@ -118,7 +118,7 @@ struct Edge_ {
 struct Node_ {
 	Node *suffix;       /* Suffix link */
 	Edge edge;          /* First linking edge */
-	long misc;          /* Initially longest path from root, then subr index */
+	int32_t misc;          /* Initially longest path from root, then subr index */
 	unsigned short paths;   /* Paths through node */
 	unsigned short id;  /* Font id */
 #define NODE_GLOBAL USHRT_MAX   /* Identifies global subr */
@@ -730,7 +730,7 @@ static void saveSubr(subrCtx h, unsigned char *label, Node *node,
 
 /* Find candidate subrs in DAWG */
 static void findCandSubrs(subrCtx h, Edge *edge, int maskcnt) {
-	long misc;
+	int32_t misc;
 	Node *node;
 	unsigned char *label;
 
@@ -1673,7 +1673,7 @@ reselect:
 	if (++pass == 2) {
 		#if 1
 		/* Discard extra subrs if exceeds capacity */
-		long limit = h->g->maxNumSubrs;
+		int32_t limit = h->g->maxNumSubrs;
 		if (limit == 0) {
 			limit = 65536L;
 		}
@@ -1885,7 +1885,7 @@ static void subrizeChars(subrCtx h, CSData *chars, unsigned id) {
 		long iStart = h->cstrs.cnt;
 
 		/* Initially allocate space for entire charstring */
-		pdst = (unsigned char *)dnaEXTEND(h->cstrs, (long)length);
+		pdst = (unsigned char *)dnaEXTEND(h->cstrs, (int32_t)length);
 
 #if DB_CHARS
 		printf("[%3ld]    =  ", i);
@@ -1930,7 +1930,7 @@ static void subrizeChars(subrCtx h, CSData *chars, unsigned id) {
    font using combined subr INDEXes. The global subrs are selected from even
    temporary array indexes and local subrs are chosen from odd indexes */
 static void reorderCombined(subrCtx h, int local) {
-	long bias;
+	int32_t bias;
 	long count; /* Element in reorder array */
 	long i;     /* Reorder array index */
 	long j;     /* Temporary array index */
@@ -2009,7 +2009,7 @@ static void reorderCombined(subrCtx h, int local) {
 /* Create biased reordering for a non-singleton font */
 static void reorderSubrs(subrCtx h) {
 	long i;
-	long bias;
+	int32_t bias;
 
 	/* Assign reording index */
 	dnaSET_CNT(h->reorder, h->tmp.cnt);
@@ -2489,7 +2489,7 @@ static void dbnode(subrCtx h, Node *node) {
 	printf("--- node[%ld]\n", dbnodeid(h, node));
 	printf("suffix=%ld (%08lx)\n",
 	       dbnodeid(h, node->suffix), (unsigned long)node->suffix);
-	printf("misc  =%ld\n", node->misc);
+	printf("misc  =%d\n", node->misc);
 	printf("paths =%hu\n", node->paths);
 	printf("id    =%hu\n", node->id);
 	printf("flags =%04hx (", (unsigned short)node->flags);

--- a/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/tc.c
+++ b/FDK/Tools/Programs/makeotf/makeotf_lib/source/typecomp/tc.c
@@ -523,7 +523,7 @@ static void fillWrapTrailer(tcCtx g, char *wrapTrailer) {
 #if TC_STATISTICS
 /* Show compression statistics */
 static void showStats(tcprivCtx h) {
-#define AVG(v, c) ((long)((c) ? (double)(v) / (c) + .5 : 0))
+#define AVG(v, c) ((int32_t)((c) ? (double)(v) / (c) + .5 : 0))
 	tcCtx g = h->g;
 	int i;
 	struct {
@@ -1211,10 +1211,10 @@ static void dblayout(tcprivCtx h) {
 	printf("strings     %7ld        -\n", h->size.strings);
 	printf("gsubrs      %7ld        -\n", h->size.gsubrs);
 	printf("FontNames   %7ld        -\n", h->size.FontNames);
-	printf("encodings   %7ld  %7ld\n", h->size.encodings, h->offset.encodings);
-	printf("charsets    %7ld  %7ld\n", h->size.charsets, h->offset.charsets);
-	printf("FDSelects   %7ld  %7ld\n", h->size.FDSelects, h->offset.FDSelects);
-	printf("copyright         -  %7ld\n", h->offset.copyright);
+	printf("encodings   %7ld  %7u\n", h->size.encodings, h->offset.encodings);
+	printf("charsets    %7ld  %7u\n", h->size.charsets, h->offset.charsets);
+	printf("FDSelects   %7ld  %7u\n", h->size.FDSelects, h->offset.FDSelects);
+	printf("copyright         -  %7u\n", h->offset.copyright);
 
 	for (i = 0; i < h->set.cnt; i++) {
 		Font *font = &h->set.array[i];
@@ -1222,16 +1222,16 @@ static void dblayout(tcprivCtx h) {
 		printf("=== font[%3d] ==============\n", i);
 		printf("FontName    %7ld        -\n", font->size.FontName);
 		printf("dict        %7ld        -\n", font->size.dict);
-		printf("encoding          -  %7ld\n", font->offset.encoding);
-		printf("charset           -  %7ld\n", font->offset.charset);
-		printf("fdselect          -  %7ld\n", font->offset.fdselect);
-		printf("CharStrings %7ld  %7ld\n",
+		printf("encoding          -  %7u\n", font->offset.encoding);
+		printf("charset           -  %7u\n", font->offset.charset);
+		printf("fdselect          -  %7u\n", font->offset.fdselect);
+		printf("CharStrings %7ld  %7u\n",
 		       font->size.CharStrings, font->offset.CharStrings);
-		printf("FDArray     %7ld  %7ld\n",
+		printf("FDArray     %7ld  %7u\n",
 		       font->size.FDArray, font->offset.FDArray);
-		printf("Private     %7ld  %7ld\n",
+		printf("Private     %7ld  %7u\n",
 		       font->size.Private, font->offset.Private);
-		printf("Subrs       %7ld  %7ld\n",
+		printf("Subrs       %7ld  %7u\n",
 		       font->size.Subrs, font->offset.Subrs);
 		if (font->flags & FONT_CID) {
 			int j;
@@ -1241,9 +1241,9 @@ static void dblayout(tcprivCtx h) {
 				if (info->seenChar) {
 					printf("--- FD[%2d] -----------------\n", iFD++);
 					printf("FD          %7ld        -\n", info->size.FD);
-					printf("Private     %7ld  %7ld\n",
+					printf("Private     %7ld  %7u\n",
 					       info->size.Private, info->offset.Private);
-					printf("Subrs       %7ld  %7ld\n",
+					printf("Subrs       %7ld  %7u\n",
 					       info->size.Subrs, info->offset.Subrs);
 				}
 			}

--- a/FDK/Tools/Programs/makeotf/source/cb.c
+++ b/FDK/Tools/Programs/makeotf/source/cb.c
@@ -51,7 +51,7 @@ extern jmp_buf mark;
 
 #define FEATUREDIR   "features"
 
-#define INT2FIX(i)  ((long)(i) << 16)
+#define INT2FIX(i)  ((int32_t)(i) << 16)
 
 #define WIN_SPACE      32
 #define WIN_BULLET     149
@@ -313,9 +313,9 @@ reload:
 		else {
 			/* Read segment length (little endian) */
 			h->ps.left = read1(h);
-			h->ps.left |= (long)read1(h) << 8;
-			h->ps.left |= (long)read1(h) << 16;
-			h->ps.left |= (long)read1(h) << 24;
+			h->ps.left |= (int32_t)read1(h) << 8;
+			h->ps.left |= (int32_t)read1(h) << 16;
+			h->ps.left |= (int32_t)read1(h) << 24;
 
 			goto reload;
 		}

--- a/FDK/Tools/Programs/public/lib/api/pstoken.h
+++ b/FDK/Tools/Programs/public/lib/api/pstoken.h
@@ -168,7 +168,7 @@ int pstMatch(pstCtx h, pstToken *token, char *value);
    null-terminated string specified by the "value" parameter, otherwise it
    returns 0. The value parameter is specified as a null-terminated string. */
 
-long pstConvInteger(pstCtx h, pstToken *token);
+int32_t pstConvInteger(pstCtx h, pstToken *token);
 
 /* pstConvInteger() converts the integer "token" parameter to an integer
    number. If the token isn't an integer, 0 is returned. Integers requiring
@@ -193,7 +193,7 @@ char *pstConvLiteral(pstCtx h, pstToken *token, long *length);
    literal "token" parameter and returns a new pointer and length accordingly.
    If the token isn't a literal, NULL is returned. */
  
-unsigned long pstConvHexString(pstCtx h, pstToken *token);
+uint32_t pstConvHexString(pstCtx h, pstToken *token);
 
 /* pstConvHexString() converts the hexadecimal string "token" parameter to an
    integer number. If the token isn't a hexadecimal string 0 is returned.

--- a/FDK/Tools/Programs/public/lib/source/cffread/cffread.c
+++ b/FDK/Tools/Programs/public/lib/source/cffread/cffread.c
@@ -70,7 +70,7 @@ typedef struct					/* Operand Stack element */
     int is_int;
     union
     {
-        long int_val;		/* allow at least 32-bit int */
+        int32_t int_val;		/* allow at least 32-bit int */
         float real_val;
     } u;
 } stack_elem;
@@ -358,7 +358,7 @@ static void seekbuf(cfrCtx h, long offset)
 static char nextbuf(cfrCtx h)
 {
 	/* 64-bit warning fixed by cast here */
-	fillbuf(h, (long)(h->src.offset + h->src.length));
+	fillbuf(h, (int32_t)(h->src.offset + h->src.length));
 	return *h->src.next++;
 }
 
@@ -391,7 +391,7 @@ static void srcRead(cfrCtx h, size_t count, char *ptr)
         
 		/* Refill buffer */
 		/* 64-bit warning fixed by cast here */
-		fillbuf(h, (long)(h->src.offset + h->src.length));
+		fillbuf(h, (int32_t)(h->src.offset + h->src.length));
 		left = h->src.length;
     }
     
@@ -411,9 +411,9 @@ static unsigned short read2(cfrCtx h)
 }
 
 /* Read 1-, 2-, 3-, or 4-byte number. */
-static unsigned long readN(cfrCtx h, int N)
+static uint32_t readN(cfrCtx h, int N)
 {
-	unsigned long value = 0;
+	uint32_t value = 0;
 	switch (N)
     {
         case 4:
@@ -530,7 +530,7 @@ do if(h->stack.cnt+(n)>T2_MAX_OP_STACK)fatal(h,cfrErrStackOverflow);while(0)
 
 /* Stack access without check. */
 #define INDEX(i) (h->stack.array[i])
-#define INDEX_INT(i) (INDEX(i).is_int? INDEX(i).u.int_val: (long)INDEX(i).u.real_val)
+#define INDEX_INT(i) (INDEX(i).is_int? INDEX(i).u.int_val: (int32_t)INDEX(i).u.real_val)
 #define PUSH_INT(v) { stack_elem*	elem = &h->stack.array[h->stack.cnt++];	\
 elem->is_int = 1; elem->u.int_val = (v); }
 #define INDEX_REAL(i) (INDEX(i).is_int? (float)INDEX(i).u.int_val: INDEX(i).u.real_val)
@@ -712,7 +712,7 @@ static void saveIntArray(cfrCtx h, size_t max, long *cnt, long *array,
 						 int delta)
 {
 	int i;
-	if (h->stack.cnt == 0 || h->stack.cnt > (long)max)
+	if (h->stack.cnt == 0 || h->stack.cnt > (size_t)max)
 		fatal(h, cfrErrDICTArray);
 	array[0] = INDEX_INT(0);
 	for (i = 1; i < h->stack.cnt; i++)
@@ -723,7 +723,7 @@ static void saveIntArray(cfrCtx h, size_t max, long *cnt, long *array,
 /* Save PostScript operator string. */
 static char *savePostScript(cfrCtx h, char *str)
 {
-	long value;
+	int32_t value;
 	int n;
 	char *p;
 	char *q;
@@ -1124,15 +1124,10 @@ static void readDICT(cfrCtx h, ctlRegion *region, int topdict)
                 /* 5 byte number */
                 CHKOFLOW(1);
 			{
-                long value = read1(h);
+                int32_t value = read1(h);
                 value = value<<8 | read1(h);
                 value = value<<8 | read1(h);
                 value = value<<8 | read1(h);
-#if LONG_MAX > 2147483647
-                /* long greater that 4 bytes; handle negative range */
-                if (value > 2417483647)
-                    value -= 4294967296;
-#endif
                 PUSH_INT(value);
 			}
                 continue;

--- a/FDK/Tools/Programs/public/lib/source/cffwrite/cffwrite_t2cstr.c
+++ b/FDK/Tools/Programs/public/lib/source/cffwrite/cffwrite_t2cstr.c
@@ -19,7 +19,7 @@
 #include <math.h>
 
 /* Fixed point (for stem list) */
-typedef long Fixed;
+typedef int32_t Fixed;
 
 /* Make up operators for internal use */
 #define tx_noop     tx_reserved0

--- a/FDK/Tools/Programs/public/lib/source/ttread/ttread.c
+++ b/FDK/Tools/Programs/public/lib/source/ttread/ttread.c
@@ -56,10 +56,10 @@ typedef struct /* Coordinate point */
 
 /* --------------------------- sfnt Definitions  --------------------------- */
 
-typedef long Fixed;
+typedef int32_t Fixed;
 typedef short FWord;
 typedef unsigned short uFWord;
-typedef unsigned long Offset;
+typedef uint32_t Offset;
 #define F2Dot14_2FLT(f)	((float)((f)/16384.0))
 
 typedef struct					/* bsearch id match record */
@@ -639,25 +639,25 @@ static short sread2(ttrCtx h)
 	}
 
 /* Read 4-byte unsigned number. */
-static unsigned long read4(ttrCtx h)
+static uint32_t read4(ttrCtx h)
 	{
-	unsigned long value = (unsigned long)read1(h)<<24;
-	value |= (unsigned long)read1(h)<<16;
-	value |= (unsigned long)read1(h)<<8;
-	return value | (unsigned long)read1(h);
+	uint32_t value = (uint32_t)read1(h)<<24;
+	value |= (uint32_t)read1(h)<<16;
+	value |= (uint32_t)read1(h)<<8;
+	return value | (uint32_t)read1(h);
 	}
 
 /* Read 4-byte signed number. */
-static long sread4(ttrCtx h)
+static int32_t sread4(ttrCtx h)
 	{
-	unsigned long value = (unsigned long)read1(h)<<24;
-	value |= (unsigned long)read1(h)<<16;
-	value |= (unsigned long)read1(h)<<8;
-	value |= (unsigned long)read1(h);
-#if LONG_MAX == 2147483647
-	return (long)value;
+	uint32_t value = (int32_t)read1(h)<<24;
+	value |= (uint32_t)read1(h)<<16;
+	value |= (uint32_t)read1(h)<<8;
+	value |= (uint32_t)read1(h);
+#if INT32_MAX == 2147483647
+	return (int32_t)value;
 #else
-	return (long)((value > 2417483647)? value - 4294967296: value);
+	return (int32_t)((value > 2417483647)? value - 4294967296: value);
 #endif
 	}
 
@@ -1202,7 +1202,7 @@ static void cmapReadFmt4(ttrCtx h)
 	{
 	long offset;
 	long i;
-    long nSegments = read2(h)/2;
+    int32_t nSegments = read2(h)/2;
 
 	/* Skip binary search fields */
 	(void)read2(h);		/* searchRange */


### PR DESCRIPTION
This is mainly a bunch of fixes for compiling in 64bit, but only for ```makeotf``` required files.

Also a included is a few fixes caught by clang address sanitizer. such as unitialized value and a memcpy with overlapping src/dst. I somewhat blindly changed that to a memmove.

