### PR TITLE
Fixed assert "out of range region index found in item variation store…

### DIFF
--- a/afdko/Tools/Programs/public/lib/source/varread/varread.c
+++ b/afdko/Tools/Programs/public/lib/source/varread/varread.c
@@ -998,7 +998,7 @@ static float var_applyDeltasForIndexPair(ctlSharedStmCallbacks *sscb, var_itemVa
         return netAdjustment;
     }
 
-    subRegionCount = var_getIVSRegionIndices(ivs, pair->outerIndex, regionIndices, subtable->regionCount);
+    subRegionCount = var_getIVSRegionIndices(ivs, pair->outerIndex, regionIndices, regionCount);
     if (subRegionCount == 0) {
         sscb->message(sscb, "out of range region index found in item variation store subtable");
     }


### PR DESCRIPTION
… subtable"

Fixed an assert "out of range region index found in item variation store subtable " in var_getIVSRegionIndices because a wrong region count was used to range-check region indexes.
The bug was exposed when reading Monotype AvenirNext-Variable.ttf