### PR TITLE
Build Script Update.  Fix all the BuildAll.cmd and *.sh files

### DIFF
--- a/afdko/Tools/Programs/BuildAll.cmd
+++ b/afdko/Tools/Programs/BuildAll.cmd
@@ -1,3 +1,13 @@
+set do_target=0
+if "%1"=="" set do_target=1
+if "%1"=="release" set do_target=1
+if "%1"=="debug" set do_target=1
+if "%1"=="clean" set do_target=1
+if %do_target%==0 (
+	echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
+	exit /B
+)
+
 echo " "
 echo "Building autohint..."
 call %~dp0autohint\build\win\vc10\BuildAll.cmd %1 || EXIT /B 1

--- a/afdko/Tools/Programs/BuildAll.sh
+++ b/afdko/Tools/Programs/BuildAll.sh
@@ -1,23 +1,29 @@
 # How to find and add all the xcode files for a new program:
-# find .   \( -path "*/xcode4/*" \)  -and \( \(  -name BuildAll.sh \) -or \( -name project.pbxproj \) -or \( -name contents.xcworkspacedata  \) \)  -exec p4 add {} \;curDir=`pwd`
+# find .   \( -path "*/xcode4/*" \)	 -and \( \(	 -name BuildAll.sh \) -or \( -name project.pbxproj \) -or \( -name contents.xcworkspacedata	 \) \)	-exec p4 add {} \;curDir=`pwd`
 
 set -e
 set -x
 
 curDir=`pwd`
 
-buildAllList=`ls -1 */build/osx/xcode4/BuildAll.sh`
-for shFile in $buildAllList
-do
-	echo "***Running $shFile"
-	newDir=`dirname $shFile`
-	shFile=`basename $shFile`
-	cd $newDir
-	sh  $shFile $1
-	failed=$?
-	cd $curDir
-	if [ "$failed" -ne 0 ]; then
-		exit "$failed"
-	fi
-done
-echo "Done"
+if [ -z "$1" ] || [ "$1" == "release" ] || [ "$1" == "debug" ] || [ "$1" == "clean" ]
+then
+	buildAllList=`ls -1 */build/osx/xcode4/BuildAll.sh`
+	for shFile in $buildAllList
+	do
+		echo "***Running $shFile"
+		newDir=`dirname $shFile`
+		shFile=`basename $shFile`
+		cd $newDir
+		sh	$shFile $1
+		failed=$?
+		cd $curDir
+		if [ "$failed" -ne 0 ]; then
+			exit "$failed"
+		fi
+	done
+	echo "Done"
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
+fi
+

--- a/afdko/Tools/Programs/BuildAllLinux.sh
+++ b/afdko/Tools/Programs/BuildAllLinux.sh
@@ -6,18 +6,23 @@ set -x
 
 curDir=`pwd`
 
-buildAllList=`ls -1 */build/linux/gcc/BuildAll.sh`
-for shFile in $buildAllList
-do
-	echo "***Running $shFile"
-	newDir=`dirname $shFile`
-	shFile=`basename $shFile`
-	cd $newDir
-	sh  $shFile $1
-	failed=$?
-	cd $curDir
-	if [ "$failed" -ne 0 ]; then
-		exit "$failed"
-	fi
-done
-echo "Done"
+if [ -z "$1" ] || [ "$1" = "release" ] || [ "$1" = "debug" ] || [ "$1" = "clean" ]
+then
+	buildAllList=`ls -1 */build/linux/gcc/BuildAll.sh`
+	for shFile in $buildAllList
+	do
+		echo "***Running $shFile"
+		newDir=`dirname $shFile`
+		shFile=`basename $shFile`
+		cd $newDir
+		sh	$shFile $1
+		failed=$?
+		cd $curDir
+		if [ "$failed" -ne 0 ]; then
+			exit "$failed"
+		fi
+	done
+	echo "Done"
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
+fi

--- a/afdko/Tools/Programs/autohint/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/autohint/build/linux/gcc/BuildAll.sh
@@ -5,19 +5,25 @@ set -x
 target=autohintexe
 curdir=`pwd`
 
-cd debug
-make $1
-cd $curdir
-
-cd release
-make $1
-cd $curdir
-
-if [ -z "$1" ]
+if [ -z "$1" ] || [ $1 = "release" ]
 then
