### PR TITLE
[spot] CFF table differences between Mac/Win

### DIFF
--- a/c/spot/source/CFF_.c
+++ b/c/spot/source/CFF_.c
@@ -406,9 +406,9 @@ static void drawText(GlyphId glyphId, IntX lsb, IntX rsb, IntX width)
 	  sprintf(workstr, "318 96 moveto (BBox:  min = %.0f, %.0f  max = %.0f, %.0f) show\n"
 			 "318 84 moveto "
 			 "(SideBearings:  L = %.0f  R = %.0f  Width = %.0f) show\n",
-			 OUTPUT(h, cffgi->bbox.left), OUTPUT(v, cffgi->bbox.bottom),
-			 OUTPUT(h, cffgi->bbox.right), OUTPUT(v, cffgi->bbox.top),
-			 OUTPUT(h, lsb), OUTPUT(h, rsb), OUTPUT(h, width));
+			 round(OUTPUT(h, cffgi->bbox.left)), round(OUTPUT(v, cffgi->bbox.bottom)),
+			 round(OUTPUT(h, cffgi->bbox.right)), round(OUTPUT(v, cffgi->bbox.top)),
+			 round(OUTPUT(h, lsb)), round(OUTPUT(h, rsb)), round(OUTPUT(h, width)));
 	  proofPSOUT(cffproofctx, workstr);
 	  workstr[0] = '\0';
 	  sprintf(workstr, "318 72 moveto "
@@ -526,14 +526,14 @@ static void newPage(IntX page)
 			sprintf(workstr, "(Widths: %.0f units/em   [%s] ) show\n"
 			   "%g (%hu) stringwidth pop sub %g moveto (%hu) show\n"
 			   "/Helvetica-Narrow findfont %d scalefont setfont\n",
-			   OUTPUT(h, unitsPerEm), synopsis.title, 
+			   round(OUTPUT(h, unitsPerEm)), synopsis.title, 
 			   PAGE_WIDTH, synopsis.page, PAGE_HEIGHT + 9, synopsis.page,
 			   TEXT_SIZE);
 		else		
 			sprintf(workstr, "(CFF:%s  head vers: %.3f  Widths: %.0f units/em   %s) show\n"
 			   "%g (%hu) stringwidth pop sub %g moveto (%hu) show\n"
 			   "/Helvetica-Narrow findfont %d scalefont setfont\n",
-			   shortfilename, fontRevision, OUTPUT(h, unitsPerEm), date,
+			   shortfilename, fontRevision, round(OUTPUT(h, unitsPerEm)), date,
 			   PAGE_WIDTH, synopsis.page, PAGE_HEIGHT + 9, synopsis.page,
 			   TEXT_SIZE);
 	}
@@ -704,7 +704,7 @@ static void drawTic(IntX marks, Pelt A)
 		  {
 			workstr[0] = '\0';
 			sprintf(workstr, "(%.0f %.0f) stringwidth pop neg %g rmoveto\n",
-				   OUTPUT(h, Bx), OUTPUT(v, By), y);
+				   round(OUTPUT(h, Bx)), round(OUTPUT(v, By)), y);
 			proofPSOUT(cffproofctx, workstr);
 		  }
 
@@ -712,7 +712,7 @@ static void drawTic(IntX marks, Pelt A)
 		sprintf(workstr, "(%.0f %.0f) show\n"
 			   "0 setlinewidth stroke\n"
 			   "grestore %% tic\n", 
-				OUTPUT(h, Bx), OUTPUT(v, By));
+				round(OUTPUT(h, Bx)), round(OUTPUT(v, By)));
 		proofPSOUT(cffproofctx, workstr);
 		}
 	}
