### PR TITLE
Cap ufoLib version to 2.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ fontMath~=0.4.5
 fontPens~=0.1.0
 fontTools~=3.28.0
 mutatorMath~=2.1.1
-ufoLib~=2.1.1
+ufoLib<=2.1.1
 ufonormalizer~=0.3.5


### PR DESCRIPTION
Cap the version of ufoLib until Cosimo revises his approach in the new `ufoLib.plistlib`. See #486.