### PR TITLE
Changed reference to UFOFontData method name back to clearHashMap for…

### DIFF
--- a/FDK/Tools/SharedData/FDKScripts/CheckOutlinesUFO.py
+++ b/FDK/Tools/SharedData/FDKScripts/CheckOutlinesUFO.py
@@ -278,7 +278,7 @@ class FontFile(object):
 
     def clear_hash_map(self):
         if self.ufo_font_hash_data is not None:
-            self.ufo_font_hash_data.clear_hash_map()
+            self.ufo_font_hash_data.clearHashMap()
 
 
 class COOptions(object):


### PR DESCRIPTION
… now (had changed it to clear_hash_map, but haven't updated ufoTools.py yet).