### PR TITLE
[appveyor] Set skip_branch_with_pr

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,6 +11,9 @@ environment:
 matrix:
   fast_finish: true
 
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true
+
 # scripts that run after cloning repository
 install:
   - pip install flake8 cpplint


### PR DESCRIPTION
Hopefully this change will speedup AppVeyor a bit by not letting it create a branch job when changes are made to a branch that has an open PR already.
Travis seems to do this by default.