### PR TITLE
fix for #329 [tx] fail to convert multi-FD CFF2 font to CID/CFF

### DIFF
--- a/afdko/Tools/Programs/public/lib/source/cffread/cffread.c
+++ b/afdko/Tools/Programs/public/lib/source/cffread/cffread.c
@@ -2308,6 +2308,15 @@ static void readCharset(cfrCtx h)
             MVARread(h);
         if (!(h->flags & CID_FONT))
             readCharSetFromPost(h);
+        else
+        {
+            long gid;
+            for (gid = 0; gid < h->glyphs.cnt; gid++)
+            {
+                abfGlyphInfo *info = &h->glyphs.array[gid];
+                info->cid = (unsigned short)gid;
+            }
+        }
         return;
     }
     


### PR DESCRIPTION
Initialize info.cid for each glyph in CID/CFF2 font with its gid, otherwise when converting CFF2 to CFF1, cfwAddGlyph in cffwrite.c regards all glyphs as CID = 0, optimize away all font dicts except font dict 0 for CID 0 as unused (see lines around comment "Force CID 0 to GID 0" at line 576 in cffwrite.c).