### PR TITLE
Fix for issue #237:

### DIFF
--- a/afdko/Tools/Programs/makeotf/makeotf_lib/api/hotconv.h
+++ b/afdko/Tools/Programs/makeotf/makeotf_lib/api/hotconv.h
@@ -10,7 +10,7 @@ This software is licensed as OpenSource, under the Apache License, Version 2.0. 
 extern "C" {
 #endif
 
-#define HOT_VERSION 0x010069 /* Library version (1.0.105) */
+#define HOT_VERSION 0x01006A /* Library version (1.0.106) */
 /* 	Major, minor, build = (HOT_VERSION >> 16) & 0xff, (HOT_VERSION >> 8) & 0xff, HOT_VERSION & 0xff) */
 /*Warning: this string is now part of heuristic used by CoolType to identify the
 first round of CoolType fonts which had the backtrack sequence of a chaining 

--- a/afdko/Tools/Programs/makeotf/makeotf_lib/source/hotconv/GSUB.c
+++ b/afdko/Tools/Programs/makeotf/makeotf_lib/source/hotconv/GSUB.c
@@ -755,7 +755,7 @@ void GSUBSetFeatureNameID(hotCtx g, Tag feat, unsigned short nameID) {
 static void fillGSUBFeatureNameParam(hotCtx g, GSUBCtx h, Subtable *sub) {
 	FeatureNameParameterFormat *feat_param = (FeatureNameParameterFormat *)sub->tbl;
 	unsigned short nameid = feat_param->nameID;
-    unsigned short cvNumber = ((sub->feature >>8 & 0xFF) - (int)'0') << 8;
+    unsigned short cvNumber = ((sub->feature >>8 & 0xFF) - (int)'0') * 10;
     cvNumber += (sub->feature & 0xFF) - (int)'0';
     if (((sub->feature >>24 & 0xFF) == (int)'s') &&
         ((sub->feature >>16 & 0xFF) == (int)'s') &&
@@ -808,7 +808,7 @@ static void fillGSUBCVParam(hotCtx g, GSUBCtx h, Subtable *sub) {
 	CVParameterFormat *feat_param = (CVParameterFormat *)sub->tbl;
     int i = 0;
     unsigned short nameIDs[4];
-    unsigned short cvNumber = ((sub->feature >>8 & 0xFF) - (int)'0') << 8;
+    unsigned short cvNumber = ((sub->feature >>8 & 0xFF) - (int)'0') * 10;
     cvNumber += (sub->feature & 0xFF) - (int)'0';
     if (((sub->feature >>24 & 0xFF) == (int)'c') &&
         ((sub->feature >>16 & 0xFF) == (int)'v') &&

--- a/afdko/Tools/Programs/makeotf/makeotf_lib/source/typecomp/parse.c
+++ b/afdko/Tools/Programs/makeotf/makeotf_lib/source/typecomp/parse.c
@@ -465,6 +465,8 @@ static void readEncoding(parseCtx h) {
 		int length;
 		long index[256]; /* Glyph name index, b31-8 buf. index, b7-0 length */
 
+		length = 0;
+
 		/* Initialize index */
 		for (i = 0; i < 256; i++) {
 			index[i] = 0;
@@ -478,7 +480,6 @@ static void readEncoding(parseCtx h) {
 
 		if (psMatchValue(h->ps, dupToken, "dup")) {
 			/* Parse encoding */
-			length = 0;
 			do {
 				int code = 0;   /* Suppress optimizer warning */
 				psToken codet;

--- a/afdko/Tools/Programs/makeotf/source/main.c
+++ b/afdko/Tools/Programs/makeotf/source/main.c
@@ -40,7 +40,7 @@
 
 jmp_buf mark;
 
-#define MAKEOTF_VERSION "2.5.65592"
+#define MAKEOTF_VERSION "2.5.65593"
 /*Warning: this string is now part of heuristic used by CoolType to identify the
    first round of CoolType fonts which had the backtrack sequence of a chaining
    contextual substitution ordered incorrectly.  Fonts with the old ordering MUST match

--- a/afdko/Tools/SharedData/FDKScripts/MakeOTF.py
+++ b/afdko/Tools/SharedData/FDKScripts/MakeOTF.py
@@ -15,7 +15,7 @@ __copyright__ = """Copyright 2017 Adobe Systems Incorporated (http://www.adobe.c
 """
 
 __version__ = """\
-makeotf v2.0.99 Nov 7 2017
+makeotf v2.0.100 Jan 17 2018
 """
 
 __methods__ = """


### PR DESCRIPTION
multiply first digit of cv number by 10 instead of shifting left by 8 bits, so now we get a cv number of 10 instead of 256 for cv10.