### PR TITLE
Revert "update PyPI URL in README.rst"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -156,4 +156,4 @@ On Windows, you need to download and install Visual C++ 6, and add all the servi
 .. |Coverage Status| image:: https://codecov.io/gh/adobe-type-tools/afdko/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/adobe-type-tools/afdko
 .. |PyPI| image:: https://img.shields.io/pypi/v/afdko.svg
-   :target: https://pypi.python.org/pypi/afdko
+   :target: https://pypi.org/project/afdko


### PR DESCRIPTION
This reverts commit 209e413b20578b2a2a8e62991f5741f5dded936d.

The red banner is gone.