### PR TITLE
travis: also skip 'script' step, all the work happens in before_deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,10 @@ matrix:
       if: type = push
       language: python
       python: 2.7
-      # skip default installation step
+      # skip default 'install' and 'script' steps: all the work is in
+      # before_deploy
       install: true
+      script: true
 
     - os: osx
       env:


### PR DESCRIPTION
not sure why for the other osx-deploy build, it doesn't complain that there is no 'script' step defined...
anyway, let's try one more time.