### PR TITLE
Fix release date

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.7.2 (released 2018-07-27)
+2.7.2 (released 2018-06-27)
 ---------------------------
 
 - Implemented an integration testing framework


### PR DESCRIPTION
Making fix in 'master' to avoid conflict when trying to merge 'release'.
This change was originally made in 4590c75e603362b63a8c71bf01dd9ef5cabd2c12