### PR TITLE
[spot] name table difference between Mac/Win spot 

### DIFF
--- a/c/spot/source/main.c
+++ b/c/spot/source/main.c
@@ -25,8 +25,8 @@ jmp_buf mark;
 #define MAX_ARGS 200
 
 
-Byte8 *version = "3.5.65518";	/* Program version */
-Byte8 *libversion = "3.5.65518";	/* Library version */
+Byte8 *version = "3.5.65519";	/* Program version */
+Byte8 *libversion = "3.5.65519";	/* Library version */
 char * sourcepath;
 char * outputfilebase = NULL;
 char *infilename=NULL;

--- a/c/spot/source/name.c
+++ b/c/spot/source/name.c
@@ -67,17 +67,6 @@ void nameRead(LongN start, Card32 length)
 	loaded = 1;
 }
 
-/* Compare nameRecord offsets and lengths */
-static int cmpOffsets(const void *a, const void *b)
-	{
-	NameRecord *first = &name->record[*(Card16 *)a];
-	NameRecord *second = &name->record[*(Card16 *)b];
-	IntX cmp = first->offset - second->offset;
-	if (cmp != 0)
-		return cmp;
-	return first->length - second->length;
-	}
-
 /* Dump string */
 static void dumpString(NameRecord *record, IntX level)
 	{
@@ -154,19 +143,12 @@ static void makeString(NameRecord *record, Byte8 *str)
 void nameDump(IntX level, LongN start)
 	{
 	IntX i;
-	Card16 *index;
 	IntX lastOffset;
 	IntX lastLength;
 	if (level == 3)
 	{
 		DL(2, (OUTPUTBUFF, "### [name] \n"));
 		
-		/* Build nameRecord index sorted by offset */
-		index = memNew(sizeof(index[0]) * name->count);
-		for (i = 0; i < name->count; i++)
-			index[i] = i;
-		qsort(index, name->count, sizeof(index[0]), cmpOffsets);
-
 		/* Dump string table (unique strings only) */
 		lastOffset = -1;
 		lastLength = -1;
@@ -174,7 +156,7 @@ void nameDump(IntX level, LongN start)
 			   "{platformId,scriptId,languageId,nameId,length,offset} = <name value>\n"));
 		for (i = 0; i < name->count; i++)
 		{
-			NameRecord *record = &name->record[index[i]];
+			NameRecord *record = &name->record[i];
 			DL(2, (OUTPUTBUFF, "[%2d]={%2hx,%2hx,%4hx,%4hu,%4hu,%04hx} ", i,
 				   record->platformId, record->scriptId, record->languageId,
 				   record->nameId, record->length, record->offset));
@@ -240,19 +222,13 @@ void nameDump(IntX level, LongN start)
 			DL(2, (OUTPUTBUFF, "\n"));
 			}
 
-		/* Build nameRecord index sorted by offset */
-		index = memNew(sizeof(index[0]) * name->count);
-		for (i = 0; i < name->count; i++)
-			index[i] = i;
-		qsort(index, name->count, sizeof(index[0]), cmpOffsets);
-
 		/* Dump string table (unique strings only) */
 		DL(2, (OUTPUTBUFF, "--- string[name string offset]=<string>\n"));
 		lastOffset = -1;
 		lastLength = -1;
 		for (i = 0; i < name->count; i++)
 			{
-			NameRecord *record = &name->record[index[i]];
+			NameRecord *record = &name->record[i];
 
 			if (lastOffset != record->offset || lastLength != record->length)
 				{
@@ -276,9 +252,8 @@ void nameDump(IntX level, LongN start)
 			dumpLanguageTagString(record, level);
 			}
 	}
-
-	memFree(index);
 	}
