### PR TITLE
[travis] Specify osx_image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
         - pip uninstall --yes afdko
 
     - os: osx
+      osx_image: xcode6.4
       env: NAME=OSX
       if: type = pull_request
       language: generic


### PR DESCRIPTION
Available versions at https://docs.travis-ci.com/user/reference/osx/#OS-X-Version

This is to force the wheel to support macOS 10.10 and above; current support is 10.12+