### PR TITLE
[rotatefont] Failures on Linux c-tools 

### DIFF
--- a/c/public/lib/api/t1read.h
+++ b/c/public/lib/api/t1read.h
@@ -7,7 +7,7 @@
 
 #include "ctlshare.h"
 
-#define T1R_VERSION CTL_MAKE_VERSION(1, 0, 41)
+#define T1R_VERSION CTL_MAKE_VERSION(1, 0, 42)
 
 #include "absfont.h"
 

--- a/c/public/lib/source/t1read/t1read.c
+++ b/c/public/lib/source/t1read/t1read.c
@@ -3408,6 +3408,21 @@ int t1rResetGlyphs(t1rCtx h) {
     for (i = 0; i < h->chars.index.cnt; i++)
         h->chars.index.array[i].flags &= ~ABF_GLYPH_SEEN;
 
+    if (h->top.sup.flags & ABF_CID_FONT)
+    {
+        /* If the font is a Type1 CID font, the charstrings must be read
+         when building a subset, in order to get the FD index. When a CID
+         charstring is read, it is decrypted in place in the src buffer.
+         If the total charstrings are smaller than the src buffer, then
+         when the glyph data is later read again when the subset is
+         applied, the charstring data is just copied from the buffer.
+         However, they are now decrypted, leading to parsing failure. Set
+         the buffer length to 0 so that the src charstring data will get
+         reloaded again. */
+        h->src.offset = 0;
+        h->src.length = 0;
+    }
+    
     return t1rSuccess;
 }
 

--- a/c/public/lib/source/t1read/t1read.c
+++ b/c/public/lib/source/t1read/t1read.c
@@ -3422,7 +3422,7 @@ int t1rResetGlyphs(t1rCtx h) {
         h->src.offset = 0;
         h->src.length = 0;
     }
-    
+
     return t1rSuccess;
 }
 

--- a/tests/rotatefont_test.py
+++ b/tests/rotatefont_test.py
@@ -85,6 +85,7 @@ def test_rt_fd_options(font_filename, i, rt_args):
         fd_args = ['fd', '_{}'.format(i)]
         ext = 'ps'
         diff_mode = ['-m', 'bin']
+
     rt_values = ['_{}'.format(val) for val in rt_args.split()]
     actual_path = runner(CMD + ['-f', font_filename,
                                 '-o', 't1', 'rt'] + rt_values + fd_args)

--- a/tests/rotatefont_test.py
+++ b/tests/rotatefont_test.py
@@ -78,7 +78,6 @@ def test_matrix(font_filename, i, matrix):
 ])
 @pytest.mark.parametrize('font_filename', ['font.pfa', 'cidfont.ps'])
 def test_rt_fd_options(font_filename, i, rt_args):
-    import subprocess32 as subprocess
     fd_args = []
     ext = 'pfa'
     diff_mode = []
@@ -86,19 +85,11 @@ def test_rt_fd_options(font_filename, i, rt_args):
         fd_args = ['fd', '_{}'.format(i)]
         ext = 'ps'
         diff_mode = ['-m', 'bin']
-
     rt_values = ['_{}'.format(val) for val in rt_args.split()]
-
-    if platform.system() == 'Linux':
-        with pytest.raises(subprocess.CalledProcessError) as err:
-            runner(CMD + ['-f', font_filename,
-                          '-o', 't1', 'rt'] + rt_values + fd_args)
-        assert err.value.returncode == 10
-    else:
-        actual_path = runner(CMD + ['-f', font_filename,
-                                    '-o', 't1', 'rt'] + rt_values + fd_args)
-        expected_path = _get_expected_path('rotatrans{}.{}'.format(i, ext))
-        assert differ([expected_path, actual_path] + diff_mode)
+    actual_path = runner(CMD + ['-f', font_filename,
+                                '-o', 't1', 'rt'] + rt_values + fd_args)
+    expected_path = _get_expected_path('rotatrans{}.{}'.format(i, ext))
+    assert differ([expected_path, actual_path] + diff_mode)
 
 
 @pytest.mark.parametrize('font_filename', ['font.pfa', 'cidfont.ps'])

--- a/tests/rotatefont_test.py
+++ b/tests/rotatefont_test.py
@@ -78,6 +78,7 @@ def test_matrix(font_filename, i, matrix):
 ])
 @pytest.mark.parametrize('font_filename', ['font.pfa', 'cidfont.ps'])
 def test_rt_fd_options(font_filename, i, rt_args):
+    import subprocess32 as subprocess
     fd_args = []
     ext = 'pfa'
     diff_mode = []
@@ -87,10 +88,17 @@ def test_rt_fd_options(font_filename, i, rt_args):
         diff_mode = ['-m', 'bin']
 
     rt_values = ['_{}'.format(val) for val in rt_args.split()]
-    actual_path = runner(CMD + ['-f', font_filename,
-                                '-o', 't1', 'rt'] + rt_values + fd_args)
-    expected_path = _get_expected_path('rotatrans{}.{}'.format(i, ext))
-    assert differ([expected_path, actual_path] + diff_mode)
+
+    if platform.system() == 'Linux':
+        with pytest.raises(subprocess.CalledProcessError) as err:
+            runner(CMD + ['-f', font_filename,
+                          '-o', 't1', 'rt'] + rt_values + fd_args)
+        assert err.value.returncode == 10
+    else:
+        actual_path = runner(CMD + ['-f', font_filename,
+                                    '-o', 't1', 'rt'] + rt_values + fd_args)
+        expected_path = _get_expected_path('rotatrans{}.{}'.format(i, ext))
+        assert differ([expected_path, actual_path] + diff_mode)
 
 
 @pytest.mark.parametrize('font_filename', ['font.pfa', 'cidfont.ps'])


### PR DESCRIPTION
[rotatefont] Failures on Linux c-tools 

fixes #569
Fixed by setting the buffer length to 0 after the first pass of parsing
so that the src charstring data will get reloaded again.

If the font is a Type1 CID font, the glyph data (charstrings) must be
read when building a subset, in order to get the FD index. When a CID
charstring is read, it is decrypted in place in the src buffer. If the
total charstring data is smaller than the src buffer, then when the
glyph data is later read again when the subset is applied, the existing
charstring data is just copied from the buffer, rather than being read
from file into the buffer. However, the data is then already decrypted,
and applying decryption again produces garbage data.

This is an old bug, and can occur on Mac and Windows as well as Linux.
It happened on Linux only because on the other OS's the std buffer size
(MAXBUFF) is defined by the compiler as 1024, while on Linux it was
6728. Hence the entire set of charstrings fit in the file buffer on
Linux.

The bug also didn't happen when the same set of glyphs was selected
using the option '-g 28-52' rather than '-fd 1', because with the former
options, the glyphs can be subset using only the glyph ID's, and the
glyphs only get read in once.