### PR TITLE
Remove obsolete AppVeyor code (round 2)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,16 +8,6 @@ environment:
     - PYTHON_HOME: "C:\\Python27"
 
 install:
-  # If there is a newer build queued for the same PR, cancel this one.
-  # The AppVeyor 'rollout builds' option is supposed to serve the same
-  # purpose but it is problematic because it tends to cancel builds pushed
-  # directly to master instead of just PR builds (or the converse).
-  # credits: JuliaLang developers.
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-          throw "There are newer queued builds for this pull request, failing early." }
-
   - set "PATH=%PYTHON_HOME%;%PYTHON_HOME%\\Scripts;%PATH%"
   # - python --version
   # - "python -c \"import struct; print(struct.calcsize('P') * 8)\""


### PR DESCRIPTION
Ilya Finkelshteyn said that the code removed by this commit is no longer needed now that https://github.com/appveyor/ci/issues/2066 is fixed.
(This is round 2, because I'm trying again off a fresh branch from `develop`.)