-	if [ $OSX ]; then
-		cp -R ../../../exe/linux/release/$target ../../../../../linux/
-	else
-		cp -dR ../../../exe/linux/release/$target ../../../../../linux/
-	fi
+	cd release
+	make
+	cd $curdir
+	cp -dR ../../../exe/linux/release/$target ../../../../../linux/
+elif [ $1 = "debug" ]
+then
+	cd debug
+	make
+	cd $curdir
+elif [ $1 = "clean" ]
+then
+	cd release
+	make $1
+	cd $curdir
+	cd debug
+	make $1
+	cd $curdir
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/autohint/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/autohint/build/osx/xcode4/BuildAll.sh
@@ -3,10 +3,18 @@ set -e
 set -x
 
 target=autohintexe
-xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1
-xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release $1
 
-if [ -z "$1" ]
+if [ -z "$1" ] || [ "$1" == "release" ]
 then
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../../osx/
+elif [ "$1" == "debug" ]
+then
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug
+elif [ "$1" == "clean" ]
+then
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release $1
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/autohint/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/autohint/build/win/vc10/BuildAll.cmd
@@ -1,6 +1,6 @@
 cd %~dp0
+setlocal enabledelayedexpansion
 set targetProgram=autohint
-set buildConfig=Build
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
 
 set do_release=0
@@ -11,20 +11,22 @@ if "%1"=="" set do_release=1
 if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	set buildConfig=Build
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%exe.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	set buildConfig=Build
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )
 
 if "%1"=="clean" (
 	set buildConfig=Clean
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	set do_target=1
 )
 if %do_target%==0 (

--- a/afdko/Tools/Programs/autohint/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/autohint/build/win/vc10/BuildAll.cmd
@@ -10,14 +10,14 @@ if "%1"=="" set do_release=1
 if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%exe.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )

--- a/afdko/Tools/Programs/autohint/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/autohint/build/win/vc10/BuildAll.cmd
@@ -1,5 +1,6 @@
 cd %~dp0
 set targetProgram=autohint
+set buildConfig=Build
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
 
 set do_release=0
@@ -10,14 +11,12 @@ if "%1"=="" set do_release=1
 if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
-	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%exe.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
-	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )

--- a/afdko/Tools/Programs/autohint/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/autohint/build/win/vc10/BuildAll.cmd
@@ -1,11 +1,33 @@
 cd %~dp0
-set buildConfig=Clean
 set targetProgram=autohint
-
-if "%1"=="" set buildConfig="Build"
-
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
-%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 
-if "%1"=="" copy /Y ..\..\..\exe\win\release\%targetProgram%exe.exe ..\..\..\..\..\win\
+set do_release=0
+set do_target=0
+
+if "%1"=="" set do_release=1
+
+if "%1"=="release" set do_release=1
+
+if %do_release%==1 (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	copy /Y ..\..\..\exe\win\release\%targetProgram%exe.exe ..\..\..\..\..\win\
+	set do_target=1
+)
+
+if "%1"=="debug" (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	set do_target=1
+)
+
+if "%1"=="clean" (
+	set buildConfig=Clean
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	set do_target=1
+)
+if %do_target%==0 (
+	echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')" 
+)

--- a/afdko/Tools/Programs/detype1/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/detype1/build/linux/gcc/BuildAll.sh
@@ -5,19 +5,25 @@ set -x
 target=detype1
 curdir=`pwd`
 
-cd debug
-make $1
-cd $curdir
-
-cd release
-make $1
-cd $curdir
-
-if [ -z "$1" ]
+if [ -z "$1" ] || [ $1 = "release" ]
 then
-	if [ $OSX ]; then
-		cp -R ../../../exe/linux/release/$target ../../../../../linux/
-	else
-		cp -dR ../../../exe/linux/release/$target ../../../../../linux/
-	fi
+	cd release
+	make
+	cd $curdir
+	cp -dR ../../../exe/linux/release/$target ../../../../../linux/
+elif [ $1 = "debug" ]
+then
+	cd debug
+	make
+	cd $curdir
+elif [ $1 = "clean" ]
+then
+	cd release
+	make $1
+	cd $curdir
+	cd debug
+	make $1
+	cd $curdir
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/detype1/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/detype1/build/osx/xcode4/BuildAll.sh
@@ -3,10 +3,18 @@ set -e
 set -x
 
 target=detype1
-xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1
-xcodebuild -target $target -project $target.xcodeproj -configuration Release $1
 
-if [ -z "$1" ]
+if [ -z "$1" ] || [ "$1" == "release" ]
 then
