### PR TITLE
cleaned up issues reported by shellcheck

### DIFF
--- a/c/autohint/build/linux/gcc/BuildAll.sh
+++ b/c/autohint/build/linux/gcc/BuildAll.sh
@@ -3,28 +3,28 @@ set -e
 set -x
 
 target=autohintexe
-curdir=`pwd`
+curdir=$(pwd)
 
-if [ -z "$1" ] || [ $1 = "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	cd release
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/release/$target ../../../../build_all
-elif [ $1 = "debug" ]
+elif [ "$1" = "debug" ]
 then
 	cd debug
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/debug/$target ../../../../build_all
-elif [ $1 = "clean" ]
+elif [ "$1" = "clean" ]
 then
 	cd release
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 	cd debug
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/autohint/build/osx/xcode4/BuildAll.sh
+++ b/c/autohint/build/osx/xcode4/BuildAll.sh
@@ -4,19 +4,19 @@ set -x
 
 target=autohintexe
 
-if [ -z "$1" ] || [ "$1" == "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target  ../../../../build_all
 	ls ../../../build
-elif [ "$1" == "debug" ]
+elif [ "$1" = "debug" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug
 	cp ../../../exe/osx/debug/$target ../../../../build_all
-elif [ "$1" == "clean" ]
+elif [ "$1" = "clean" ]
 then
-	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1
-	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release $1
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug "$1"
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release "$1"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/buildall.sh
+++ b/c/buildall.sh
@@ -1,23 +1,25 @@
+#! /bin/sh
+
 # How to find and add all the xcode files for a new program:
 # find .   \( -path "*/xcode4/*" \)	 -and \( \(	 -name BuildAll.sh \) -or \( -name project.pbxproj \) -or \( -name contents.xcworkspacedata	 \) \)	-exec p4 add {} \;curDir=`pwd`
 
 set -e
 set -x
 
-curDir=`pwd`
+curDir=$(pwd)
 
-if [ -z "$1" ] || [ "$1" == "release" ] || [ "$1" == "debug" ] || [ "$1" == "clean" ]
+if [ -z "$1" ] || [ "$1" = "release" ] || [ "$1" = "debug" ] || [ "$1" = "clean" ]
 then
-	buildAllList=`ls -1 */build/osx/xcode4/BuildAll.sh`
+	buildAllList=$(ls -1 ./*/build/osx/xcode4/BuildAll.sh)
 	for shFile in $buildAllList
 	do
 		echo "***Running $shFile"
-		newDir=`dirname $shFile`
-		shFile=`basename $shFile`
-		cd $newDir
-		sh	$shFile $1
+		newDir=$(dirname "$shFile")
+		shFile=$(basename "$shFile")
+		cd "$newDir"
+		sh	"$shFile" "$1"
 		failed=$?
-		cd $curDir
+		cd "$curDir"
 		if [ "$failed" -ne 0 ]; then
 			exit "$failed"
 		fi

--- a/c/buildalllinux.sh
+++ b/c/buildalllinux.sh
@@ -1,23 +1,25 @@
+#! /bin/sh
+
 # How to find and add all the xcode files for a new program:
 # find .   \( -path "*/xcode4/*" \)  -and \( \(  -name BuildAll.sh \) -or \( -name project.pbxproj \) -or \( -name contents.xcworkspacedata  \) \)  -exec p4 add {} \;curDir=`pwd`
 
 set -e
 set -x
 
-curDir=`pwd`
+curDir=$(pwd)
 
 if [ -z "$1" ] || [ "$1" = "release" ] || [ "$1" = "debug" ] || [ "$1" = "clean" ]
 then
-	buildAllList=`ls -1 */build/linux/gcc/BuildAll.sh`
+	buildAllList=$(ls -1 ./*/build/linux/gcc/BuildAll.sh)
 	for shFile in $buildAllList
 	do
 		echo "***Running $shFile"
-		newDir=`dirname $shFile`
-		shFile=`basename $shFile`
-		cd $newDir
-		sh	$shFile $1
+		newDir=$(dirname "$shFile")
+		shFile=$(basename "$shFile")
+		cd "$newDir"
+		sh	"$shFile" "$1"
 		failed=$?
-		cd $curDir
+		cd "$curDir"
 		if [ "$failed" -ne 0 ]; then
 			exit "$failed"
 		fi

--- a/c/detype1/build/linux/gcc/BuildAll.sh
+++ b/c/detype1/build/linux/gcc/BuildAll.sh
@@ -3,28 +3,28 @@ set -e
 set -x
 
 target=detype1
-curdir=`pwd`
+curdir=$(pwd)
 
-if [ -z "$1" ] || [ $1 = "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	cd release
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/release/$target ../../../../build_all
-elif [ $1 = "debug" ]
+elif [ "$1" = "debug" ]
 then
 	cd debug
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/debug/$target ../../../../build_all
-elif [ $1 = "clean" ]
+elif [ "$1" = "clean" ]
 then
 	cd release
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 	cd debug
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/detype1/build/osx/xcode4/BuildAll.sh
+++ b/c/detype1/build/osx/xcode4/BuildAll.sh
@@ -4,18 +4,18 @@ set -x
 
 target=detype1
 
-if [ -z "$1" ] || [ "$1" == "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../build_all
-elif [ "$1" == "debug" ]
+elif [ "$1" = "debug" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Debug
 	cp ../../../exe/osx/debug/$target ../../../../build_all
-elif [ "$1" == "clean" ]
+elif [ "$1" = "clean" ]
 then
-	xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1
-	xcodebuild -target $target -project $target.xcodeproj -configuration Release $1
+	xcodebuild -target $target -project $target.xcodeproj -configuration Debug "$1"
+	xcodebuild -target $target -project $target.xcodeproj -configuration Release "$1"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/makeotf/build/linux/gcc/BuildAll.sh
+++ b/c/makeotf/build/linux/gcc/BuildAll.sh
@@ -3,28 +3,28 @@ set -e
 set -x
 
 target=makeotfexe
-curdir=`pwd`
+curdir=$(pwd)
 
-if [ -z "$1" ] || [ $1 = "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	cd release
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/release/$target ../../../../build_all
-elif [ $1 = "debug" ]
+elif [ "$1" = "debug" ]
 then
 	cd debug
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/debug/$target ../../../../build_all
-elif [ $1 = "clean" ]
+elif [ "$1" = "clean" ]
 then
 	cd release
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 	cd debug
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/makeotf/build/osx/xcode4/BuildAll.sh
+++ b/c/makeotf/build/osx/xcode4/BuildAll.sh
@@ -4,18 +4,18 @@ set -x
 
 target=makeotf
 
-if [ -z "$1" ] || [ "$1" == "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/${target}exe ../../../../build_all
-elif [ "$1" == "debug" ]
+elif [ "$1" = "debug" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug
 	cp ../../../exe/osx/debug/${target}exe ../../../../build_all
-elif [ "$1" == "clean" ]
+elif [ "$1" = "clean" ]
 then
-	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1
-	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release $1
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug "$1"
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release "$1"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/mergefonts/build/linux/gcc/BuildAll.sh
+++ b/c/mergefonts/build/linux/gcc/BuildAll.sh
@@ -3,28 +3,28 @@ set -e
 set -x
 
 target=mergefonts
-curdir=`pwd`
+curdir=$(pwd)
 
-if [ -z "$1" ] || [ $1 = "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	cd release
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/release/$target ../../../../build_all
-elif [ $1 = "debug" ]
+elif [ "$1" = "debug" ]
 then
 	cd debug
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/debug/$target ../../../../build_all
-elif [ $1 = "clean" ]
+elif [ "$1" = "clean" ]
 then
 	cd release
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 	cd debug
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/mergefonts/build/osx/xcode4/BuildAll.sh
+++ b/c/mergefonts/build/osx/xcode4/BuildAll.sh
@@ -4,18 +4,18 @@ set -x
 
 target=mergefonts
 
-if [ -z "$1" ] || [ "$1" == "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../build_all
-elif [ "$1" == "debug" ]
+elif [ "$1" = "debug" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug
 	cp ../../../exe/osx/debug/$target ../../../../build_all
-elif [ "$1" == "clean" ]
+elif [ "$1" = "clean" ]
 then
-	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1
-	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release $1
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug "$1"
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release "$1"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/rotatefont/build/linux/gcc/BuildAll.sh
+++ b/c/rotatefont/build/linux/gcc/BuildAll.sh
@@ -3,28 +3,28 @@ set -e
 set -x
 
 target=rotatefont
-curdir=`pwd`
+curdir=$(pwd)
 
-if [ -z "$1" ] || [ $1 = "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	cd release
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/release/$target ../../../../build_all
-elif [ $1 = "debug" ]
+elif [ "$1" = "debug" ]
 then
 	cd debug
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/debug/$target ../../../../build_all
-elif [ $1 = "clean" ]
+elif [ "$1" = "clean" ]
 then
 	cd release
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 	cd debug
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/rotatefont/build/osx/xcode4/BuildAll.sh
+++ b/c/rotatefont/build/osx/xcode4/BuildAll.sh
@@ -4,18 +4,18 @@ set -x
 
 target=rotatefont
 
-if [ -z "$1" ] || [ "$1" == "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../build_all
-elif [ "$1" == "debug" ]
+elif [ "$1" = "debug" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug
 	cp ../../../exe/osx/debug/$target ../../../../build_all
-elif [ "$1" == "clean" ]
+elif [ "$1" = "clean" ]
 then
-	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1
-	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release $1
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug "$1"
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release "$1"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/sfntdiff/build/linux/gcc/BuildAll.sh
+++ b/c/sfntdiff/build/linux/gcc/BuildAll.sh
@@ -3,28 +3,28 @@ set -e
 set -x
 
 target=sfntdiff
-curdir=`pwd`
+curdir=$(pwd)
 
-if [ -z "$1" ] || [ $1 = "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	cd release
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/release/$target ../../../../build_all
-elif [ $1 = "debug" ]
+elif [ "$1" = "debug" ]
 then
 	cd debug
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/debug/$target ../../../../build_all
-elif [ $1 = "clean" ]
+elif [ "$1" = "clean" ]
 then
 	cd release
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 	cd debug
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/sfntdiff/build/osx/xcode4/BuildAll.sh
+++ b/c/sfntdiff/build/osx/xcode4/BuildAll.sh
@@ -4,18 +4,18 @@ set -x
 
 target=sfntdiff
 
-if [ -z "$1" ] || [ "$1" == "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../build_all
-elif [ "$1" == "debug" ]
+elif [ "$1" = "debug" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Debug
 	cp ../../../exe/osx/debug/$target ../../../../build_all
-elif [ "$1" == "clean" ]
+elif [ "$1" = "clean" ]
 then
-	xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1
-	xcodebuild -target $target -project $target.xcodeproj -configuration Release $1
+	xcodebuild -target $target -project $target.xcodeproj -configuration Debug "$1"
+	xcodebuild -target $target -project $target.xcodeproj -configuration Release "$1"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/sfntedit/build/linux/gcc/BuildAll.sh
+++ b/c/sfntedit/build/linux/gcc/BuildAll.sh
@@ -3,28 +3,28 @@ set -e
 set -x
 
 target=sfntedit
-curdir=`pwd`
+curdir=$(pwd)
 
-if [ -z "$1" ] || [ $1 = "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	cd release
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/release/$target ../../../../build_all
-elif [ $1 = "debug" ]
+elif [ "$1" = "debug" ]
 then
 	cd debug
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/debug/$target ../../../../build_all
-elif [ $1 = "clean" ]
+elif [ "$1" = "clean" ]
 then
 	cd release
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 	cd debug
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/sfntedit/build/osx/xcode4/BuildAll.sh
+++ b/c/sfntedit/build/osx/xcode4/BuildAll.sh
@@ -4,18 +4,18 @@ set -x
 
 target=sfntedit
 
-if [ -z "$1" ] || [ "$1" == "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../build_all
-elif [ "$1" == "debug" ]
+elif [ "$1" = "debug" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Debug
 	cp ../../../exe/osx/debug/$target ../../../../build_all
-elif [ "$1" == "clean" ]
+elif [ "$1" = "clean" ]
 then
-	xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1
-	xcodebuild -target $target -project $target.xcodeproj -configuration Release $1
+	xcodebuild -target $target -project $target.xcodeproj -configuration Debug "$1"
+	xcodebuild -target $target -project $target.xcodeproj -configuration Release "$1"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/spot/build/linux/gcc/BuildAll.sh
+++ b/c/spot/build/linux/gcc/BuildAll.sh
@@ -3,28 +3,28 @@ set -e
 set -x
 
 target=spot
-curdir=`pwd`
+curdir=$(pwd)
 
-if [ -z "$1" ] || [ $1 = "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	cd release
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/release/$target ../../../../build_all
-elif [ $1 = "debug" ]
+elif [ "$1" = "debug" ]
 then
 	cd debug
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/debug/$target ../../../../build_all
-elif [ $1 = "clean" ]
+elif [ "$1" = "clean" ]
 then
 	cd release
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 	cd debug
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/spot/build/osx/xcode4/BuildAll.sh
+++ b/c/spot/build/osx/xcode4/BuildAll.sh
@@ -4,18 +4,18 @@ set -x
 
 target=spot
 
-if [ -z "$1" ] || [ "$1" == "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../build_all
-elif [ "$1" == "debug" ]
+elif [ "$1" = "debug" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Debug
 	cp ../../../exe/osx/debug/$target ../../../../build_all
-elif [ "$1" == "clean" ]
+elif [ "$1" = "clean" ]
 then
-	xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1
-	xcodebuild -target $target -project $target.xcodeproj -configuration Release $1
+	xcodebuild -target $target -project $target.xcodeproj -configuration Debug "$1"
+	xcodebuild -target $target -project $target.xcodeproj -configuration Release "$1"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/tx/build/linux/gcc/BuildAll.sh
+++ b/c/tx/build/linux/gcc/BuildAll.sh
@@ -3,28 +3,28 @@ set -e
 set -x
 
 target=tx
-curdir=`pwd`
+curdir=$(pwd)
 
-if [ -z "$1" ] || [ $1 = "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	cd release
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/release/$target ../../../../build_all
-elif [ $1 = "debug" ]
+elif [ "$1" = "debug" ]
 then
 	cd debug
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/debug/$target ../../../../build_all
-elif [ $1 = "clean" ]
+elif [ "$1" = "clean" ]
 then
 	cd release
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 	cd debug
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/tx/build/osx/xcode4/BuildAll.sh
+++ b/c/tx/build/osx/xcode4/BuildAll.sh
@@ -4,18 +4,18 @@ set -x
 
 target=tx
 
-if [ -z "$1" ] || [ "$1" == "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../build_all
-elif [ "$1" == "debug" ]
+elif [ "$1" = "debug" ]
 then
 	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug
 	cp ../../../exe/osx/debug/$target ../../../../build_all
-elif [ "$1" == "clean" ]
+elif [ "$1" = "clean" ]
 then
-	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug $1
-	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release $1
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Debug "$1"
+	xcodebuild -target BuildAll -project $target.xcodeproj -configuration Release "$1"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/type1/build/linux/gcc/BuildAll.sh
+++ b/c/type1/build/linux/gcc/BuildAll.sh
@@ -3,28 +3,28 @@ set -e
 set -x
 
 target=type1
-curdir=`pwd`
+curdir=$(pwd)
 
-if [ -z "$1" ] || [ $1 = "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	cd release
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/release/$target ../../../../build_all
-elif [ $1 = "debug" ]
+elif [ "$1" = "debug" ]
 then
 	cd debug
 	make
-	cd $curdir
+	cd "$curdir"
 	cp -dR ../../../exe/linux/debug/$target ../../../../build_all
-elif [ $1 = "clean" ]
+elif [ "$1" = "clean" ]
 then
 	cd release
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 	cd debug
-	make $1
-	cd $curdir
+	make "$1"
+	cd "$curdir"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi

--- a/c/type1/build/osx/xcode4/BuildAll.sh
+++ b/c/type1/build/osx/xcode4/BuildAll.sh
@@ -4,18 +4,18 @@ set -x
 
 target=type1
 
-if [ -z "$1" ] || [ "$1" == "release" ]
+if [ -z "$1" ] || [ "$1" = "release" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Release
 	cp ../../../exe/osx/release/$target ../../../../build_all
-elif [ "$1" == "debug" ]
+elif [ "$1" = "debug" ]
 then
 	xcodebuild -target $target -project $target.xcodeproj -configuration Debug
 	cp ../../../exe/osx/debug/$target ../../../../build_all
-elif [ "$1" == "clean" ]
+elif [ "$1" = "clean" ]
 then
-	xcodebuild -target $target -project $target.xcodeproj -configuration Debug $1
-	xcodebuild -target $target -project $target.xcodeproj -configuration Release $1
+	xcodebuild -target $target -project $target.xcodeproj -configuration Debug "$1"
+	xcodebuild -target $target -project $target.xcodeproj -configuration Release "$1"
 else
    echo "Build target must be 'release', 'debug', 'clean', or simply omitted (same as 'release')"
 fi


### PR DESCRIPTION
Out of all the files in the `c` folder, the only two with a grade of "F" on Codacy were shell scripts, so I cleaned up all the shell scripts to get a clean report from `shellcheck` (the tool used by Codacy to analyze shell scripts).