### PR TITLE
moved .coveragerc into Tests and changed paths for mapping files

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,5 +8,5 @@ install:
 build: false
 
 test_script:
-  - pytest -v Tests/
+  - pytest
   - pip uninstall --yes afdko

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
         - python -m virtualenv .venv/
         - source .venv/bin/activate
         - pip install codecov
-        - pip install pytest
         - pip install pytest-cov
         - pip install collective.checkdocs
         - pip install pygments
@@ -33,9 +32,7 @@ matrix:
         - python setup.py check --restructuredtext --strict
         - python setup.py bdist_wheel
         - pip install dist/*.whl
-        - pushd Tests
-        - pytest -v --cov=afdko .
-        - popd
+        - pytest --cov
         - flake8 setup.py
         - pushd afdko/Tools/SharedData/FDKScripts
         - flake8 buildCFF2VF.py
@@ -49,7 +46,6 @@ matrix:
         - popd
         - pip uninstall --yes afdko
       after_success:
-        - cd Tests
         - codecov
 
 # only build for *pushes* to master,

--- a/Tests/checkoutlinesufo_test.py
+++ b/Tests/checkoutlinesufo_test.py
@@ -39,9 +39,3 @@ def test_remove_tiny_sub_paths_small_contour():
     assert remove_tiny_sub_paths(bg, 25, []) == \
         ['Contour 0 is too small: bounding box is less than minimum area. '
          'Start point: ((1, 1)).']
-
-
-if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main(sys.argv))

--- a/Tests/ttfcomponentizer_test.py
+++ b/Tests/ttfcomponentizer_test.py
@@ -220,9 +220,3 @@ def test_assemble_components():
     assert (comp_two.x, comp_two.y) == (263, 0)
     assert comp_one.flags == 0x204
     assert comp_two.flags == 0x4
-
-
-if __name__ == "__main__":
-    import sys
-
-    sys.exit(pytest.main(sys.argv))


### PR DESCRIPTION
(using psautohint's `.coveragerc` as a point of reference)