### PR TITLE
Copy executables in debug build target as well

### DIFF
--- a/afdko/Tools/Programs/autohint/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/autohint/build/linux/gcc/BuildAll.sh
@@ -16,6 +16,7 @@ then
 	cd debug
 	make
 	cd $curdir
+	cp -dR ../../../exe/linux/debug/$target ../../../../../linux/
 elif [ $1 = "clean" ]
 then
 	cd release

--- a/afdko/Tools/Programs/autohint/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/autohint/build/osx/xcode4/BuildAll.sh
@@ -11,6 +11,7 @@ then
 elif [ "$1" == "debug" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug
+	cp ../../../exe/osx/debug/$target ../../../../../osx/
 elif [ "$1" == "clean" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1

--- a/afdko/Tools/Programs/detype1/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/detype1/build/linux/gcc/BuildAll.sh
@@ -16,6 +16,7 @@ then
 	cd debug
 	make
 	cd $curdir
+	cp -dR ../../../exe/linux/debug/$target ../../../../../linux/
 elif [ $1 = "clean" ]
 then
 	cd release

--- a/afdko/Tools/Programs/detype1/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/detype1/build/osx/xcode4/BuildAll.sh
@@ -11,6 +11,7 @@ then
 elif [ "$1" == "debug" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Debug
+	cp ../../../exe/osx/debug/$target ../../../../../osx/
 elif [ "$1" == "clean" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1

--- a/afdko/Tools/Programs/makeotf/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/makeotf/build/linux/gcc/BuildAll.sh
@@ -16,6 +16,7 @@ then
 	cd debug
 	make
 	cd $curdir
+	cp -dR ../../../exe/linux/debug/$target ../../../../../linux/
 elif [ $1 = "clean" ]
 then
 	cd release

--- a/afdko/Tools/Programs/makeotf/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/makeotf/build/osx/xcode4/BuildAll.sh
@@ -11,6 +11,7 @@ then
 elif [ "$1" == "debug" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug
+	cp ../../../exe/osx/debug/${target}exe ../../../../../osx/
 elif [ "$1" == "clean" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1

--- a/afdko/Tools/Programs/mergeFonts/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/mergeFonts/build/linux/gcc/BuildAll.sh
@@ -16,6 +16,7 @@ then
 	cd debug
 	make
 	cd $curdir
+	cp -dR ../../../exe/linux/debug/$target ../../../../../linux/
 elif [ $1 = "clean" ]
 then
 	cd release

--- a/afdko/Tools/Programs/mergeFonts/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/mergeFonts/build/osx/xcode4/BuildAll.sh
@@ -11,6 +11,7 @@ then
 elif [ "$1" == "debug" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug
+	cp ../../../exe/osx/debug/$target ../../../../../osx/
 elif [ "$1" == "clean" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1

--- a/afdko/Tools/Programs/rotateFont/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/rotateFont/build/linux/gcc/BuildAll.sh
@@ -16,6 +16,7 @@ then
 	cd debug
 	make
 	cd $curdir
+	cp -dR ../../../exe/linux/debug/$target ../../../../../linux/
 elif [ $1 = "clean" ]
 then
 	cd release

--- a/afdko/Tools/Programs/rotateFont/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/rotateFont/build/osx/xcode4/BuildAll.sh
@@ -11,6 +11,7 @@ then
 elif [ "$1" == "debug" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug
+	cp ../../../exe/osx/debug/$target ../../../../../osx/
 elif [ "$1" == "clean" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1

--- a/afdko/Tools/Programs/sfntdiff/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/sfntdiff/build/linux/gcc/BuildAll.sh
@@ -16,6 +16,7 @@ then
 	cd debug
 	make
 	cd $curdir
+	cp -dR ../../../exe/linux/debug/$target ../../../../../linux/
 elif [ $1 = "clean" ]
 then
 	cd release

--- a/afdko/Tools/Programs/sfntdiff/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/sfntdiff/build/osx/xcode4/BuildAll.sh
@@ -11,6 +11,7 @@ then
 elif [ "$1" == "debug" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Debug
+	cp ../../../exe/osx/debug/$target ../../../../../osx/
 elif [ "$1" == "clean" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1

--- a/afdko/Tools/Programs/sfntedit/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/sfntedit/build/linux/gcc/BuildAll.sh
@@ -16,6 +16,7 @@ then
 	cd debug
 	make
 	cd $curdir
+	cp -dR ../../../exe/linux/debug/$target ../../../../../linux/
 elif [ $1 = "clean" ]
 then
 	cd release

--- a/afdko/Tools/Programs/sfntedit/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/sfntedit/build/osx/xcode4/BuildAll.sh
@@ -11,6 +11,7 @@ then
 elif [ "$1" == "debug" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Debug
+	cp ../../../exe/osx/debug/$target ../../../../../osx/
 elif [ "$1" == "clean" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1

--- a/afdko/Tools/Programs/spot/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/spot/build/linux/gcc/BuildAll.sh
@@ -16,6 +16,7 @@ then
 	cd debug
 	make
 	cd $curdir
+	cp -dR ../../../exe/linux/debug/$target ../../../../../linux/
 elif [ $1 = "clean" ]
 then
 	cd release

--- a/afdko/Tools/Programs/spot/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/spot/build/osx/xcode4/BuildAll.sh
@@ -11,6 +11,7 @@ then
 elif [ "$1" == "debug" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Debug
+	cp ../../../exe/osx/debug/$target ../../../../../osx/
 elif [ "$1" == "clean" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1

--- a/afdko/Tools/Programs/tx/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/tx/build/linux/gcc/BuildAll.sh
@@ -16,6 +16,7 @@ then
 	cd debug
 	make
 	cd $curdir
+	cp -dR ../../../exe/linux/debug/$target ../../../../../linux/
 elif [ $1 = "clean" ]
 then
 	cd release

--- a/afdko/Tools/Programs/tx/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/tx/build/osx/xcode4/BuildAll.sh
@@ -11,6 +11,7 @@ then
 elif [ "$1" == "debug" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug
+	cp ../../../exe/osx/debug/$target ../../../../../osx/
 elif [ "$1" == "clean" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1

--- a/afdko/Tools/Programs/type1/build/linux/gcc/BuildAll.sh
+++ b/afdko/Tools/Programs/type1/build/linux/gcc/BuildAll.sh
@@ -16,6 +16,7 @@ then
 	cd debug
 	make
 	cd $curdir
+	cp -dR ../../../exe/linux/debug/$target ../../../../../linux/
 elif [ $1 = "clean" ]
 then
 	cd release

--- a/afdko/Tools/Programs/type1/build/osx/xcode4/BuildAll.sh
+++ b/afdko/Tools/Programs/type1/build/osx/xcode4/BuildAll.sh
@@ -11,6 +11,7 @@ then
 elif [ "$1" == "debug" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Debug
+	cp ../../../exe/osx/debug/$target ../../../../../osx/
 elif [ "$1" == "clean" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1


### PR DESCRIPTION
Otherwise it is not of much use; appending `debug` to build command in `setup.py` will fail with missing executables.