+	xcodebuild -target $target -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../../osx/
+elif [ "$1" == "debug" ]
+then
+	xcodebuild -target $target -project $target.xcodeproj -configuration Debug
+elif [ "$1" == "clean" ]
+then
+	xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1
+	xcodebuild -target $target -project $target.xcodeproj -configuration Release $1
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/detype1/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/detype1/build/win/vc10/BuildAll.cmd
@@ -10,14 +10,14 @@ if "%1"=="" set do_release=1
 if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )

--- a/afdko/Tools/Programs/detype1/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/detype1/build/win/vc10/BuildAll.cmd
@@ -1,11 +1,33 @@
 cd %~dp0
-set buildConfig=Clean
 set targetProgram=detype1
-
-if "%1"=="" set buildConfig="Build"
-
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
-%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 
-if "%1"=="" copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
+set do_release=0
+set do_target=0
+
+if "%1"=="" set do_release=1
+
+if "%1"=="release" set do_release=1
+
+if %do_release%==1 (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
+	set do_target=1
+)
+
+if "%1"=="debug" (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	set do_target=1
+)
+
+if "%1"=="clean" (
+	set buildConfig=Clean
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	set do_target=1
+)
+if %do_target%==0 (
+	echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')" 
+)

--- a/afdko/Tools/Programs/detype1/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/detype1/build/win/vc10/BuildAll.cmd
@@ -1,4 +1,5 @@
 cd %~dp0
+setlocal enabledelayedexpansion
 set targetProgram=detype1
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
 
@@ -11,21 +12,21 @@ if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )
 
 if "%1"=="clean" (
 	set buildConfig=Clean
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	set do_target=1
 )
 if %do_target%==0 (

--- a/afdko/Tools/Programs/makeotf/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/makeotf/build/linux/gcc/BuildAll.sh
@@ -5,19 +5,25 @@ set -x
 target=makeotfexe
 curdir=`pwd`
 
-cd debug
-make $1
-cd $curdir
-
-cd release
-make $1
-cd $curdir
-
-if [ -z "$1" ]
+if [ -z "$1" ] || [ $1 = "release" ]
 then
-	if [ $OSX ]; then
-		cp -R ../../../exe/linux/release/$target ../../../../../linux/
-	else
-		cp -dR ../../../exe/linux/release/$target ../../../../../linux/
-	fi
+	cd release
+	make
+	cd $curdir
+	cp -dR ../../../exe/linux/release/$target ../../../../../linux/
+elif [ $1 = "debug" ]
+then
+	cd debug
+	make
+	cd $curdir
+elif [ $1 = "clean" ]
+then
+	cd release
+	make $1
+	cd $curdir
+	cd debug
+	make $1
+	cd $curdir
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/makeotf/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/makeotf/build/osx/xcode4/BuildAll.sh
@@ -3,10 +3,18 @@ set -e
 set -x
 
 target=makeotf
-xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1
-xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release $1
 
-if [ -z "$1" ]
+if [ -z "$1" ] || [ "$1" == "release" ]
 then
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/${target}exe ../../../../../osx/
+elif [ "$1" == "debug" ]
+then
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug
+elif [ "$1" == "clean" ]
+then
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release $1
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/makeotf/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/makeotf/build/win/vc10/BuildAll.cmd
@@ -1,5 +1,6 @@
 echo ON
 cd %~dp0
+setlocal enabledelayedexpansion
 set targetProgram=makeotf
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
 
@@ -12,21 +13,21 @@ if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%exe.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )
 
 if "%1"=="clean" (
 	set buildConfig=Clean
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	set do_target=1
 )
 if %do_target%==0 (

--- a/afdko/Tools/Programs/makeotf/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/makeotf/build/win/vc10/BuildAll.cmd
@@ -1,11 +1,34 @@
+echo ON
 cd %~dp0
-set buildConfig=Clean
 set targetProgram=makeotf
-
-if "%1"=="" set buildConfig="Build"
-
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
-%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 
-if "%1"=="" copy /Y ..\..\..\exe\win\release\%targetProgram%exe.exe ..\..\..\..\..\win\
+set do_release=0
+set do_target=0
+
+if "%1"=="" set do_release=1
+
+if "%1"=="release" set do_release=1
+
+if %do_release%==1 (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	copy /Y ..\..\..\exe\win\release\%targetProgram%exe.exe ..\..\..\..\..\win\
+	set do_target=1
+)
+
+if "%1"=="debug" (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	set do_target=1
+)
+
+if "%1"=="clean" (
+	set buildConfig=Clean
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	set do_target=1
+)
+if %do_target%==0 (
+	echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')" 
+)

--- a/afdko/Tools/Programs/makeotf/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/makeotf/build/win/vc10/BuildAll.cmd
@@ -11,14 +11,14 @@ if "%1"=="" set do_release=1
 if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%exe.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )

