### PR TITLE
Spec: add missing “markClass” to TOC

### DIFF
--- a/afdko/Technical Documentation/OpenTypeFeatureFileSpecification.html
+++ b/afdko/Technical Documentation/OpenTypeFeatureFileSpecification.html
@@ -61,8 +61,9 @@ This software is licensed as OpenSource, under the Apache License, Version 2.0. 
 <li><a href="#4.c">parameters</a></li>
 <li><a href="#4.d">lookupflag</a></li>
 <li><a href="#4.e">lookup</a></li>
-<li><a href="#4.f">subtable</a></li>
-<li><a href="#4.g">Examples</a></li>
+<li><a href="#4.f">markClass</a></li>
+<li><a href="#4.g">subtable</a></li>
+<li><a href="#4.h">Examples</a></li>
 </ol>
 </li>
 <li><p><a href="#5"> Glyph substitution (GSUB) rules</a></p>


### PR DESCRIPTION
Add link to “markClass” in TOC.

Fix links to “subtable” and “Examples” in TOC.