+
 void nameFree(void)
 	{
 	if (!loaded)

--- a/tests/spot_data/expected_output/dump_name=3.txt
+++ b/tests/spot_data/expected_output/dump_name=3.txt
@@ -2,9 +2,9 @@
 --- record[index]={platformId,scriptId,languageId,nameId,length,offset} = <name value>
 [ 0]={ 3, 1, 409,   0, 224,0000} [0000]=<Copyright 2010, 2012, 2014 Adobe Systems Incorporated (http://www.adobe.com/), with Reserved Font Name \2018Source\2019.>
 [ 1]={ 3, 1, 409,   1,  42,00e0} [00e0]=<Source Sans Pro Black>
-[ 2]={ 3, 1, 409,   4,  42,00e0} [00e0]=<Source Sans Pro Black>
-[ 3]={ 3, 1, 409,   2,  14,010a} [010a]=<Regular>
-[ 4]={ 3, 1, 409,   3,  72,0118} [0118]=<2.020;ADBO;SourceSansPro-Black;ADOBE>
+[ 2]={ 3, 1, 409,   2,  14,010a} [010a]=<Regular>
+[ 3]={ 3, 1, 409,   3,  72,0118} [0118]=<2.020;ADBO;SourceSansPro-Black;ADOBE>
+[ 4]={ 3, 1, 409,   4,  42,00e0} [00e0]=<Source Sans Pro Black>
 [ 5]={ 3, 1, 409,   5, 112,0160} [0160]=<Version 2.020;PS 2.0;hotconv 1.0.86;makeotf.lib2.5.63406>
 [ 6]={ 3, 1, 409,   6,  38,01d0} [01d0]=<SourceSansPro-Black>
 [ 7]={ 3, 1, 409,   7, 192,01f6} [01f6]=<Source is a trademark of Adobe Systems Incorporated in the United States and/or other countries.>

--- a/tests/spot_data/expected_output/dump_name=4.txt
+++ b/tests/spot_data/expected_output/dump_name=4.txt
@@ -29,6 +29,7 @@ stringOffset=00f6
 [00e0]=<Source Sans Pro Black>
 [010a]=<Regular>
 [0118]=<2.020;ADBO;SourceSansPro-Black;ADOBE>
+[00e0]=<Source Sans Pro Black>
 [0160]=<Version 2.020;PS 2.0;hotconv 1.0.86;makeotf.lib2.5.63406>
 [01d0]=<SourceSansPro-Black>
 [01f6]=<Source is a trademark of Adobe Systems Incorporated in the United States and/or other countries.>

--- a/tests/spot_test.py
+++ b/tests/spot_test.py
@@ -104,15 +104,15 @@ def test_bug465():
     assert differ([expected_path, actual_path])
 
 
-@pytest.mark.parametrize('args, exp_filename', [(['t', '_name=3'], 'dump_name=3.txt')])
+@pytest.mark.parametrize(
+    'args, exp_filename', [(['t', '_name=3'], 'dump_name=3.txt')])
 def test_bug468(args, exp_filename):
-    """ verify that with current code, this test fails on Windows.
-    Using the same logic as test_options().
-    spot currently sorts the name records by offset to the string, rather
-    than name record order. If the offsets for two different names are the same,
-    then the qsort is unstable, and Windows sorts differently than Mac.
-    The fix is to NOT sort, and report the records by name record order.
-    """
+    """ verify that with current code, this test fails on Windows. Using
+    the same logic as test_options(). spot currently sorts the name
+    records by offset to the string, rather than name record order. If
+    the offsets for two different names are the same, then the qsort is
+    unstable, and Windows sorts differently than Mac. The fix is to NOT
+    sort, and report the records by name record order. """
 
     import platform
     platform_system = platform.system()

--- a/tests/spot_test.py
+++ b/tests/spot_test.py
@@ -102,3 +102,27 @@ def test_bug465():
     actual_path = runner(CMD + ['-r', '-o', 't', '_GPOS=7', '-f', file_name])
     expected_path = _get_expected_path('bug465_otf.txt')
     assert differ([expected_path, actual_path])
+
+
+@pytest.mark.parametrize('args, exp_filename', [(['t', '_name=3'], 'dump_name=3.txt')])
+def test_bug468(args, exp_filename):
+    """ verify that with current code, this test fails on Windows.
+    Using the same logic as test_options().
+    spot currently sorts the name records by offset to the string, rather
+    than name record order. If the offsets for two different names are the same,
+    then the qsort is unstable, and Windows sorts differently than Mac.
+    The fix is to NOT sort, and report the records by name record order.
+    """
+
+    import platform
+    platform_system = platform.system()
+    if platform_system == "Windows":
+        dump_differs = True
+    elif platform_system == "Darwin":
+        dump_differs = False
+    else:
+        assert 0, "Test does not support " + platform_system
+
+    actual_path = runner(CMD + ['-r', '-f', 'black.otf', '-o'] + args)
+    expected_path = _get_expected_path(exp_filename)
+    assert (not dump_differs) == differ([expected_path, actual_path])

--- a/tests/spot_test.py
+++ b/tests/spot_test.py
@@ -51,10 +51,7 @@ def _get_expected_path(file_name):
     (['t', '_hmtx=7'], 'dump_hmtx=7.txt'),
     (['t', '_hmtx=8'], 'dump_hmtx=8.txt'),
     (['t', '_name=2'], 'dump_name=2.txt'),
-    # Fails on Windows, passes on Mac
-    # https://ci.appveyor.com/project/adobe-type-tools/afdko/build/1.0.217
-    # https://travis-ci.org/adobe-type-tools/afdko/builds/378601819
-    # (['t', '_name=3'], 'dump_name=3.txt'),
+    (['t', '_name=3'], 'dump_name=3.txt'),
     (['t', '_name=4'], 'dump_name=4.txt'),
     (['t', '_CFF_=6'], 'dump_CFF_=6.ps'),
     (['t', '_CFF_=6', 'a'], 'dump_CFF_=6a.ps'),
@@ -102,27 +99,3 @@ def test_bug465():
     actual_path = runner(CMD + ['-r', '-o', 't', '_GPOS=7', '-f', file_name])
     expected_path = _get_expected_path('bug465_otf.txt')
     assert differ([expected_path, actual_path])
-
-
-@pytest.mark.parametrize(
-    'args, exp_filename', [(['t', '_name=3'], 'dump_name=3.txt')])
-def test_bug468(args, exp_filename):
-    """ verify that with current code, this test fails on Windows. Using
-    the same logic as test_options(). spot currently sorts the name
-    records by offset to the string, rather than name record order. If
-    the offsets for two different names are the same, then the qsort is
-    unstable, and Windows sorts differently than Mac. The fix is to NOT
-    sort, and report the records by name record order. """
-
-    import platform
-    platform_system = platform.system()
-    if platform_system == "Windows":
-        dump_differs = True
-    elif platform_system == "Darwin":
-        dump_differs = False
-    else:
-        assert 0, "Test does not support " + platform_system
-
-    actual_path = runner(CMD + ['-r', '-f', 'black.otf', '-o'] + args)
-    expected_path = _get_expected_path(exp_filename)
-    assert (not dump_differs) == differ([expected_path, actual_path])


### PR DESCRIPTION
Fixes issue 468

spot sorted the name records by offset to the string, rather than name record order. If the offsets for two different names are the same, then the qsort is unstable, and Windows sorts differently than Mac. The fix is to NOT sort, and report the records by name record order.

The logic was originally an optimization for name table dumps other than level 3, as report of a name string could be omitted if it the name strings were sorted by offset, and the offset of the current record was the same as the previous record. However, we now think it more valuable to have one string dump per name record, and for the strings to be reported in name record order.