### PR TITLE
Move wheel-making and -installation to later in the process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
         - pip install pygments
         - pip install flake8
         - pip install --upgrade wheel cython
+        - pip install -r requirements.txt
       script:
         - python setup.py checkdocs
         - python setup.py check --restructuredtext --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ matrix:
         - pip install flake8
         - pip install --upgrade wheel cython
         - pip install -r requirements.txt
+      before_script:
+        - export PYTHONPATH=$PYTHONPATH:$(pwd)
       script:
         - python setup.py checkdocs
         - python setup.py check --restructuredtext --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ matrix:
       script:
         - python setup.py checkdocs
         - python setup.py check --restructuredtext --strict
-        - python setup.py bdist_wheel
-        - pip install dist/*.whl
         - pytest --cov
         - flake8 setup.py
         - pushd afdko/Tools/SharedData/FDKScripts
@@ -44,6 +42,8 @@ matrix:
         - flake8 ttfcomponentizer.py
         - flake8 ufoTools.py
         - popd
+        - python setup.py bdist_wheel
+        - pip install dist/*.whl
         - pip uninstall --yes afdko
       after_success:
         - codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+booleanOperations>=0.7.1
+defcon>=0.3.5
+fontMath>=0.4.4
+fontPens>=0.1.0'
+fonttools>=3.19.0
+mutatorMath>=2.1.0
+ufolib>=2.1.1
+ufonormalizer>=0.3.2

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ class CustomBuild(setuptools.command.build_py.build_py):
         setuptools.command.build_py.build_py.run(self)
 
 
-def get_scripts():
+def _get_scripts():
     bin_dir = get_executable_dir()
     script_names = [
         'autohintexe', 'detype1', 'makeotfexe', 'mergeFonts', 'rotateFont',
@@ -92,7 +92,7 @@ def get_scripts():
     return scripts
 
 
-def get_console_scripts():
+def _get_console_scripts():
     script_entries = [
         ('autohint', 'autohint:main'),
         ('buildcff2vf', 'buildCFF2VF:run'),
@@ -134,9 +134,6 @@ def main():
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2.7',
     ]
-
-    scripts = get_scripts()
-    console_scripts = get_console_scripts()
 
     platform_system = platform.system()
     if platform_system == "Darwin":
@@ -186,11 +183,13 @@ def main():
               'ufonormalizer>=0.3.2',
               'fontPens>=0.1.0'
           ],
-          scripts=scripts,
+          scripts=_get_scripts(),
           entry_points={
-              'console_scripts': console_scripts,
+              'console_scripts': _get_console_scripts(),
           },
-          cmdclass={'build_py': CustomBuild, 'bdist_wheel': CustomBDistWheel},
+          cmdclass={
+              'build_py': CustomBuild,
+              'bdist_wheel': CustomBDistWheel},
           )
 
 

--- a/setup.py
+++ b/setup.py
@@ -178,6 +178,8 @@ def main():
           zip_safe=False,
           python_requires='>=2.7',
           setup_requires=['wheel'],
+          tests_require=[
+              'pytest',
           ],
           install_requires=_get_requirements(),
           scripts=_get_scripts(),

--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,11 @@ def _get_console_scripts():
     return scripts
 
 
+def _get_requirements():
+    with io.open("requirements.txt", encoding="utf-8") as requirements:
+        return requirements.read().splitlines()
+
+
 def main():
     pkg_list = find_packages()
     classifiers = [
@@ -173,16 +178,8 @@ def main():
           zip_safe=False,
           python_requires='>=2.7',
           setup_requires=['wheel'],
-          install_requires=[
-              'fonttools>=3.19.0',
-              'booleanOperations>=0.7.1',
-              'fontMath>=0.4.4',
-              'defcon>=0.3.5',
-              'mutatorMath>=2.1.0',
-              'ufolib>=2.1.1',
-              'ufonormalizer>=0.3.2',
-              'fontPens>=0.1.0'
           ],
+          install_requires=_get_requirements(),
           scripts=_get_scripts(),
           entry_points={
               'console_scripts': _get_console_scripts(),

--- a/setup.py
+++ b/setup.py
@@ -10,15 +10,6 @@ import setuptools.command.build_py
 from setuptools import setup, find_packages
 
 """
-Notes:
-In order to upolad the afdko wheel to testpypi to test the package, I had to
-first update the Mac OSX system python ssl module with 'pip install pyOpenSSL
-ndg-httpsclient pyasn1'. Otherwise, the command 'twine upload --repository-url
-https://test.pypi.org/legacy/ dist/*' would fail with
-'SSLError: [SSL: TLSV1_ALERT_PROTOCOL_VERSION]'
-"""
-
-"""
 We need a customized version of the 'bdist_wheel' command, because otherwise
 the wheel is identified as being non-platform specific. This is because the
 afdko has no Python extensions and the command line tools are installed as


### PR DESCRIPTION
This way there's less scrolling to get to failing tests, and the coverage is reported for the source files, not for the installed ones.