--- a/afdko/Tools/Programs/mergeFonts/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/mergeFonts/build/linux/gcc/BuildAll.sh
@@ -5,19 +5,25 @@ set -x
 target=mergeFonts
 curdir=`pwd`
 
-cd debug
-make $1
-cd $curdir
-
-cd release
-make $1
-cd $curdir
-
-if [ -z "$1" ]
+if [ -z "$1" ] || [ $1 = "release" ]
 then
-	if [ $OSX ]; then
-		cp -R ../../../exe/linux/release/$target ../../../../../linux/
-	else
-		cp -dR ../../../exe/linux/release/$target ../../../../../linux/
-	fi
+	cd release
+	make
+	cd $curdir
+	cp -dR ../../../exe/linux/release/$target ../../../../../linux/
+elif [ $1 = "debug" ]
+then
+	cd debug
+	make
+	cd $curdir
+elif [ $1 = "clean" ]
+then
+	cd release
+	make $1
+	cd $curdir
+	cd debug
+	make $1
+	cd $curdir
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/mergeFonts/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/mergeFonts/build/osx/xcode4/BuildAll.sh
@@ -3,10 +3,18 @@ set -e
 set -x
 
 target=mergeFonts
-xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1
-xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release $1
 
-if [ -z "$1" ]
+if [ -z "$1" ] || [ "$1" == "release" ]
 then
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../../osx/
+elif [ "$1" == "debug" ]
+then
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug
+elif [ "$1" == "clean" ]
+then
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release $1
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/mergeFonts/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/mergeFonts/build/win/vc10/BuildAll.cmd
@@ -1,11 +1,33 @@
 cd %~dp0
-set buildConfig=Clean
 set targetProgram=mergeFonts
-
-if "%1"=="" set buildConfig="Build"
-
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
-%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 
-if "%1"=="" copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
+set do_release=0
+set do_target=0
+
+if "%1"=="" set do_release=1
+
+if "%1"=="release" set do_release=1
+
+if %do_release%==1 (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
+	set do_target=1
+)
+
+if "%1"=="debug" (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	set do_target=1
+)
+
+if "%1"=="clean" (
+	set buildConfig=Clean
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	set do_target=1
+)
+if %do_target%==0 (
+	echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')" 
+)

--- a/afdko/Tools/Programs/mergeFonts/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/mergeFonts/build/win/vc10/BuildAll.cmd
@@ -10,14 +10,14 @@ if "%1"=="" set do_release=1
 if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )

--- a/afdko/Tools/Programs/mergeFonts/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/mergeFonts/build/win/vc10/BuildAll.cmd
@@ -1,4 +1,5 @@
 cd %~dp0
+setlocal enabledelayedexpansion
 set targetProgram=mergeFonts
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
 
@@ -11,21 +12,21 @@ if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )
 
 if "%1"=="clean" (
 	set buildConfig=Clean
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	set do_target=1
 )
 if %do_target%==0 (

--- a/afdko/Tools/Programs/rotateFont/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/rotateFont/build/linux/gcc/BuildAll.sh
@@ -5,19 +5,25 @@ set -x
 target=rotateFont
 curdir=`pwd`
 
-cd debug
-make $1
-cd $curdir
-
-cd release
-make $1
-cd $curdir
-
-if [ -z "$1" ]
+if [ -z "$1" ] || [ $1 = "release" ]
 then
-	if [ $OSX ]; then
-		cp -R ../../../exe/linux/release/$target ../../../../../linux/
-	else
-		cp -dR ../../../exe/linux/release/$target ../../../../../linux/
-	fi
+	cd release
+	make
+	cd $curdir
+	cp -dR ../../../exe/linux/release/$target ../../../../../linux/
+elif [ $1 = "debug" ]
+then
+	cd debug
+	make
+	cd $curdir
+elif [ $1 = "clean" ]
+then
+	cd release
+	make $1
+	cd $curdir
+	cd debug
+	make $1
+	cd $curdir
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/rotateFont/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/rotateFont/build/osx/xcode4/BuildAll.sh
@@ -3,10 +3,18 @@ set -e
 set -x
 
 target=rotateFont
-xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1
-xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release $1
 
-if [ -z "$1" ]
+if [ -z "$1" ] || [ "$1" == "release" ]
 then
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../../osx/
+elif [ "$1" == "debug" ]
+then
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug
+elif [ "$1" == "clean" ]
+then
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release $1
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/rotateFont/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/rotateFont/build/win/vc10/BuildAll.cmd
@@ -1,11 +1,33 @@
 cd %~dp0
-set buildConfig=Clean
 set targetProgram=rotateFont
-
-if "%1"=="" set buildConfig="Build"
-
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
-%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 
-if "%1"=="" copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
+set do_release=0
+set do_target=0
+
+if "%1"=="" set do_release=1
+
+if "%1"=="release" set do_release=1
+
+if %do_release%==1 (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
+	set do_target=1
+)
+
+if "%1"=="debug" (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	set do_target=1
+)
+
+if "%1"=="clean" (
+	set buildConfig=Clean
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	set do_target=1
+)
+if %do_target%==0 (
+	echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')" 
+)

--- a/afdko/Tools/Programs/rotateFont/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/rotateFont/build/win/vc10/BuildAll.cmd
@@ -1,4 +1,5 @@
 cd %~dp0
+setlocal enabledelayedexpansion
 set targetProgram=rotateFont
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
 
@@ -11,21 +12,21 @@ if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )
 
 if "%1"=="clean" (
 	set buildConfig=Clean
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	set do_target=1
 )
 if %do_target%==0 (

--- a/afdko/Tools/Programs/rotateFont/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/rotateFont/build/win/vc10/BuildAll.cmd
@@ -10,14 +10,14 @@ if "%1"=="" set do_release=1
 if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )

--- a/afdko/Tools/Programs/sfntdiff/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/sfntdiff/build/linux/gcc/BuildAll.sh
@@ -5,19 +5,25 @@ set -x
 target=sfntdiff
 curdir=`pwd`
 
-cd debug
-make $1
-cd $curdir
-
-cd release
-make $1
-cd $curdir
-
-if [ -z "$1" ]
+if [ -z "$1" ] || [ $1 = "release" ]
 then
-	if [ $OSX ]; then
-		cp -R ../../../exe/linux/release/$target ../../../../../linux/
-	else
-		cp -dR ../../../exe/linux/release/$target ../../../../../linux/
-	fi
+	cd release
+	make
+	cd $curdir
+	cp -dR ../../../exe/linux/release/$target ../../../../../linux/
+elif [ $1 = "debug" ]
+then
+	cd debug
+	make
+	cd $curdir
+elif [ $1 = "clean" ]
+then
+	cd release
+	make $1
+	cd $curdir
+	cd debug
+	make $1
+	cd $curdir
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/sfntdiff/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/sfntdiff/build/osx/xcode4/BuildAll.sh
@@ -3,10 +3,18 @@ set -e
 set -x
 
 target=sfntdiff
-xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1
-xcodebuild -target $target -project $target.xcodeproj -configuration Release $1
 
-if [ -z "$1" ]
+if [ -z "$1" ] || [ "$1" == "release" ]
 then
+	xcodebuild -target $target -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../../osx/
+elif [ "$1" == "debug" ]
+then
+	xcodebuild -target $target -project $target.xcodeproj -configuration Debug
+elif [ "$1" == "clean" ]
+then
+	xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1
+	xcodebuild -target $target -project $target.xcodeproj -configuration Release $1
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/sfntdiff/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/sfntdiff/build/win/vc10/BuildAll.cmd
@@ -10,14 +10,14 @@ if "%1"=="" set do_release=1
 if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )

--- a/afdko/Tools/Programs/sfntdiff/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/sfntdiff/build/win/vc10/BuildAll.cmd
@@ -1,11 +1,33 @@
 cd %~dp0
-set buildConfig=Clean
 set targetProgram=sfntdiff
-
-if "%1"=="" set buildConfig="Build"
-
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
-%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 
-if "%1"=="" copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
+set do_release=0
+set do_target=0
+
+if "%1"=="" set do_release=1
+
+if "%1"=="release" set do_release=1
+
+if %do_release%==1 (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
+	set do_target=1
+)
+
+if "%1"=="debug" (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	set do_target=1
+)
+
+if "%1"=="clean" (
+	set buildConfig=Clean
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	set do_target=1
+)
+if %do_target%==0 (
+	echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')" 
+)

--- a/afdko/Tools/Programs/sfntdiff/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/sfntdiff/build/win/vc10/BuildAll.cmd
@@ -1,4 +1,5 @@
 cd %~dp0
+setlocal enabledelayedexpansion
 set targetProgram=sfntdiff
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
 
