### PR TITLE
[tx] fix for crash when tx calls fatal()

### DIFF
--- a/afdko/Tools/Programs/public/lib/source/support/except.c
+++ b/afdko/Tools/Programs/public/lib/source/support/except.c
@@ -21,12 +21,15 @@ PUBLIC procedure os_raise (_Exc_Buf *buf, int  code, char * msg)
 #ifdef USE_CXX_EXCEPTION
 	(void)buf;
 	_Exc_Buf e(code, msg);
-    throw e;
+	throw e;
 #else
 
-  buf->Code = code;
-  buf->Message = msg;
+	/* Replacing setjmp/longjmp  with a simple call to exit().
+	buf->Code = code;
+	buf->Message = msg;
 
-  longjmp(buf->Environ, 1);
+	longjmp(buf->Environ, 1);
+	*/
+	exit(code);
 #endif
 }


### PR DESCRIPTION
Fix for issue 445. Substituted a call to exit() instead of longjmp() in all the fatal() functions.
There are no tests, as the only reliable test case to force the crash was removed when issue 444 was fixed. Instead, I provided tests in  a branch called 'test-for-issue445', which branched from 'develop' before the fix for issue 444. The branch 'test-for-issue445' contains a test for causing the crash before the fix is applied, and a test for verifying that the correct exit code is returned after the fix is applied.

Note that some white space changed in 'except.c' in lines other than the fixed line; this was to make all the lines in the block have the same white space.