### PR TITLE
setup.py: build 'universal' py2.py3 wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal=0
-
 [metadata]
 license_file = LICENSE.md

--- a/setup.py
+++ b/setup.py
@@ -13,19 +13,21 @@ import setuptools.command.build_py
 import setuptools.command.install
 from setuptools import setup
 
-"""
-We need a customized version of the 'bdist_wheel' command, because otherwise
-the wheel is identified as being non-platform specific. This is because the
-afdko has no Python extensions and the command line tools are installed as
-data files.
-"""
 try:
     from wheel.bdist_wheel import bdist_wheel
 
     class CustomBDistWheel(bdist_wheel):
+        """Mark the wheel as "universal" (both python 2 and 3), yet
+        platform-specific, since it contains native C executables.
+        """
+
         def finalize_options(self):
             bdist_wheel.finalize_options(self)
             self.root_is_pure = False
+
+        def get_tag(self):
+            return ('py2.py3', 'none',) + bdist_wheel.get_tag(self)[2:]
+
 except ImportError:
     print("afdko: setup.py requires that the Python package 'wheel' be "
           "installed. Try the command 'pip install wheel'.")


### PR DESCRIPTION
the afdko doesn't include any extenstion modules, only native C executables. These are independent from the Python version, they only depend on the system's platform and architecture (32 vs 64 bit).

You can greatly reduce the number of wheel packages that you build and publish if you name the wheels with a "universal" `py2.py3` tag, an ABI tag of "none" (meaning it does not depend on CPython ABI), and with a platform tag that reflects the different platforms and architecture supported (Linux, MacOS, Windows, 32 vs 64 bit, etc. all automatically selected by bdist_wheel command).

I used the same approach in ttfautohint-py, where I bundle a DLL of libttfautohint (wrapped via ctypes). It reduced the number of wheels I publish to only 4: 1 for macOS (a fat "intel" binary including both 32 and 64 bits); 1 for linux (only the `manylinux1_x86_64`, the `i686` or 32-bit version is not really needed on linux desktop any more); and finally 2 for windows, `win32` and `win_amd64` (on Windows, 32 bit Pythons are still a thing, since the default url from Python.org is still the `win32` version, but I encourage everyone to download the 64 bit version instead).

Since the wheel is universal, you can build it either with py27 or with py37 or whatever. It will be the same.