@@ -11,21 +12,21 @@ if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )
 
 if "%1"=="clean" (
 	set buildConfig=Clean
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	set do_target=1
 )
 if %do_target%==0 (

--- a/afdko/Tools/Programs/sfntedit/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/sfntedit/build/linux/gcc/BuildAll.sh
@@ -5,19 +5,25 @@ set -x
 target=sfntedit
 curdir=`pwd`
 
-cd debug
-make $1
-cd $curdir
-
-cd release
-make $1
-cd $curdir
-
-if [ -z "$1" ]
+if [ -z "$1" ] || [ $1 = "release" ]
 then
-	if [ $OSX ]; then
-		cp -R ../../../exe/linux/release/$target ../../../../../linux/
-	else
-		cp -dR ../../../exe/linux/release/$target ../../../../../linux/
-	fi
+	cd release
+	make
+	cd $curdir
+	cp -dR ../../../exe/linux/release/$target ../../../../../linux/
+elif [ $1 = "debug" ]
+then
+	cd debug
+	make
+	cd $curdir
+elif [ $1 = "clean" ]
+then
+	cd release
+	make $1
+	cd $curdir
+	cd debug
+	make $1
+	cd $curdir
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/sfntedit/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/sfntedit/build/osx/xcode4/BuildAll.sh
@@ -3,10 +3,18 @@ set -e
 set -x
 
 target=sfntedit
-xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1
-xcodebuild -target $target -project $target.xcodeproj -configuration Release $1
 
-if [ -z "$1" ]
+if [ -z "$1" ] || [ "$1" == "release" ]
 then
+	xcodebuild -target $target -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../../osx/
+elif [ "$1" == "debug" ]
+then
+	xcodebuild -target $target -project $target.xcodeproj -configuration Debug
+elif [ "$1" == "clean" ]
+then
+	xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1
+	xcodebuild -target $target -project $target.xcodeproj -configuration Release $1
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/sfntedit/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/sfntedit/build/win/vc10/BuildAll.cmd
@@ -10,14 +10,14 @@ if "%1"=="" set do_release=1
 if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )

--- a/afdko/Tools/Programs/sfntedit/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/sfntedit/build/win/vc10/BuildAll.cmd
@@ -1,11 +1,33 @@
 cd %~dp0
-set buildConfig=Clean
 set targetProgram=sfntedit
-
-if "%1"=="" set buildConfig="Build"
-
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
-%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 
-if "%1"=="" copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
+set do_release=0
+set do_target=0
+
+if "%1"=="" set do_release=1
+
+if "%1"=="release" set do_release=1
+
+if %do_release%==1 (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
+	set do_target=1
+)
+
+if "%1"=="debug" (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	set do_target=1
+)
+
+if "%1"=="clean" (
+	set buildConfig=Clean
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	set do_target=1
+)
+if %do_target%==0 (
+	echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')" 
+)

--- a/afdko/Tools/Programs/sfntedit/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/sfntedit/build/win/vc10/BuildAll.cmd
@@ -1,4 +1,5 @@
 cd %~dp0
+setlocal enabledelayedexpansion
 set targetProgram=sfntedit
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
 
