### PR TITLE
[spot] Fix a crash due to buffer overrun errors from long glyph names.

### DIFF
--- a/Tests/spot_test.py
+++ b/Tests/spot_test.py
@@ -108,13 +108,12 @@ def test_bug373_dump_gsub_equal_7_long_glyph_name_otf():
     assert differ([expected_path, actual_path]) is True
 
 
-# Abort trap: 6
 # https://github.com/adobe-type-tools/afdko/issues/373
-# def test_bug373_dump_gsub_equal_7_long_glyph_name_ttf():
-#     actual_path = runner(CMD + ['-r', '-o', 't', '_GSUB=7',
-#                                 '-f', 'long_glyph_name.ttf'])
-#     expected_path = _get_expected_path('bug373_ttf.txt')
-#     assert differ([expected_path, actual_path]) is True
+def test_bug373_dump_gsub_equal_7_long_glyph_name_ttf():
+    actual_path = runner(CMD + ['-r', '-o', 't', '_GSUB=7',
+                                '-f', 'long_glyph_name.ttf'])
+    expected_path = _get_expected_path('bug373_ttf.txt')
+    assert differ([expected_path, actual_path]) is True
 
 
 def test_dump_cmap_equal_5():

--- a/afdko/Tools/Programs/spot/source/GDEF.c
+++ b/afdko/Tools/Programs/spot/source/GDEF.c
@@ -253,7 +253,7 @@ static void dumpAttachList(Offset attachListOffset, AttachList * attachList, int
 
 	for (i = 0; i < attachList->GlyphCount; i++)
 		{
-		char name[64];
+		char name[MAX_NAME_LEN];
 		GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
 		AttachPoint * attachPoint = &attachList->_AttachPoint[i];
 
@@ -311,7 +311,7 @@ static void dumpLigCaretList(Offset ligCaretListoffset, LigCaretList* ligCaretLi
 	
 	for (i = 0; i < ligCaretList->LigGlyphCount; i++)
 		{
-		char name[64];
+		char name[MAX_NAME_LEN];
 		CaretValueFormat3 * caretValue;
 		GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
 		LigGlyph * ligGlyph = &ligCaretList->_LigGlyph[i];

--- a/afdko/Tools/Programs/spot/source/GPOS.c
+++ b/afdko/Tools/Programs/spot/source/GPOS.c
@@ -46,9 +46,10 @@ static IntX GPOSLookupIndex = 0;
 static IntX GPOSLookupCnt = 0;
 static IntX GPOSContextRecursionCnt = 0;
 
-static Byte8 contextPrefix[40]; /* when dumping the context sub rules, this cntains the context string for the rule, if any. */
+static Byte8 contextPrefix[MAX_NAME_LEN]; /* when dumping the context sub rules, this cntains the context string for the rule, if any. */
 
 static FILE * AFMout;
+static char* tempFileName;
 
 static void *readSubtable(Card32 offset, Card16 type);
 
@@ -1374,7 +1375,6 @@ static void proofSinglePos1(SinglePosFormat1 *fmt, IntX glyphtoproof)
 	  ttoEnumerateCoverage(fmt->Coverage, fmt->_Coverage, &CovList, &nitems);
 	  for ((glyphtoproof!=-1)?(i=glyphtoproof):(i = 0); (glyphtoproof!=-1)?(i<=glyphtoproof):(i < (IntX)nitems); i++) 
 		{
-		  char name[40];
 		  char label[80];
 		  GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
 		  if (glyphtoproof==-1 && !opt_Present("-f")) {
@@ -1387,6 +1387,7 @@ static void proofSinglePos1(SinglePosFormat1 *fmt, IntX glyphtoproof)
 				proofRec->vert=proofIsVerticalMode();
 				curproofrec++;
 		  }else{
+			  char name[MAX_NAME_LEN];
 			  strcpy(name, getGlyphName(glyphId, 1));
 			  getMetrics(glyphId, &origShift, &lsb, &rsb, &width, &tsb, &bsb, &vwidth, &yorig);
 			  if (isVert)
@@ -1451,7 +1452,7 @@ static void dumpSinglePos1(SinglePosFormat1 *fmt, IntX level, IntX glyphtoproof)
 	  	ttoEnumerateCoverage(fmt->Coverage, fmt->_Coverage, &CovList, &nitems);
 	    for (i = 0; i < (IntX)nitems; i++) 
 		{
-		  char name[40];
+		  char name[MAX_NAME_LEN];
 		  GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
 
 		  strcpy(name, getGlyphName(glyphId, 0));
@@ -1506,7 +1507,6 @@ static void proofSinglePos2(SinglePosFormat2 *fmt, IntX glyphtoproof)
 	  ttoEnumerateCoverage(fmt->Coverage, fmt->_Coverage, &CovList, &nitems);
 	  for ((glyphtoproof!=-1)?(i=glyphtoproof):(i = 0); (glyphtoproof!=-1)?(i<=glyphtoproof):(i < (IntX)nitems); i++) 
 		{
-		  char name[40];
 		  char label[80];
 		  GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
 		  if (glyphtoproof ==-1 && !opt_Present("-f")) {
@@ -1519,6 +1519,7 @@ static void proofSinglePos2(SinglePosFormat2 *fmt, IntX glyphtoproof)
 				proofRec->vert=proofIsVerticalMode();
 				curproofrec++;
 		  }else{
+			  char name[MAX_NAME_LEN];
 			  strcpy(name, getGlyphName(glyphId, 1));
 			  xpla = fmt->Value[i].XPlacement;
 			  ypla = fmt->Value[i].YPlacement;
@@ -1594,7 +1595,7 @@ static void dumpSinglePos2(SinglePosFormat2 *fmt, IntX level , IntX glyphtoproof
 		  	ttoEnumerateCoverage(fmt->Coverage, fmt->_Coverage, &CovList, &nitems);
 		  	for (i = 0; i < (IntX)nitems; i++) 
 			{
-			  char name[40];
+			  char name[MAX_NAME_LEN];
 			  GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
 			  strcpy(name, getGlyphName(glyphId, 0));
 			  
@@ -1771,7 +1772,7 @@ static void proofPosPair1(PosPairFormat1 *fmt, IntX glyphtoproof1, IntX glyphtop
 	  /* generate the pairs list */
 	  for ((glyphtoproof1!=-1)?(i=glyphtoproof1):(i = 0); (glyphtoproof1!=-1)?(i<=glyphtoproof1):(i < (IntX)nitems); i++) 
 		{
-		  char nam1[40];
+		  char nam1[MAX_NAME_LEN];
 		  GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
 		  PairSet *pairset = &(fmt->_PairSet[i]);
 		  
@@ -1780,7 +1781,7 @@ static void proofPosPair1(PosPairFormat1 *fmt, IntX glyphtoproof1, IntX glyphtop
 		  for ((glyphtoproof2!=-1)?(j=glyphtoproof2):(j = 0); (glyphtoproof2!=-1)?(j<=glyphtoproof2):(j < pairset->PairValueCount); j++) 
 			{
 			  PairValueRecord *pv = &(pairset->PairValueRecord[j]);
-			  char nam2[40];	
+			  char nam2[MAX_NAME_LEN];	
 			  char label[80];
 			  IntX width2, vwidth2, yorig2;
 			  strcpy(nam2, getGlyphName(pv->SecondGlyph, 1));
@@ -1953,7 +1954,7 @@ static void dumpPosPair1(PosPairFormat1 *fmt, IntX level, IntX glyphtoproof1, In
 
 		  for (i = 0; i < (IntX)nitems; i++) 
 			{
-			  char nam1[40];
+			  char nam1[MAX_NAME_LEN];
 			  GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
 			  PairSet *pairset = &(fmt->_PairSet[i]);
 			  strcpy(nam1, getGlyphName(glyphId, 0));			  
@@ -1961,7 +1962,7 @@ static void dumpPosPair1(PosPairFormat1 *fmt, IntX level, IntX glyphtoproof1, In
 			  for (j = 0; j < pairset->PairValueCount; j++) 
 				{
 				  PairValueRecord *pv = &(pairset->PairValueRecord[j]);
-				  char nam2[40];	
+				  char nam2[MAX_NAME_LEN];	
 				  strcpy(nam2, getGlyphName(pv->SecondGlyph, 0));
 				  if (level == 7)
 				  {
@@ -2018,8 +2019,8 @@ static void proofPosPair2(PosPairFormat2 *fmt, IntX glyphtoproof1, IntX glyphtop
 	  IntX origShift, lsb, rsb, width, width2, tsb, bsb, vwidth, vwidth2, yorig , yorig2;
 	  proofOptions options;
 	  IntX isVert = proofIsVerticalMode();
-	  char nam1[40];
-	  char nam2[40];
+	  char nam1[MAX_NAME_LEN];
+	  char nam2[MAX_NAME_LEN];
 	  char label[80];
 	  ttoEnumRec CovList;
 	  Card32 nitems, i;
@@ -2187,8 +2188,8 @@ static void dumpPosPair2(PosPairFormat2 *fmt, IntX level, IntX glyphtoproof1, In
 		  ttoEnumRec *class2;
 		  Card32 class2count;
 		  IntX c1, c2, c1g, c2g;
-		  char nam1[40];
-		  char nam2[40];
+		  char nam1[MAX_NAME_LEN];
+		  char nam2[MAX_NAME_LEN];
 		  bit_declp(CoverageSet);
 
 		  class1 = memNew(sizeof(ttoEnumRec) * fmt->Class1Count);
@@ -2335,8 +2336,8 @@ static void dumpPosPair2(PosPairFormat2 *fmt, IntX level, IntX glyphtoproof1, In
 		  Card32 class2count;
 		  IntX c1, c2, c1g, c2g;
 		  IntX xpla, xadv, ypla, yadv;
-		  char nam1[40];
-		  char nam2[40];
+		  char nam1[MAX_NAME_LEN];
+		  char nam2[MAX_NAME_LEN];
 		  bit_declp(CoverageSet);
 
 		  class1 = memNew(sizeof(ttoEnumRec) * fmt->Class1Count);
@@ -2735,7 +2736,7 @@ static void dumpCursiveAttachPos(CursivePosFormat1 *fmt, IntX level)
 	  	ttoEnumerateCoverage(fmt->Coverage, fmt->_Coverage, &CovList, &nitems);
 	    for (i = 0; i < (IntX)nitems; i++) 
 			{
-			char name[40];
+			char name[MAX_NAME_LEN];
 			GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
 			IntX offsetAnchor;
 			void * anchorTable;
@@ -2926,7 +2927,7 @@ static void dumpMarkToBase(MarkBasePosFormat1 *fmt, IntX level, int isMarkToMark
 		ttoEnumerateCoverage(fmt->MarkCoverage, fmt->_MarkCoverage, &MarkCovList, &nitems);
 		for (i = 0; i < (IntX)nitems; i++) 
 			{
-			char name[40];
+			char name[MAX_NAME_LEN];
 			GlyphId glyphId = *da_INDEX(MarkCovList.glyphidlist, i);
 			IntX offsetAnchor;
 			void * anchorTable;
@@ -2953,7 +2954,7 @@ static void dumpMarkToBase(MarkBasePosFormat1 *fmt, IntX level, int isMarkToMark
 	  	ttoEnumerateCoverage(fmt->BaseCoverage, fmt->_BaseCoverage, &BaseCovList, &mitems);
 	    for (i = 0; i < (IntX)mitems; i++) 
 			{
-			char name[40];
+			char name[MAX_NAME_LEN];
 			GlyphId glyphId = *da_INDEX(BaseCovList.glyphidlist, i);
 			
  		 	BaseRecord *record = &basearray->BaseRecord[i];
@@ -3113,7 +3114,7 @@ static void dumpMarkToLigatureAttach(MarkToLigPosFormat1 *fmt, IntX level)
 	  	ttoEnumerateCoverage(fmt->MarkCoverage, fmt->_MarkCoverage, &MarkCovList, &nitems);
 	    for (i = 0; i < (IntX)nitems; i++) 
 			{
-			char name[40];
+			char name[MAX_NAME_LEN];
 			GlyphId glyphId = *da_INDEX(MarkCovList.glyphidlist, i);
 			IntX offsetAnchor;
 			void * anchorTable;
@@ -3140,7 +3141,7 @@ static void dumpMarkToLigatureAttach(MarkToLigPosFormat1 *fmt, IntX level)
 	  	ttoEnumerateCoverage(fmt->LigatureCoverage, fmt->_LigatureCoverage, &LigatureCoverage, &mitems);
 	    for (i = 0; i < (IntX)mitems; i++) 
 			{
-			char name[40];
+			char name[MAX_NAME_LEN];
 			GlyphId glyphId = *da_INDEX(LigatureCoverage.glyphidlist, i);
 			
  		 	LigatureAttach *ligatureAttachRec = &ligArray->_LigatureAttach[i];
@@ -3318,7 +3319,7 @@ static void dumpContext1(ContextPosFormat1 *fmt, IntX level)
 	  	ttoEnumerateCoverage(fmt->Coverage, fmt->_Coverage, &CovList, &nitems);
 		for (i = 0; i < nitems; i++) 
 		{
-		  	char name[40];
+		  	char name[MAX_NAME_LEN];
 		  	PosRuleSet *posruleset = &fmt->_PosRuleSet[i];
 		  	GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
 
@@ -3427,7 +3428,7 @@ static void dumpContext1(ContextPosFormat1 *fmt, IntX level)
 		
 		for (i = 0; i < nitems; i++)
 		  {
-			char name1[40];
+			char name1[MAX_NAME_LEN];
 			IntX srscnt;
 			IntX origShift, lsb, rsb, width1, tsb, bsb, vwidth, yorig;
 			GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
@@ -3538,7 +3539,7 @@ static void showContext2(ContextPosFormat2 *fmt, IntX level, void *feattag)
 					CR = &(classList[classId]);
 					for (c = 0; c < CR->glyphidlist.cnt; c++)
 					  {
-						char name2[64];
+						char name2[MAX_NAME_LEN];
 						GlyphId glyphId2 = *da_INDEX(CR->glyphidlist, c);
 						strcpy(name2, getGlyphName(glyphId2, forProofing));
 						psIndex = strlen(proofString);
@@ -3561,7 +3562,7 @@ static void showContext2(ContextPosFormat2 *fmt, IntX level, void *feattag)
 						sprintf(&proofString[psIndex],"[");
 						for (c = 0; c < CR->glyphidlist.cnt; c++)
 						  {
-							char name2[64];
+							char name2[MAX_NAME_LEN];
 							GlyphId glyphId2 = *da_INDEX(CR->glyphidlist, c);
 							strcpy(name2, getGlyphName(glyphId2, forProofing));
                               if ((psIndex + strlen(name2) + 10) >= kProofBufferLen)
@@ -3632,7 +3633,7 @@ static void proofContext2(ContextPosFormat2 *fmt)
 		ttoEnumerateCoverage(fmt->Coverage, fmt->_Coverage, &CovList, &nitems);
 		for (i = 0; i < nitems; i++)
 		  {
-			char name1[40];
+			char name1[MAX_NAME_LEN];
 			IntX scscnt;
 			GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
 			strcpy(name1, getGlyphName(glyphId, 1));
@@ -3680,7 +3681,7 @@ static void proofContext2(ContextPosFormat2 *fmt)
 						CR = &(classList[classId]);
 						for (c = 0; c < CR->glyphidlist.cnt; c++)
 						  {
-							char name2[40];
+							char name2[MAX_NAME_LEN];
 							GlyphId inputgid[4];
 							GlyphId outputgid[4];
 							IntX inputcount, outputcount, o;
@@ -3739,7 +3740,7 @@ static void proofContext2(ContextPosFormat2 *fmt)
 							for (o = 0; o < outputcount; o++)
 							  {
 								IntX owid, OW;
-								char oname[40];
+								char oname[MAX_NAME_LEN];
 								GlyphId ogid = outputgid[o];
 								strcpy(oname, getGlyphName(ogid, 1));
 								getMetrics(ogid, &origShift, &lsb, &rsb, &owid, &tsb, &bsb, &vwidth, &yorig3);
@@ -4365,7 +4366,7 @@ static void  proofPosChainContext3(ChainContextPosFormat3 *fmt, int level, void*
 			Card32 nitems1;
 			IntX j = fmt->BacktrackGlyphCount - (i+1);
 			GlyphId gId1;
-			char name1[40];
+			char name1[MAX_NAME_LEN];
 			ttoEnumRec *ter1 = da_NEXT(BacktrackGlyphCovListArray);
 			ttoEnumerateCoverage(fmt->Backtrack[j], fmt->_Backtrack[j], ter1, &nitems1);
 			if (nitems1 > 1)
@@ -4414,7 +4415,7 @@ static void  proofPosChainContext3(ChainContextPosFormat3 *fmt, int level, void*
 			Card32 nitems1;
 			IntX j;
 			GlyphId gId1;
-			char name1[40];
+			char name1[MAX_NAME_LEN];
 			ttoEnumRec *ter1 = da_NEXT(InputGlyphCovListArray);
 			ttoEnumerateCoverage(fmt->Input[i], fmt->_Input[i], ter1, &nitems1);
 			if (nitems1 > 1)
@@ -4468,7 +4469,7 @@ static void  proofPosChainContext3(ChainContextPosFormat3 *fmt, int level, void*
 			Card32 nitems1;
 			IntX j;
 			GlyphId gId1;
-			char name1[40];
+			char name1[MAX_NAME_LEN];
 			ttoEnumRec *ter1 = da_NEXT(LookaheadGlyphCovListArray);
 			ttoEnumerateCoverage(fmt->Lookahead[i], fmt->_Lookahead[i], ter1, &nitems1);
 			if (nitems1 > 1)
@@ -4525,7 +4526,7 @@ static void  proofPosChainContext3(ChainContextPosFormat3 *fmt, int level, void*
 			Card32 nitems1, nitems2 ;
 			IntX j, k;
 			GlyphId gId1, gId2;
-			char name1[40], name2[40];
+			char name1[MAX_NAME_LEN], name2[MAX_NAME_LEN];
 			ttoEnumRec *ter1, *ter2;
 			char label[100];
 			
@@ -5377,8 +5378,8 @@ void GPOSDump(IntX level, LongN start)
 	  				{
 	  				/* collect data from temp AFM file line */
 	  				char prefix[6];
-	  				char name1[65];
-	  				char name2[65];
+	  				char name1[MAX_NAME_LEN];
+	  				char name2[MAX_NAME_LEN];
 	  				int val1 = 0, val2 = 0, val3 = 0;
 	  				kernEntry = da_INDEX(afmLines, lineCount);
 	  				scanNum = sscanf(inLine,"%5s %64s %64s %d %d %d", prefix, name1, name2, &val1, &val2, &val3);

--- a/afdko/Tools/Programs/spot/source/GSUB.c
+++ b/afdko/Tools/Programs/spot/source/GSUB.c
@@ -17,7 +17,7 @@ This software is licensed as OpenSource, under the Apache License, Version 2.0. 
 static GSUBTbl GSUB;
 static IntX loaded = 0;
 static Card32 GSUBStart;
-static Byte8 contextPrefix[40];
+static Byte8 contextPrefix[MAX_NAME_LEN];
 
 static ProofContextPtr proofctx = NULL;
 /*static Card32 featuretag = 0;*/
@@ -1055,8 +1055,8 @@ static void proofSingle1(SingleSubstFormat1 *fmt)
 	ttoEnumerateCoverage(fmt->Coverage, fmt->_Coverage, &CovList, &nitems);
 	for (i = 0; i < nitems; i++)
 	  {
-		char name[40];
-		char name2[40];
+		char name[MAX_NAME_LEN];
+		char name2[MAX_NAME_LEN];
 		IntX glyphId2;
 		GlyphId glyphId = *da_INDEX(CovList.glyphidlist, (Int32)i);
 		strcpy(name, getGlyphName(glyphId, 1));
@@ -1122,7 +1122,7 @@ static void dumpSingle1(SingleSubstFormat1 *fmt, IntX level)
 	  	ttoEnumerateCoverage(fmt->Coverage, fmt->_Coverage, &CovList, &nitems);
 	    for (i = 0; i < (Int32)nitems; i++) 
 		{
-		  char name[40];
+		  char name[MAX_NAME_LEN];
 		  GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
 
 		  strcpy(name, getGlyphName(glyphId, 0));
@@ -1158,8 +1158,8 @@ static void proofSingle2(SingleSubstFormat2 *fmt)
 
 		for (i = 0; i < (Int32)nitems; i++)
 		  {
-			char name[40];
-			char name2[40];
+			char name[MAX_NAME_LEN];
+			char name2[MAX_NAME_LEN];
 			IntX glyphId2;
 			IntX origShift, lsb, rsb, width, tsb, bsb, vwidth, yorig, W;
 			GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
@@ -1229,7 +1229,7 @@ static void dumpSingle2(SingleSubstFormat2 *fmt, IntX level)
 	  	ttoEnumerateCoverage(fmt->Coverage, fmt->_Coverage, &CovList, &nitems);
 	    for (i = 0; i < (Int32)nitems; i++) 
 		{
-		  char name[40];
+		  char name[MAX_NAME_LEN];
 		  GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
 
 		  strcpy(name, getGlyphName(glyphId, 0));
@@ -1325,8 +1325,8 @@ static void proofMultiple1(MultipleSubstFormat1 *fmt)
 
 		for (i = 0; i < (Int32)nitems; i++)
 		  {
-			char name[40];
-			char name2[40];
+			char name[MAX_NAME_LEN];
+			char name2[MAX_NAME_LEN];
 			IntX glyphId2;
 			IntX j;
 			Sequence *sequence;
@@ -1474,8 +1474,8 @@ static void proofAlternate1(AlternateSubstFormat1 *fmt)
 
 		for (i = 0; i < (IntX)nitems; i++)
 		  {
-			char name[40];
-			char name2[40];
+			char name[MAX_NAME_LEN];
+			char name2[MAX_NAME_LEN];
 			IntX glyphId2;
 			AlternateSet *altset;
 			IntX origShift, lsb, rsb, width, tsb, bsb, vwidth, yorig, W;
@@ -1624,9 +1624,9 @@ static void proofLigature1(LigatureSubstFormat1 *fmt)
 		for (i = 0; i < (IntX)nitems; i++)
 		  {
 			LigatureSet *ligatureSet;
-			char name1[40];
-			char name2[40];
-			char ligname[40];
+			char name1[MAX_NAME_LEN];
+			char name2[MAX_NAME_LEN];
+			char ligname[MAX_NAME_LEN];
 			IntX glyphId2, ligId;
 			IntX j;
 			IntX origShift, lsb, rsb, width1, width2, tsb, bsb, vwidth, W1, W2;
@@ -1723,7 +1723,7 @@ static void dumpLigature1(LigatureSubstFormat1 *fmt, IntX level)
 	  	ttoEnumerateCoverage(fmt->Coverage, fmt->_Coverage, &CovList, (Card32*)&nitems);
 		for (i = 0; i < (Int32)nitems; i++) 
 		{
-		  char name[40];
+		  char name[MAX_NAME_LEN];
 		  IntX j;
 		  LigatureSet *ligatureSet = &fmt->_LigatureSet[i];
 		  GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
@@ -1908,7 +1908,7 @@ static void dumpContext1(ContextSubstFormat1 *fmt, IntX level)
 		
 		for (i = 0; i < (IntX)nitems; i++)
 		  {
-			char name1[40];
+			char name1[MAX_NAME_LEN];
 			IntX srscnt;
 			IntX origShift, lsb, rsb, width1, tsb, bsb, vwidth, yorig;
 			GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
@@ -1939,7 +1939,7 @@ static void dumpContext1(ContextSubstFormat1 *fmt, IntX level)
 	  	ttoEnumerateCoverage(fmt->Coverage, fmt->_Coverage, &CovList, &nitems);
 		for (i = 0; i < nitems; i++) 
 		{
-		  	char name[40];
+		  	char name[MAX_NAME_LEN];
 		  	SubRuleSet *subruleset = &fmt->_SubRuleSet[i];
 		  	GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
 
@@ -2099,7 +2099,7 @@ static void showContext2(ContextSubstFormat2 *fmt, IntX level, void *feattag)
 					CR = &(classList[classId]);
 					for (c = 0; c < CR->glyphidlist.cnt; c++)
 					  {
-						char name2[64];
+						char name2[MAX_NAME_LEN];
 						GlyphId glyphId2 = *da_INDEX(CR->glyphidlist, c);
 						strcpy(name2, getGlyphName(glyphId2, forProofing));
 						psIndex = strlen(proofString);
@@ -2122,7 +2122,7 @@ static void showContext2(ContextSubstFormat2 *fmt, IntX level, void *feattag)
 						sprintf(&proofString[psIndex],"[");
 						for (c = 0; c < CR->glyphidlist.cnt; c++)
 						  {
-							char name2[64];
+							char name2[MAX_NAME_LEN];
 							GlyphId glyphId2 = *da_INDEX(CR->glyphidlist, c);
 							strcpy(name2, getGlyphName(glyphId2, forProofing));
 							psIndex = strlen(proofString);
@@ -2192,7 +2192,7 @@ static void proofContext2(ContextSubstFormat2 *fmt)
 		ttoEnumerateCoverage(fmt->Coverage, fmt->_Coverage, &CovList, &nitems);
 		for (i = 0; i < nitems; i++)
 		  {
-			char name1[40];
+			char name1[MAX_NAME_LEN];
 			IntX scscnt;
 			GlyphId glyphId = *da_INDEX(CovList.glyphidlist, i);
 			strcpy(name1, getGlyphName(glyphId, 1));
@@ -2240,7 +2240,7 @@ static void proofContext2(ContextSubstFormat2 *fmt)
 						CR = &(classList[classId]);
 						for (c = 0; c < CR->glyphidlist.cnt; c++)
 						  {
-							char name2[40];
+							char name2[MAX_NAME_LEN];
 							GlyphId inputgid[4];
 							GlyphId outputgid[4];
 							IntX inputcount, outputcount, o;
@@ -2297,7 +2297,7 @@ static void proofContext2(ContextSubstFormat2 *fmt)
 							for (o = 0; o < outputcount; o++)
 							  {
 								IntX owid, OW;
-								char oname[40];
+								char oname[MAX_NAME_LEN];
 								GlyphId ogid = outputgid[o];
 								strcpy(oname, getGlyphName(ogid, 1));
 								getMetrics(ogid, &origShift, &lsb, &rsb, &owid, &tsb, &bsb, &vwidth, &yorig3);
@@ -3012,7 +3012,7 @@ static void proofChainContext3(ChainContextSubstFormat3 *fmt)
 			Card32 nitems;
 			IntX j = fmt->BacktrackGlyphCount - (i+1); /* Backtack is enumerated in reverse order from the offset order */
 			GlyphId gId;
-			char name[40];
+			char name[MAX_NAME_LEN];
 			ttoEnumRec *ter = da_INDEX(BacktrackGlyphCovListArray, i);
 			ttoEnumerateCoverage(fmt->Backtrack[j], fmt->_Backtrack[j], ter, &nitems);
 			if (nitems > 1)
@@ -3061,7 +3061,7 @@ static void proofChainContext3(ChainContextSubstFormat3 *fmt)
 			Card32 nitems;
 			IntX j;
 			GlyphId gId;
-			char name[40];
+			char name[MAX_NAME_LEN];
 			ttoEnumRec *ter = da_INDEX(InputGlyphCovListArray, i);
 			ttoEnumerateCoverage(fmt->Input[i], fmt->_Input[i], ter, &nitems);
 			if (nitems > 1)
@@ -3115,7 +3115,7 @@ static void proofChainContext3(ChainContextSubstFormat3 *fmt)
 			Card32 nitems;
 			IntX j;
 			GlyphId gId;
-			char name[40];
+			char name[MAX_NAME_LEN];
 			ttoEnumRec *ter = da_INDEX(LookaheadGlyphCovListArray, i);
 			ttoEnumerateCoverage(fmt->Lookahead[i], fmt->_Lookahead[i], ter, &nitems);
 			if (nitems > 1)
@@ -3188,7 +3188,7 @@ static void proofChainContext3(ChainContextSubstFormat3 *fmt)
 			Card32 nitems;
 			IntX j = fmt->BacktrackGlyphCount - (i+1); /* Backtrack is enumerated in the feaure syntax in reverse order form the offset order. */
 			GlyphId gId;
-			char name[40];
+			char name[MAX_NAME_LEN];
 			ttoEnumRec *ter = da_INDEX(BacktrackGlyphCovListArray, i);
 			ttoEnumerateCoverage(fmt->Backtrack[j], fmt->_Backtrack[j], ter, &nitems);
 			if (nitems > 1)
@@ -3268,7 +3268,7 @@ static void proofChainContext3(ChainContextSubstFormat3 *fmt)
 				for (o = 0; o < outputcount; o++)
 				  {
 					IntX owid, OW;
-					char oname[40];
+					char oname[MAX_NAME_LEN];
 					GlyphId ogid = outputgid[o];
 					strcpy(oname, getGlyphName(ogid, 1));
 					getMetrics(ogid, &origShift, &lsb, &rsb, &owid, &tsb, &bsb, &vwidth, &yorig);
@@ -3367,7 +3367,7 @@ static void proofChainContext3(ChainContextSubstFormat3 *fmt)
 			  	for (o = 0; o < outputcount; o++)
 					{
 					  IntX owid, OW;
-					  char oname[40];
+					  char oname[MAX_NAME_LEN];
 					  GlyphId ogid = outputgid[o];
 					  strcpy(oname, getGlyphName(ogid, 1));
 					  getMetrics(ogid, &origShift, &lsb, &rsb, &owid, &tsb, &bsb, &vwidth, &yorig);
@@ -3414,7 +3414,7 @@ static void proofChainContext3(ChainContextSubstFormat3 *fmt)
 			Card32 nitems;
 			IntX j;
 			GlyphId gId;
-			char name[40];
+			char name[MAX_NAME_LEN];
 			ttoEnumRec *ter = da_INDEX(LookaheadGlyphCovListArray, i);
 			ttoEnumerateCoverage(fmt->Lookahead[i], fmt->_Lookahead[i], ter, &nitems);
 			if (nitems > 1)
@@ -3723,7 +3723,7 @@ static void proofReverseChainContext1(ReverseChainContextSubstFormat1 *fmt)
 			Card32 nitems;
 			IntX j = fmt->BacktrackGlyphCount - (i+1); /* Backtrack is enumerated in the feaure syntax in reverse order form the offset order. */
 			GlyphId gId;
-			char name[40];
+			char name[MAX_NAME_LEN];
 			ttoEnumRec *ter = da_INDEX(BacktrackGlyphCovListArray, i);
 			ttoEnumerateCoverage(fmt->Backtrack[j], fmt->_Backtrack[j], ter, &nitems);
 			if (nitems > 1)
@@ -3771,7 +3771,7 @@ static void proofReverseChainContext1(ReverseChainContextSubstFormat1 *fmt)
 			Card32 nitems;
 			IntX j;
 			GlyphId gId;
-			char name[40];
+			char name[MAX_NAME_LEN];
 			ttoEnumRec *ter = &InputGlyphCovList;
 			ttoEnumerateCoverage(fmt->InputCoverage, fmt->_InputCoverage, ter, &nitems);
 			if (nitems > 1)
@@ -3825,7 +3825,7 @@ static void proofReverseChainContext1(ReverseChainContextSubstFormat1 *fmt)
 			Card32 nitems;
 			IntX j;
 			GlyphId gId;
-			char name[40];
+			char name[MAX_NAME_LEN];
 			ttoEnumRec *ter = da_INDEX(LookaheadGlyphCovListArray, i);
 			ttoEnumerateCoverage(fmt->Lookahead[i], fmt->_Lookahead[i], ter, &nitems);
 			if (nitems > 1)
@@ -3883,7 +3883,7 @@ static void proofReverseChainContext1(ReverseChainContextSubstFormat1 *fmt)
 			{
 			GlyphId	gId = fmt->Substitutions[i];
 			IntX owid, OW;
-			char oname[40];
+			char oname[MAX_NAME_LEN];
 			strcpy(oname, getGlyphName(gId, 1));
 			getMetrics(gId, &origShift, &lsb, &rsb, &owid, &tsb, &bsb, &vwidth, &yorig);
 			if (isVert)

--- a/afdko/Tools/Programs/spot/source/SING.c
+++ b/afdko/Tools/Programs/spot/source/SING.c
@@ -77,7 +77,7 @@ IntX SINGGetUnitsPerEm(Card16 *unitsPerEm, Card32 client)
 void SINGDump(IntX level, LongN start)
 	{
 	IntX i;
-	char nam[64];
+	char nam[MAX_NAME_LEN];
 	DL(1, (OUTPUTBUFF, "### [SING] (%08lx)\n", start));
 
 	DLu(2, "tableVersionMajor =", SING->tableVersionMajor);

--- a/afdko/Tools/Programs/spot/source/cmap.c
+++ b/afdko/Tools/Programs/spot/source/cmap.c
@@ -658,7 +658,7 @@ static void dumpMapping(IntX level)
 			break;
 		case 9: case 10:
 			{
-			Byte8 title[64];
+			Byte8 title[MAX_NAME_LEN];
 			Card16 platformId = encoding->platformId;
 			Card16 scriptId = encoding->scriptId;
 			Card16 languageId = ((FormatHdr *)encoding->format)->languageId;

--- a/afdko/Tools/Programs/spot/source/global.c
+++ b/afdko/Tools/Programs/spot/source/global.c
@@ -324,7 +324,6 @@ void initGlyphNames(void)
    pointer to SINGLE static buffer so subsequent calls will overwrite. */
 Byte8 *getGlyphName(GlyphId glyphId, IntX forProofing)
 	{
-#define NAME_LEN 128
 	static Byte8 name[NAME_LEN + 1];
 	static Byte8 nicename[NAME_LEN + 7]; /* allow an extra 6 chars for GID. */
 	Byte8 *p;

--- a/afdko/Tools/Programs/spot/source/global.h
+++ b/afdko/Tools/Programs/spot/source/global.h
@@ -113,6 +113,8 @@ extern IntX parseIdList(Byte8 *list, IdList *ids);
 extern IntX getNGlyphs(Card16 *nGlyphs, Card32 client);
 extern void quit(IntN status);
 extern void initGlyphNames(void);
+#define NAME_LEN 128 /*  base glyph name length returned by getGlyphName */
+#define MAX_NAME_LEN  NAME_LEN+7 /* max glyph name langth returned by getGlyphName */
 extern Byte8 *getGlyphName(GlyphId glyphId, IntX forProofing);
 extern void dumpAllGlyphNames(IntN docrlfs);
 extern void getMetrics(GlyphId glyphId, 

--- a/afdko/Tools/Programs/spot/source/global.h
+++ b/afdko/Tools/Programs/spot/source/global.h
@@ -114,7 +114,7 @@ extern IntX getNGlyphs(Card16 *nGlyphs, Card32 client);
 extern void quit(IntN status);
 extern void initGlyphNames(void);
 #define NAME_LEN 128 /*  base glyph name length returned by getGlyphName */
-#define MAX_NAME_LEN  NAME_LEN+7 /* max glyph name langth returned by getGlyphName */
+#define MAX_NAME_LEN  NAME_LEN+7 /* max glyph name length returned by getGlyphName */
 extern Byte8 *getGlyphName(GlyphId glyphId, IntX forProofing);
 extern void dumpAllGlyphNames(IntN docrlfs);
 extern void getMetrics(GlyphId glyphId, 

--- a/afdko/Tools/Programs/spot/source/map.c
+++ b/afdko/Tools/Programs/spot/source/map.c
@@ -53,7 +53,7 @@ void InitAliasFromFile(void)
 			return;
 		}
 	while(1){
-		char temp1[32], temp2[32], c;
+		char temp1[MAX_NAME_LEN], temp2[MAX_NAME_LEN], c;
 		value = fscanf(file, "%s %s", temp1, temp2);
 		if (value==EOF || value == 0)
 			break;

--- a/afdko/Tools/Programs/spot/source/opt.c
+++ b/afdko/Tools/Programs/spot/source/opt.c
@@ -285,7 +285,7 @@ int opt_##n(int argc, char *argv[], int argi, opt_Option *opt) \
 	else \
 		{ \
 		t value; \
-		char s[128]; \
+		char s[64]; \
 		strncpy(s, argv[argi], 63); \
 		s[63] = '\0'; \
 		if (sscanf(s, f, &value) != 1) \

--- a/afdko/Tools/Programs/spot/source/opt.c
+++ b/afdko/Tools/Programs/spot/source/opt.c
@@ -285,7 +285,7 @@ int opt_##n(int argc, char *argv[], int argi, opt_Option *opt) \
 	else \
 		{ \
 		t value; \
-		char s[64]; \
+		char s[128]; \
 		strncpy(s, argv[argi], 63); \
 		s[63] = '\0'; \
 		if (sscanf(s, f, &value) != 1) \

--- a/afdko/Tools/Programs/spot/source/proof.c
+++ b/afdko/Tools/Programs/spot/source/proof.c
@@ -1144,7 +1144,7 @@ ProofContextPtr proofInitContext(proofOutputType where,
 		{
 			if (isPatt) 
 			{
-				char tempname[64];
+				char tempname[MAX_NAME_LEN];
 				if(outputfilebase)
 					sprintf(tempname,"%s_%s.ps", outputfilebase, PSFilenameorPATTorNULL);
 				else
@@ -1176,7 +1176,7 @@ ProofContextPtr proofInitContext(proofOutputType where,
 		}
 		else 
 		{
-			char tempname[64];
+			char tempname[MAX_NAME_LEN];
 			if(outputfilebase)
 				sprintf(tempname, "%s.ps", outputfilebase);
 			else
@@ -1213,7 +1213,7 @@ ProofContextPtr proofInitContext(proofOutputType where,
 			 {
 			 if (isPatt) 
 			   {
-				 char tempname[64];
+				 char tempname[MAX_NAME_LEN];
 				 sprintf(tempname,"/tmp/%s_%s_XXXXXX", global.progname, PSFilenameorPATTorNULL);
 				 mktemp(tempname);
 				 len = strlen(tempname);
@@ -1235,7 +1235,7 @@ ProofContextPtr proofInitContext(proofOutputType where,
 		   }
 		   else 
 			 {
-			 char tempname[64];
+			 char tempname[MAX_NAME_LEN];
 			 sprintf(tempname,"/tmp/%s.ps_XXXXXX", global.progname);
 			 mktemp(tempname);
 			 len = strlen(tempname);


### PR DESCRIPTION
With the 64-bit update, the function global.c::getGlyphName() can return a glyph name of up to 128+7 characters long. The returned string was, in many places, copied into a string buffer that was much shorter. Fixes issue 373.