### PR TITLE
Removed Windows-specific replacements for C stdlib functions...

### DIFF
--- a/c/makeotf/source/cb.c
+++ b/c/makeotf/source/cb.c
@@ -648,37 +648,11 @@ static void uvsClose(void *ctx) {
 
 /* --------------------------- Temporary file I/O -------------------------- */
 
-/* On Windows, the stdio.h 'tmpfile' function tries to make temp files in the root
-directory, thus requiring administrative privileges. So we first need to use '_tempnam'
-to generate a unique filename inside the user's TMP environment variable (or the
-current working directory if TMP is not defined). Then we open the temporary file
-and return its pointer */
-static FILE *_tmpfile() {
-    FILE *fp;
-#ifdef _WIN32
-    char *tempname;
-    tempname = _tempnam(NULL, "tx_tmpfile");
-    if (tempname != NULL) {
-        int fd, flags, mode;
-        flags = _O_BINARY | _O_CREAT | _O_EXCL | _O_RDWR | _O_TEMPORARY;
-        mode = _S_IREAD | _S_IWRITE;
-        fd = _open(tempname, flags, mode);
-        if (fd != -1)
-            fp = _fdopen(fd, "w+b");
-        free(tempname);
-    }
-#else
-    /* Use the default tmpfile on non-Windows platforms */
-    fp = tmpfile();
-#endif
-    return fp;
-}
-
 /* [hot callback] Open temporary file */
 static void tmpOpen(void *ctx) {
     cbCtx h = ctx;
     h->tmp.file.name = "tmpfile";
-    if ((h->tmp.file.fp = _tmpfile()) == NULL) {
+    if ((h->tmp.file.fp = tmpfile()) == NULL) {
         fileError(&h->tmp.file);
     }
 }

--- a/c/mergefonts/source/mergeFonts.c
+++ b/c/mergefonts/source/mergeFonts.c
@@ -732,38 +732,11 @@ static void tmpSet(Stream *s, char *filename) {
     s->pos = 0;
 }
 
-/* On Windows, the stdio.h 'tmpfile' function tries to make temp files in the root
-directory, thus requiring administrative privileges. So we first need to use '_tempnam'
-to generate a unique filename inside the user's TMP environment variable (or the
-current working directory if TMP is not defined). Then we open the temporary file
-and return its pointer */
-static FILE *_tmpfile() {
-#ifdef _WIN32
-    FILE *fp = NULL;
-    char *tempname;
-    int flags, mode;
-    flags = _O_BINARY | _O_CREAT | _O_EXCL | _O_RDWR | _O_TEMPORARY;
-    mode = _S_IREAD | _S_IWRITE;
-    tempname = _tempnam(NULL, "tx_tmpfile");
-    if (tempname != NULL) {
-        int fd = _open(tempname, flags, mode);
-        if (fd != -1)
-            fp = _fdopen(fd, "w+b");
-        free(tempname);
-    }
-#else
-    FILE *fp;
-    /* Use the default tmpfile on non-Windows platforms */
-    fp = tmpfile();
-#endif
-    return fp;
-}
-
 /* Open tmp stream. */
 static Stream *tmp_open(txCtx h, Stream *s) {
     s->buf = memNew(h, TMPSIZE + BUFSIZ);
     memset(s->buf, 0, TMPSIZE + BUFSIZ);
-    s->fp = _tmpfile();
+    s->fp = tmpfile();
     if (s->fp == NULL)
         fileError(h, s->filename);
     return s;
@@ -2970,7 +2943,7 @@ static void copyPFBSegment(txCtx h, int type, long length,
 static void writePFB(txCtx h, FILE *font, char *fontfile,
                      long begBinary, long begTrailer, long endTrailer) {
     char *tmpfil = "(t1w) reformat tmpfil";
-    FILE *tmp = _tmpfile();
+    FILE *tmp = tmpfile();
     if (tmp == NULL)
         fileError(h, tmpfil);
 
@@ -3084,7 +3057,7 @@ static void writeLWFN(txCtx h, FILE *font, char *fontfile,
     long datalen = rescnt * (4 + 1 + 1) + endTrailer;
     long maplen = MAP_HEADER_LEN + TYPE_LIST_LEN + rescnt * REFERENCE_LEN;
     char *tmpfil = "(t1w) reformat tmpfile";
-    FILE *tmp = _tmpfile();
+    FILE *tmp = tmpfile();
     if (tmp == NULL)
         fileError(h, tmpfil);
 

--- a/c/public/lib/source/uforead/uforead.c
+++ b/c/public/lib/source/uforead/uforead.c
@@ -64,9 +64,6 @@ typedef struct
 typedef unsigned short STI; /* String index */
 #define STI_UNDEF 0xffff    /* Undefined string index */
 #define ARRAY_LEN(a) (sizeof(a) / sizeof(a[0]))
-#ifdef _WIN32
-#define round round_int
-#endif
 
 enum {
 #define DCL_KEY(key, index) index,
@@ -696,12 +693,6 @@ static token* getElementValue(ufoCtx h, int state) {
 
     return tk;
 }
-
-#if _WIN32
-static int round_int(double r) {
-    return (int)((r > 0.0) ? (r + 0.5) : (r - 0.5));
-}
-#endif
 
 /* Construct matrix from args. */
 static void setTransformMtx(Transform* transform,

--- a/c/public/lib/source/ufowrite/ufowrite.c
+++ b/c/public/lib/source/ufowrite/ufowrite.c
@@ -21,9 +21,6 @@
 #define XML_HEADER "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
 #define PLIST_DTD_HEADER "<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">"
 
-#ifdef _WIN32
-#define round round_int
-#endif
 /* ---------------------------- Library Context ---------------------------- */
 
 typedef struct /* Glyph data */
@@ -106,12 +103,6 @@ static void fatal(ufwCtx h, int err_code) {
     h->err.code = err_code;
     RAISE(&h->err.env, err_code, NULL);
 }
-
-#if _WIN32
-static int round_int(double r) {
-    return (int)((r > 0.0) ? (r + 0.5) : (r - 0.5));
-}
-#endif
 
 /* --------------------------- Destination Stream -------------------------- */
 

--- a/c/rotatefont/source/rotateFont.c
+++ b/c/rotatefont/source/rotateFont.c
@@ -678,38 +678,11 @@ static void tmpSet(Stream *s, char *filename) {
     s->pos = 0;
 }
 
-/* On Windows, the stdio.h 'tmpfile' function tries to make temp files in the root
-directory, thus requiring administrative privileges. So we first need to use '_tempnam'
-to generate a unique filename inside the user's TMP environment variable (or the
-current working directory if TMP is not defined). Then we open the temporary file
-and return its pointer */
-static FILE *_tmpfile() {
-#ifdef _WIN32
-    FILE *fp = NULL;
-    char *tempname;
-    int flags, mode;
-    flags = _O_BINARY | _O_CREAT | _O_EXCL | _O_RDWR | _O_TEMPORARY;
-    mode = _S_IREAD | _S_IWRITE;
-    tempname = _tempnam(NULL, "tx_tmpfile");
-    if (tempname != NULL) {
-        int fd = _open(tempname, flags, mode);
-        if (fd != -1)
-            fp = _fdopen(fd, "w+b");
-        free(tempname);
-    }
-#else
-    FILE *fp;
-    /* Use the default tmpfile on non-Windows platforms */
-    fp = tmpfile();
-#endif
-    return fp;
-}
-
 /* Open tmp stream. */
 static Stream *tmp_open(txCtx h, Stream *s) {
     s->buf = memNew(h, TMPSIZE + BUFSIZ);
     memset(s->buf, 0, TMPSIZE + BUFSIZ);
-    s->fp = _tmpfile();
+    s->fp = tmpfile();
     if (s->fp == NULL)
         fileError(h, s->filename);
     return s;
@@ -2814,7 +2787,7 @@ static void copyPFBSegment(txCtx h, int type, long length,
 static void writePFB(txCtx h, FILE *font, char *fontfile,
                      long begBinary, long begTrailer, long endTrailer) {
     char *tmpfil = "(t1w) reformat tmpfil";
-    FILE *tmp = _tmpfile();
+    FILE *tmp = tmpfile();
     if (tmp == NULL)
         fileError(h, tmpfil);
 
@@ -2928,7 +2901,7 @@ static void writeLWFN(txCtx h, FILE *font, char *fontfile,
     long datalen = rescnt * (4 + 1 + 1) + endTrailer;
     long maplen = MAP_HEADER_LEN + TYPE_LIST_LEN + rescnt * REFERENCE_LEN;
     char *tmpfil = "(t1w) reformat tmpfile";
-    FILE *tmp = _tmpfile();
+    FILE *tmp = tmpfile();
     if (tmp == NULL)
         fileError(h, tmpfil);
 

--- a/c/spot/source/CFF_.c
+++ b/c/spot/source/CFF_.c
@@ -120,17 +120,6 @@ static char *syntheticGlyphs[] = {"Delta", "Euro", "Omega", "approxequal", "asci
 
 static Byte8 *workstr = NULL;
 
-#if _WIN32
-#define round round_double
-static double round_double(double r) {
-    /* I return double as this is mostly used to round values for float or
-       double printf format specifiers, and since I hope to remove this code
-       soon when we move to VS 2017, it is less work to do an extra cast here
-       than change all the printf format statements. */
-    return (double)((int)((r > 0.0) ? (r + 0.5) : (r - 0.5)));
-}
-#endif
-
 static void CFFfatal(void *ctx) {
     fatal(SPOT_MSG_CFFPARSING);
 }

--- a/c/tx/source/tx.c
+++ b/c/tx/source/tx.c
@@ -656,38 +656,11 @@ static void tmpSet(Stream *s, char *filename) {
     s->pos = 0;
 }
 
-/* On Windows, the stdio.h 'tmpfile' function tries to make temp files in the root
-directory, thus requiring administrative privileges. So we first need to use '_tempnam'
-to generate a unique filename inside the user's TMP environment variable (or the
-current working directory if TMP is not defined). Then we open the temporary file
-and return its pointer */
-static FILE *_tmpfile() {
-#ifdef _WIN32
-    FILE *fp = NULL;
-    char *tempname;
-    int flags, mode;
-    flags = _O_BINARY | _O_CREAT | _O_EXCL | _O_RDWR | _O_TEMPORARY;
-    mode = _S_IREAD | _S_IWRITE;
-    tempname = _tempnam(NULL, "tx_tmpfile");
-    if (tempname != NULL) {
-        int fd = _open(tempname, flags, mode);
-        if (fd != -1)
-            fp = _fdopen(fd, "w+b");
-        free(tempname);
-    }
-#else
-    FILE *fp;
-    /* Use the default tmpfile on non-Windows platforms */
-    fp = tmpfile();
-#endif
-    return fp;
-}
-
 /* Open tmp stream. */
 static Stream *tmp_open(txCtx h, Stream *s) {
     s->buf = memNew(h, TMPSIZE + BUFSIZ);
     memset(s->buf, 0, TMPSIZE + BUFSIZ);
-    s->fp = _tmpfile();
+    s->fp = tmpfile();
     if (s->fp == NULL)
         fileError(h, s->filename);
     return s;
@@ -2925,7 +2898,7 @@ static void copyPFBSegment(txCtx h, int type, long length,
 static void writePFB(txCtx h, FILE *font, char *fontfile,
                      long begBinary, long begTrailer, long endTrailer) {
     char *tmpfil = "(t1w) reformat tmpfil";
-    FILE *tmp = _tmpfile();
+    FILE *tmp = tmpfile();
     if (tmp == NULL)
         fileError(h, tmpfil);
 
@@ -3039,7 +3012,7 @@ static void writeLWFN(txCtx h, FILE *font, char *fontfile,
     long datalen = rescnt * (4 + 1 + 1) + endTrailer;
     long maplen = MAP_HEADER_LEN + TYPE_LIST_LEN + rescnt * REFERENCE_LEN;
     char *tmpfil = "(t1w) reformat tmpfile";
-    FILE *tmp = _tmpfile();
+    FILE *tmp = tmpfile();
     if (tmp == NULL)
         fileError(h, tmpfil);
 


### PR DESCRIPTION
...now that we're using VisualStudio 2017 for Windows builds:
* removed Windows-specific `tmpfile()` implementations
* removed Windows-specific `round()` implementations

resolves #535