@@ -11,21 +12,21 @@ if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )
 
 if "%1"=="clean" (
 	set buildConfig=Clean
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	set do_target=1
 )
 if %do_target%==0 (

--- a/afdko/Tools/Programs/spot/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/spot/build/linux/gcc/BuildAll.sh
@@ -5,19 +5,25 @@ set -x
 target=spot
 curdir=`pwd`
 
-cd debug
-make $1
-cd $curdir
-
-cd release
-make $1
-cd $curdir
-
-if [ -z "$1" ]
+if [ -z "$1" ] || [ $1 = "release" ]
 then
-	if [ $OSX ]; then
-		cp -R ../../../exe/linux/release/$target ../../../../../linux/
-	else
-		cp -dR ../../../exe/linux/release/$target ../../../../../linux/
-	fi
+	cd release
+	make
+	cd $curdir
+	cp -dR ../../../exe/linux/release/$target ../../../../../linux/
+elif [ $1 = "debug" ]
+then
+	cd debug
+	make
+	cd $curdir
+elif [ $1 = "clean" ]
+then
+	cd release
+	make $1
+	cd $curdir
+	cd debug
+	make $1
+	cd $curdir
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/spot/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/spot/build/osx/xcode4/BuildAll.sh
@@ -3,10 +3,18 @@ set -e
 set -x
 
 target=spot
-xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1
-xcodebuild -target $target -project $target.xcodeproj -configuration Release $1
 
-if [ -z "$1" ]
+if [ -z "$1" ] || [ "$1" == "release" ]
 then
+	xcodebuild -target $target -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../../osx/
+elif [ "$1" == "debug" ]
+then
+	xcodebuild -target $target -project $target.xcodeproj -configuration Debug
+elif [ "$1" == "clean" ]
+then
+	xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1
+	xcodebuild -target $target -project $target.xcodeproj -configuration Release $1
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/spot/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/spot/build/win/vc10/BuildAll.cmd
@@ -1,11 +1,33 @@
 cd %~dp0
-set buildConfig=Clean
 set targetProgram=spot
-
-if "%1"=="" set buildConfig="Build"
-
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
-%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 
-if "%1"=="" copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
+set do_release=0
+set do_target=0
+
+if "%1"=="" set do_release=1
+
+if "%1"=="release" set do_release=1
+
+if %do_release%==1 (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
+	set do_target=1
+)
+
+if "%1"=="debug" (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	set do_target=1
+)
+
+if "%1"=="clean" (
+	set buildConfig=Clean
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	set do_target=1
+)
+if %do_target%==0 (
+	echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')" 
+)

--- a/afdko/Tools/Programs/spot/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/spot/build/win/vc10/BuildAll.cmd
@@ -10,14 +10,14 @@ if "%1"=="" set do_release=1
 if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )

--- a/afdko/Tools/Programs/spot/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/spot/build/win/vc10/BuildAll.cmd
@@ -1,4 +1,5 @@
 cd %~dp0
+setlocal enabledelayedexpansion
 set targetProgram=spot
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
 
@@ -11,21 +12,21 @@ if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )
 
 if "%1"=="clean" (
 	set buildConfig=Clean
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	set do_target=1
 )
 if %do_target%==0 (

--- a/afdko/Tools/Programs/tx/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/tx/build/linux/gcc/BuildAll.sh
@@ -5,19 +5,25 @@ set -x
 target=tx
 curdir=`pwd`
 
-cd debug
-make $1
-cd $curdir
-
-cd release
-make $1
-cd $curdir
-
-if [ -z "$1" ]
+if [ -z "$1" ] || [ $1 = "release" ]
 then
-	if [ $OSX ]; then
-		cp -R ../../../exe/linux/release/$target ../../../../../linux/
-	else
-		cp -dR ../../../exe/linux/release/$target ../../../../../linux/
-	fi
+	cd release
+	make
+	cd $curdir
+	cp -dR ../../../exe/linux/release/$target ../../../../../linux/
+elif [ $1 = "debug" ]
+then
+	cd debug
+	make
+	cd $curdir
+elif [ $1 = "clean" ]
+then
+	cd release
+	make $1
+	cd $curdir
+	cd debug
+	make $1
+	cd $curdir
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/tx/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/tx/build/osx/xcode4/BuildAll.sh
@@ -3,11 +3,19 @@ set -e
 set -x
 
 target=tx
-xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1
-xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release $1
 
-if [ -z "$1" ]
+if [ -z "$1" ] || [ "$1" == "release" ]
 then
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../../osx/
+elif [ "$1" == "debug" ]
+then
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug
+elif [ "$1" == "clean" ]
+then
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release $1
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi
 

--- a/afdko/Tools/Programs/tx/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/tx/build/win/vc10/BuildAll.cmd
@@ -10,14 +10,14 @@ if "%1"=="" set do_release=1
 if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )

--- a/afdko/Tools/Programs/tx/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/tx/build/win/vc10/BuildAll.cmd
@@ -1,11 +1,33 @@
 cd %~dp0
-set buildConfig=Clean
 set targetProgram=tx
-
-if "%1"=="" set buildConfig="Build"
-
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
-%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 
-if "%1"=="" copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
+set do_release=0
+set do_target=0
+
+if "%1"=="" set do_release=1
+
+if "%1"=="release" set do_release=1
+
+if %do_release%==1 (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
+	set do_target=1
+)
+
+if "%1"=="debug" (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	set do_target=1
+)
+
+if "%1"=="clean" (
+	set buildConfig=Clean
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	set do_target=1
+)
+if %do_target%==0 (
+	echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')" 
+)

--- a/afdko/Tools/Programs/tx/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/tx/build/win/vc10/BuildAll.cmd
@@ -1,4 +1,5 @@
 cd %~dp0
+setlocal enabledelayedexpansion
 set targetProgram=tx
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
 
