### PR TITLE
nullify glyph stemVF callback when not writing CFF2

### DIFF
--- a/afdko/Tools/Programs/tx/source/tx.c
+++ b/afdko/Tools/Programs/tx/source/tx.c
@@ -1762,6 +1762,7 @@ static void cff_BegFont(txCtx h, abfTopDict *top)
             h->cb.glyph.moveVF = NULL;
             h->cb.glyph.lineVF = NULL;
             h->cb.glyph.curveVF = NULL;
+            h->cb.glyph.stemVF = NULL;
         }
         
         if (cfwBegFont(h->cfw.ctx, NULL, h->cfw.maxNumSubrs))
@@ -1793,6 +1794,7 @@ static void cff_EndFont(txCtx h)
             h->cb.glyph.moveVF = NULL;
             h->cb.glyph.lineVF = NULL;
             h->cb.glyph.curveVF = NULL;
+            h->cb.glyph.stemVF = NULL;
         }
         if (h->flags & PATH_SUPRESS_HINTS)
         {
@@ -1861,6 +1863,7 @@ static void cff_SetMode(txCtx h)
             h->cb.glyph.moveVF = NULL;
             h->cb.glyph.lineVF = NULL;
             h->cb.glyph.curveVF = NULL;
+            h->cb.glyph.stemVF = NULL;
         }
 
         if (h->abf.ctx == NULL)


### PR DESCRIPTION
Otherwise stem hints are written out with the default values of CFF2 variable stem hints when we want blended hints snapshotted for the current instance in the output.