### PR TITLE
travis: skip the default Travis python 'install' step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,8 @@ matrix:
       if: type = push
       language: python
       python: 2.7
+      # skip default installation step
+      install: true
 
     - os: osx
       env:


### PR DESCRIPTION
when no 'install:' is defined, and language is 'python', Travis automatically does
pip install -r requirements.txt

it shouldn't do that.

(i'm not sure this is going to change anything, but let's try anyway.. also, it's quite annoying that in order to test this, we have to merge a PR and tag all the time... though I see no other way) 