@@ -1158,8 +1158,8 @@ int CFF_DrawTile(GlyphId glyphId, Byte8 *code)
 	workstr[0] = '\0';
 	sprintf(workstr, "closepath 0 setlinewidth stroke\n"
 		   "%g (%.0f) stringwidth pop sub %g moveto (%.0f) show\n",
-		   synopsis.hTile + TILE_WIDTH - 1, OUTPUT(h, width), 
-		   synopsis.vTile - (TEXT_BASE + 1), OUTPUT(h, width));
+		   synopsis.hTile + TILE_WIDTH - 1, round(OUTPUT(h, width)), 
+		   synopsis.vTile - (TEXT_BASE + 1), round(OUTPUT(h, width)));
 	proofPSOUT(cffproofctx, workstr);
 
 	/* Draw [code/]glyphId */

--- a/c/spot/source/CFF_.c
+++ b/c/spot/source/CFF_.c
@@ -122,6 +122,18 @@ static char *syntheticGlyphs[]={"Delta","Euro", "Omega" ,"approxequal", "asciici
 
 static Byte8 *workstr = NULL;
 
+#if _WIN32
+#define round round_double
+static double round_double( double r )
+{
+	/* I return double as this is mostly used to round values for float or double printf format specifiers,
+	 and since I hope to remove this code soon when we move to VS 2017, it is less work to do an extra cast here
+	 than change all the printf format statements.
+	 */
+	return (double)((int)((r > 0.0) ? (r + 0.5) : (r - 0.5))); 
+}
+#endif
+
 static void CFFfatal(void *ctx)
 	{
 	  fatal(SPOT_MSG_CFFPARSING);

--- a/tests/spot_data/expected_output/dump_CFF_=6s.ps
+++ b/tests/spot_data/expected_output/dump_CFF_=6s.ps
@@ -353,8 +353,8 @@ newpath
 grestore
 /Helvetica findfont 12 scalefont setfont
 72 764 moveto (Outline Instructions:  CFF/Type2) show
-318 764 moveto (Sun May 13 21:25:27 2018) show
-72 750 moveto (spot_data/input/black.otf  .notdef  [@0]) show
+318 764 moveto (Tue Aug 07 09:15:38 2018) show
+72 750 moveto (black.otf  .notdef  [@0]) show
 gsave
 newpath 72 745 moveto 504 0 rlineto 2 setlinewidth stroke
 grestore
@@ -611,8 +611,8 @@ newpath
 grestore
 /Helvetica findfont 12 scalefont setfont
 72 764 moveto (Outline Instructions:  CFF/Type2) show
-318 764 moveto (Sun May 13 21:25:27 2018) show
-72 750 moveto (spot_data/input/black.otf  A  [@1]) show
+318 764 moveto (Tue Aug 07 09:15:38 2018) show
+72 750 moveto (black.otf  A  [@1]) show
 gsave
 newpath 72 745 moveto 504 0 rlineto 2 setlinewidth stroke
 grestore
@@ -926,8 +926,8 @@ newpath
 grestore
 /Helvetica findfont 12 scalefont setfont
 72 764 moveto (Outline Instructions:  CFF/Type2) show
-318 764 moveto (Sun May 13 21:25:27 2018) show
-72 750 moveto (spot_data/input/black.otf  B  [@2]) show
+318 764 moveto (Tue Aug 07 09:15:38 2018) show
+72 750 moveto (black.otf  B  [@2]) show
 gsave
 newpath 72 745 moveto 504 0 rlineto 2 setlinewidth stroke
 grestore
@@ -1161,8 +1161,8 @@ newpath
 grestore
 /Helvetica findfont 12 scalefont setfont
 72 764 moveto (Outline Instructions:  CFF/Type2) show
-318 764 moveto (Sun May 13 21:25:27 2018) show
-72 750 moveto (spot_data/input/black.otf  C  [@3]) show
+318 764 moveto (Tue Aug 07 09:15:38 2018) show
+72 750 moveto (black.otf  C  [@3]) show
 gsave
 newpath 72 745 moveto 504 0 rlineto 2 setlinewidth stroke
 grestore
@@ -1475,8 +1475,8 @@ newpath
 grestore
 /Helvetica findfont 12 scalefont setfont
 72 764 moveto (Outline Instructions:  CFF/Type2) show
-318 764 moveto (Sun May 13 21:25:27 2018) show
-72 750 moveto (spot_data/input/black.otf  a  [@4]) show
+318 764 moveto (Tue Aug 07 09:15:38 2018) show
+72 750 moveto (black.otf  a  [@4]) show
 gsave
 newpath 72 745 moveto 504 0 rlineto 2 setlinewidth stroke
 grestore
@@ -1785,8 +1785,8 @@ newpath
 grestore
 /Helvetica findfont 12 scalefont setfont
 72 764 moveto (Outline Instructions:  CFF/Type2) show
-318 764 moveto (Sun May 13 21:25:27 2018) show
-72 750 moveto (spot_data/input/black.otf  b  [@5]) show
+318 764 moveto (Tue Aug 07 09:15:38 2018) show
+72 750 moveto (black.otf  b  [@5]) show
 gsave
 newpath 72 745 moveto 504 0 rlineto 2 setlinewidth stroke
 grestore
@@ -2020,8 +2020,8 @@ newpath
 grestore
 /Helvetica findfont 12 scalefont setfont
 72 764 moveto (Outline Instructions:  CFF/Type2) show
-318 764 moveto (Sun May 13 21:25:27 2018) show
-72 750 moveto (spot_data/input/black.otf  c  [@6]) show
+318 764 moveto (Tue Aug 07 09:15:38 2018) show
+72 750 moveto (black.otf  c  [@6]) show
 gsave
 newpath 72 745 moveto 504 0 rlineto 2 setlinewidth stroke
 grestore
@@ -2058,7 +2058,7 @@ newpath
 252 409 moveto
 4.60648 -17.1179 rlineto
 0 -13.3333 rmoveto
-(378 204) show
+(378 205) show
 0 setlinewidth stroke
 grestore % tic
 230 292 cntlpt
@@ -2068,8 +2068,8 @@ gsave % tic
 newpath
 256 409 moveto
 -4.48584 -17.4039 rlineto
-(384 204) stringwidth pop neg -13.3333 rmoveto
-(384 204) show
+(384 205) stringwidth pop neg -13.3333 rmoveto
+(384 205) show
 0 setlinewidth stroke
 grestore % tic
 269 359 280 292 291 244 _CT
@@ -2077,8 +2077,8 @@ gsave % tic
 newpath
 291 244 moveto
 -7.15947 -4.76208 rlineto
-(436 122) stringwidth pop neg -13.3333 rmoveto
-(436 122) show
+(437 122) stringwidth pop neg -13.3333 rmoveto
+(437 122) show
 0 setlinewidth stroke
 grestore % tic
 269 359 cntlpt
@@ -2107,7 +2107,7 @@ newpath
 219 244 moveto
 7.15947 -4.76208 rlineto
 0 -13.3333 rmoveto
-(328 122) show
+(329 122) show
 0 setlinewidth stroke
 grestore % tic
 gsave
@@ -2173,8 +2173,8 @@ gsave % tic
 newpath
 155 532 moveto
 -4.35013 17.7112 rlineto
-(232 266) stringwidth pop neg 0 rmoveto
-(232 266) show
+(233 266) stringwidth pop neg 0 rmoveto
+(233 266) show
 0 setlinewidth stroke
 grestore % tic
 _CP
@@ -2278,8 +2278,8 @@ newpath
 grestore
 /Helvetica findfont 12 scalefont setfont
 72 764 moveto (Outline Instructions:  CFF/Type2) show
-318 764 moveto (Sun May 13 21:25:27 2018) show
-72 750 moveto (spot_data/input/black.otf  A.sc  [@7]) show
+318 764 moveto (Tue Aug 07 09:15:38 2018) show
+72 750 moveto (black.otf  A.sc  [@7]) show
 gsave
 newpath 72 745 moveto 504 0 rlineto 2 setlinewidth stroke
 grestore
@@ -2367,7 +2367,7 @@ newpath
 283 532 moveto
 0 22 rlineto
 0 0 rmoveto
-(424 266) show
+(425 266) show
 0 setlinewidth stroke
 grestore % tic
 501 507 cntlpt
@@ -2409,7 +2409,7 @@ newpath
 287 408 moveto
 0 -22 rlineto
 0 -13.3333 rmoveto
-(430 204) show
+(431 204) show
 0 setlinewidth stroke
 grestore % tic
 327 408 345 398 345 370 _CT
@@ -2462,7 +2462,7 @@ newpath
 291 218 moveto
 0 -22 rlineto
 0 -13.3333 rmoveto
-(436 109) show
+(437 109) show
 0 setlinewidth stroke
 grestore % tic
 339 218 359 202 359 172 _CT
@@ -2470,8 +2470,8 @@ gsave % tic
 newpath
 359 172 moveto
 -7.33333 -0 rlineto
-(538 86) stringwidth pop neg -13.3333 rmoveto
-(538 86) show
+(539 86) stringwidth pop neg -13.3333 rmoveto
+(539 86) show
 0 setlinewidth stroke
 grestore % tic
 339 218 cntlpt
@@ -2482,7 +2482,7 @@ newpath
 291 124 moveto
 0 22 rlineto
 0 0 rmoveto
-(436 62) show
+(437 62) show
 0 setlinewidth stroke
 grestore % tic
 359 145 cntlpt
@@ -2593,8 +2593,8 @@ newpath
 grestore
 /Helvetica findfont 12 scalefont setfont
 72 764 moveto (Outline Instructions:  CFF/Type2) show
-318 764 moveto (Sun May 13 21:25:27 2018) show
-72 750 moveto (spot_data/input/black.otf  B.sc  [@8]) show
+318 764 moveto (Tue Aug 07 09:15:38 2018) show
+72 750 moveto (black.otf  B.sc  [@8]) show
 gsave
 newpath 72 745 moveto 504 0 rlineto 2 setlinewidth stroke
 grestore
@@ -2704,7 +2704,7 @@ newpath
 327 544 moveto
 0 22 rlineto
 0 0 rmoveto
-(490 272) show
+(491 272) show
 0 setlinewidth stroke
 grestore % tic
 462 512 cntlpt
@@ -2714,8 +2714,8 @@ gsave % tic
 newpath
 44 261 moveto
 -7.33333 -0 rlineto
-(66 130) stringwidth pop neg -13.3333 rmoveto
-(66 130) show
+(66 131) stringwidth pop neg -13.3333 rmoveto
+(66 131) show
 0 setlinewidth stroke
 grestore % tic
 180 544 cntlpt
@@ -2828,8 +2828,8 @@ newpath
 grestore
 /Helvetica findfont 12 scalefont setfont
 72 764 moveto (Outline Instructions:  CFF/Type2) show
-318 764 moveto (Sun May 13 21:25:27 2018) show
-72 750 moveto (spot_data/input/black.otf  C.sc  [@9]) show
+318 764 moveto (Tue Aug 07 09:15:38 2018) show
+72 750 moveto (black.otf  C.sc  [@9]) show
 gsave
 newpath 72 745 moveto 504 0 rlineto 2 setlinewidth stroke
 grestore

--- a/tests/spot_test.py
+++ b/tests/spot_test.py
@@ -105,3 +105,27 @@ def test_bug465():
     actual_path = runner(CMD + ['-r', '-o', 't', '_GPOS=7', '-f', file_name])
     expected_path = _get_expected_path('bug465_otf.txt')
     assert differ([expected_path, actual_path])
+
+
+@pytest.mark.parametrize('args, exp_filename', [
+    # Fails on Windows, passes on Mac
+    # https://ci.appveyor.com/project/adobe-type-tools/afdko/build/1.0.217
+    # https://travis-ci.org/adobe-type-tools/afdko/builds/378601819
+    (['t', '_CFF_=6', 's1.5,0.5'], 'dump_CFF_=6s.ps'),
+])
+def test_bug469(args, exp_filename):
+    import platform
+    platform_system = platform.system()
+    if platform_system == "Windows":
+        dump_differs = True
+    elif platform_system == "Darwin":
+        dump_differs = False
+    else:
+        assert 0, "Test does not support " + platform_system
+
+    skip = ['318 764 moveto (' + SPLIT_MARKER + '72 750 moveto (']
+    if skip:
+        skip.insert(0, '-s')
+    actual_path = runner(CMD + ['-r', '-f', 'black.otf', '-o'] + args)
+    expected_path = _get_expected_path(exp_filename)
+    assert (not dump_differs) == differ([expected_path, actual_path] + skip)

--- a/tests/spot_test.py
+++ b/tests/spot_test.py
@@ -61,10 +61,7 @@ def _get_expected_path(file_name):
     (['t', '_CFF_=6', 'c'], 'dump_CFF_=6c.ps'),
     (['t', '_CFF_=6', 'R'], 'dump_CFF_=6R.ps'),
     (['t', '_CFF_=6', 'g2,5-7'], 'dump_CFF_=6g.ps'),
-    # Fails on Windows, passes on Mac
-    # https://ci.appveyor.com/project/adobe-type-tools/afdko/build/1.0.217
-    # https://travis-ci.org/adobe-type-tools/afdko/builds/378601819
-    # (['t', '_CFF_=6', 's1.5,0.5'], 'dump_CFF_=6s.ps'),
+    (['t', '_CFF_=6', 's1.5,0.5'], 'dump_CFF_=6s.ps'),
     (['t', '_CFF_=6', 'b-10,-10,200,500', 'g4'], 'dump_CFF_=6b.ps'),
     (['t', '_CFF_=7'], 'dump_CFF_=7.ps'),
     (['t', '_CFF_=7', 'g2,5-7'], 'dump_CFF_=7g.ps'),
@@ -105,27 +102,3 @@ def test_bug465():
     actual_path = runner(CMD + ['-r', '-o', 't', '_GPOS=7', '-f', file_name])
     expected_path = _get_expected_path('bug465_otf.txt')
     assert differ([expected_path, actual_path])
-
-
-@pytest.mark.parametrize('args, exp_filename', [
-    # Fails on Windows, passes on Mac
-    # https://ci.appveyor.com/project/adobe-type-tools/afdko/build/1.0.217
-    # https://travis-ci.org/adobe-type-tools/afdko/builds/378601819
-    (['t', '_CFF_=6', 's1.5,0.5'], 'dump_CFF_=6s.ps'),
-])
-def test_bug469(args, exp_filename):
-    import platform
-    platform_system = platform.system()
-    if platform_system == "Windows":
-        dump_differs = True
-    elif platform_system == "Darwin":
-        dump_differs = False
-    else:
-        assert 0, "Test does not support " + platform_system
-
-    skip = ['318 764 moveto (' + SPLIT_MARKER + '72 750 moveto (']
-    if skip:
-        skip.insert(0, '-s')
-    actual_path = runner(CMD + ['-r', '-f', 'black.otf', '-o'] + args)
-    expected_path = _get_expected_path(exp_filename)
-    assert (not dump_differs) == differ([expected_path, actual_path] + skip)


### PR DESCRIPTION
[spot] CFF table differences between Mac/Win
Fixes #469
The text writing code uses printf formatting statements to round some values. On Mac, x.5 rounds down, on Win, x.5 rounds up.
Use std lib round() function to round arguments before they are passed to the printf function.