### PR TITLE
setup.py: allow to install native exe scripts on python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ class CustomBuildScripts(distutils.command.build_scripts.build_scripts):
         attempting to adjust the !# shebang. The default build_scripts command
         in python3 calls tokenize to detect the text encoding, treating all
         scripts as python scripts. But all our 'scripts' are native C
-        executables, thus the python3 tokenize module fails witn SyntaxError
+        executables, thus the python3 tokenize module fails with SyntaxError
         on them. Here we just skip the if branch where distutils attempts
         to ajust the shebang.
         """

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,10 @@ import platform
 import subprocess
 import sys
 from distutils.util import get_platform
-
+import distutils.command.build_scripts
+from distutils.dep_util import newer
+from distutils import log
+from distutils.util import convert_path
 import setuptools.command.build_py
 import setuptools.command.install
 from setuptools import setup, find_packages
@@ -93,6 +96,50 @@ class CustomBuild(setuptools.command.build_py.build_py):
         pkg_dir = 'afdko'
         compile_package(pkg_dir)
         setuptools.command.build_py.build_py.run(self)
+
+
+class CustomBuildScripts(distutils.command.build_scripts.build_scripts):
+
+    def copy_scripts(self):
+        """Copy each script listed in 'self.scripts' *as is*, without
+        attempting to adjust the !# shebang. The default build_scripts command
+        in python3 calls tokenize to detect the text encoding, treating all
+        scripts as python scripts. But all our 'scripts' are native C
+        executables, thus the python3 tokenize module fails witn SyntaxError
+        on them. Here we just skip the if branch where distutils attempts
+        to ajust the shebang.
+        """
+        self.mkpath(self.build_dir)
+        outfiles = []
+        updated_files = []
+        for script in self.scripts:
+            script = convert_path(script)
+            outfile = os.path.join(self.build_dir, os.path.basename(script))
+            outfiles.append(outfile)
+
+            if not self.force and not newer(script, outfile):
+                log.debug("not copying %s (up-to-date)", script)
+                continue
+
+            try:
+                f = open(script, "rb")
+            except OSError:
+                if not self.dry_run:
+                    raise
+                f = None
+            else:
+                first_line = f.readline()
+                if not first_line:
+                    f.close()
+                    self.warn("%s is an empty file (skipping)" % script)
+                    continue
+
+            if f:
+                f.close()
+            updated_files.append(outfile)
+            self.copy_file(script, outfile)
+
+        return outfiles, updated_files
 
 
 def _get_scripts():
@@ -209,6 +256,7 @@ def main():
           },
           cmdclass={
               'build_py': CustomBuild,
+              'build_scripts': CustomBuildScripts,
               'bdist_wheel': CustomBDistWheel,
               'install': InstallPlatlib,
           },


### PR DESCRIPTION
we need to skip the step where python3's distutils attempts to fix up the script's shebang, otherwise it fails with a SyntaxError, since it expects them to be text (shell or python) files, whereas in our case they are simply C binary executables.

the code is based on the latest cpython distutils:
https://github.com/python/cpython/blob/master/Lib/distutils/command/build_scripts.py

this is the error that python3.6 throws when one attempts to create a wheel from the afdko source, without this patch:

```
running build_scripts
creating build/scripts-3.6
Traceback (most recent call last):
  File "/home/clupo/.pyenv/versions/afdko-py36/lib/python3.6/tokenize.py", line 390, in find_cookie
    line_string = line.decode('utf-8')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf4 in position 32: invalid continuation byte

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "setup.py", line 219, in <module>
    main()
  File "setup.py", line 213, in main
    'install': InstallPlatlib,
  File "/home/clupo/.pyenv/versions/afdko-py36/lib/python3.6/site-packages/setuptools/__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "/home/clupo/.pyenv/versions/3.6.5/lib/python3.6/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/home/clupo/.pyenv/versions/3.6.5/lib/python3.6/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/home/clupo/.pyenv/versions/3.6.5/lib/python3.6/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/home/clupo/.pyenv/versions/afdko-py36/lib/python3.6/site-packages/wheel/bdist_wheel.py", line 202, in run
    self.run_command('build')
  File "/home/clupo/.pyenv/versions/3.6.5/lib/python3.6/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/home/clupo/.pyenv/versions/3.6.5/lib/python3.6/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/home/clupo/.pyenv/versions/3.6.5/lib/python3.6/distutils/command/build.py", line 135, in run
    self.run_command(cmd_name)
  File "/home/clupo/.pyenv/versions/3.6.5/lib/python3.6/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/home/clupo/.pyenv/versions/3.6.5/lib/python3.6/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/home/clupo/.pyenv/versions/3.6.5/lib/python3.6/distutils/command/build_scripts.py", line 50, in run
    self.copy_scripts()
  File "/home/clupo/.pyenv/versions/3.6.5/lib/python3.6/distutils/command/build_scripts.py", line 82, in copy_scripts
    encoding, lines = tokenize.detect_encoding(f.readline)
  File "/home/clupo/.pyenv/versions/afdko-py36/lib/python3.6/tokenize.py", line 431, in detect_encoding
    encoding = find_cookie(first)
  File "/home/clupo/.pyenv/versions/afdko-py36/lib/python3.6/tokenize.py", line 395, in find_cookie
    raise SyntaxError(msg)
SyntaxError: invalid or missing encoding declaration for 'afdko/Tools/linux/autohintexe'
```