@@ -11,21 +12,21 @@ if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )
 
 if "%1"=="clean" (
 	set buildConfig=Clean
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	set do_target=1
 )
 if %do_target%==0 (

--- a/afdko/Tools/Programs/type1/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/type1/build/linux/gcc/BuildAll.sh
@@ -5,23 +5,25 @@ set -x
 target=type1
 curdir=`pwd`
 
-cd debug
-make $1
-cd $curdir
-
-cd release
-make $1
-cd $curdir
-
-if [ -z "$1" ]
+if [ -z "$1" ] || [ $1 = "release" ]
 then
-	if [ $OSX ]; then
-		cp -R ../../../exe/linux/release/$target ../../../../../linux/
-	else
-		if [ $OSX ]; then
-		cp -R ../../../exe/linux/release/$target ../../../../../linux/
-	else
-		cp -dR ../../../exe/linux/release/$target ../../../../../linux/
-	fi
-	fi
+	cd release
+	make
+	cd $curdir
+	cp -dR ../../../exe/linux/release/$target ../../../../../linux/
+elif [ $1 = "debug" ]
+then
+	cd debug
+	make
+	cd $curdir
+elif [ $1 = "clean" ]
+then
+	cd release
+	make $1
+	cd $curdir
+	cd debug
+	make $1
+	cd $curdir
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/type1/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/type1/build/osx/xcode4/BuildAll.sh
@@ -3,10 +3,18 @@ set -e
 set -x
 
 target=type1
-xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1
-xcodebuild -target $target -project $target.xcodeproj -configuration Release $1
 
-if [ -z "$1" ]
+if [ -z "$1" ] || [ "$1" == "release" ]
 then
+	xcodebuild -target $target -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../../osx/
+elif [ "$1" == "debug" ]
+then
+	xcodebuild -target $target -project $target.xcodeproj -configuration Debug
+elif [ "$1" == "clean" ]
+then
+	xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1
+	xcodebuild -target $target -project $target.xcodeproj -configuration Release $1
+else
+   echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/afdko/Tools/Programs/type1/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/type1/build/win/vc10/BuildAll.cmd
@@ -1,12 +1,33 @@
 cd %~dp0
-set buildConfig=Clean
 set targetProgram=type1
-
-if "%1"=="" set buildConfig="Build"
-
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
-%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 
+set do_release=0
+set do_target=0
 
-if "%1"=="" copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
+if "%1"=="" set do_release=1
+
+if "%1"=="release" set do_release=1
+
+if %do_release%==1 (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
+	set do_target=1
+)
+
+if "%1"=="debug" (
+	set buildConfig="Build"
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	set do_target=1
+)
+
+if "%1"=="clean" (
+	set buildConfig=Clean
+	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	set do_target=1
+)
+if %do_target%==0 (
+	echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')" 
+)

--- a/afdko/Tools/Programs/type1/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/type1/build/win/vc10/BuildAll.cmd
@@ -1,4 +1,5 @@
 cd %~dp0
+setlocal enabledelayedexpansion
 set targetProgram=type1
 set VCPATH="C:/Windows/Microsoft.NET/Framework/v4.0.30319/msbuild.exe"
 
@@ -11,21 +12,21 @@ if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
 	set buildConfig=Build
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )
 
 if "%1"=="clean" (
 	set buildConfig=Clean
-	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
-	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Debug  %~dp0%targetProgram%.sln
+	%VCPATH% /target:!buildConfig! /p:configuration=Release %~dp0%targetProgram%.sln
 	set do_target=1
 )
 if %do_target%==0 (

--- a/afdko/Tools/Programs/type1/build/win/vc10/BuildAll.cmd
+++ b/afdko/Tools/Programs/type1/build/win/vc10/BuildAll.cmd
@@ -10,14 +10,14 @@ if "%1"=="" set do_release=1
 if "%1"=="release" set do_release=1
 
 if %do_release%==1 (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Release %~dp0%targetProgram%.sln
 	copy /Y ..\..\..\exe\win\release\%targetProgram%.exe ..\..\..\..\..\win\
 	set do_target=1
 )
 
 if "%1"=="debug" (
-	set buildConfig="Build"
+	set buildConfig=Build
 	%VCPATH% /target:%buildConfig% /p:configuration=Debug  %~dp0%targetProgram%.sln
 	set do_target=1
 )


### PR DESCRIPTION
 ... to build only the release projects if no target is given.

They will also run the right build for the targets 'release', 'debug', and 'clean', and do nothing for any other target.