### PR TITLE
Fix for issue #228:

### DIFF
--- a/afdko/Tools/SharedData/FDKScripts/CheckOutlinesUFO.py
+++ b/afdko/Tools/SharedData/FDKScripts/CheckOutlinesUFO.py
@@ -1116,6 +1116,9 @@ def run(args=None):
         seen_glyph_count += 1
         msg = []
 
+        if glyph_name not in defcon_font:
+            continue
+
         # font_file.check_skip_glyph updates the hash map for the glyph,
         # so we call it even when the  '-all' option is used.
         skip = font_file.check_skip_glyph(glyph_name, options.check_all)

--- a/afdko/Tools/SharedData/FDKScripts/ufoTools.py
+++ b/afdko/Tools/SharedData/FDKScripts/ufoTools.py
@@ -685,7 +685,7 @@ class UFOFontData:
 			self.loadGlyphMap()
 		glyphFileName = self.glyphMap.get(glyphName)
 		if glyphFileName is None:
-			print "Warning. Skipping glyph '%s' because is not in the UFO glyph map." % (glyphName)
+			print "Warning. Skipping glyph '%s' because it is not in the UFO glyph map." % (glyphName)
 			skip = 1
 			return None, None, skip
 		width, glifXML, outlineXML = self.getGlyphXML(self.glyphDefaultDir, glyphFileName)

--- a/afdko/Tools/SharedData/FDKScripts/ufoTools.py
+++ b/afdko/Tools/SharedData/FDKScripts/ufoTools.py
@@ -683,7 +683,11 @@ class UFOFontData:
 		# If the program name is in the history list, and the srcHash matches the default glyph layer data, we can skip.
 		if len(self.glyphMap) == 0:
 			self.loadGlyphMap()
-		glyphFileName = self.glyphMap[glyphName]
+		glyphFileName = self.glyphMap.get(glyphName)
+		if glyphFileName is None:
+			print "Warning. Skipping glyph '%s' because is not in the UFO glyph map." % (glyphName)
+			skip = 1
+			return None, None, skip
 		width, glifXML, outlineXML = self.getGlyphXML(self.glyphDefaultDir, glyphFileName)
 		if glifXML == None:
 			skip = 1

--- a/afdko/Tools/SharedData/FDKScripts/ufoTools.py
+++ b/afdko/Tools/SharedData/FDKScripts/ufoTools.py
@@ -684,8 +684,7 @@ class UFOFontData:
 		if len(self.glyphMap) == 0:
 			self.loadGlyphMap()
 		glyphFileName = self.glyphMap.get(glyphName)
-		if glyphFileName is None:
-			print "Warning. Skipping glyph '%s' because it is not in the UFO glyph map." % (glyphName)
+		if not glyphFileName:
 			skip = 1
 			return None, None, skip
 		width, glifXML, outlineXML = self.getGlyphXML(self.glyphDefaultDir, glyphFileName)


### PR DESCRIPTION
now reporting a warning about skipping a glyph that is not in the UFO glyph map rather than crashing with an error.