### PR TITLE
use explicit paths for ignoring compiled OSX & linux programs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,16 +18,8 @@ htmlcov
 .pytest_cache
 
 # ignore the OSX and linux compiled programs
-autohintexe
-detype1
-makeotfexe
-mergefonts
-rotatefont
-sfntdiff
-sfntedit
-spot
-tx
-type1
+c/build_all/*
+!c/build_all/this_folder_intentionally_left_empty
 
 # ignore the temp build directories and files
 *.o


### PR DESCRIPTION
(otherwise changes in matching folders don't get picked up, e.g. in the `tx` folder)

I realized we had a problem after a comment that @anthrotype made in this thread: https://github.com/typemytype/booleanOperations/issues/40#issuecomment-408395042)
