### PR TITLE
Fix outdated tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,8 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm"]
+# Temporarily pin wheel version to 0.31.1 as 0.32 breaks scikit-build
+# https://github.com/scikit-build/scikit-build/issues/360
+requires = [
+	"setuptools",
+	"wheel == 0.31.1",
+	"setuptools_scm"
+]

--- a/tests/tx_test.py
+++ b/tests/tx_test.py
@@ -34,6 +34,11 @@ PDF_SKIP = [
     '(Time:',
 ]
 
+PDF_SKIP_REGEX = [
+    '^.+30.00 Td',
+    '^.+0.00 Td',
+]
+
 PS_SKIP = [
     '0 740 moveto (Filename:' + SPLIT_MARKER +
     '560 (Date:' + SPLIT_MARKER +
@@ -98,16 +103,21 @@ def test_convert(from_format, to_format):
         diff_mode = []
 
     # skip items
+    regex_skip = []
+    skip = []
     if to_format == 'afm':
         skip = ['Comment Creation Date:']
     elif to_format == 'pdf':
         skip = PDF_SKIP[:]
+        regex_skip = PDF_SKIP_REGEX[:]
     elif to_format == 'ps':
         skip = PS_SKIP[:]
-    else:
-        skip = []
     if skip:
         skip.insert(0, '-s')
+    if regex_skip:
+        for regex in regex_skip:
+            skip.append('-r')
+            skip.append(regex)
 
     # format arg fix
     if to_format in ('ufo2', 'ufo3'):


### PR DESCRIPTION
The test tx_test.py::test_convert() tests were failing when converting ufo to PDF, because the positioning of the data and time stamps on the PDF page changed with the change of current date to Oct.:
```
498.50 30.00 Td
(Date:  24 Aug 18)'
16.00 0.00 Td
(Time:  14:53)'
```

Added regex's to skip the positioning lines containing '0.00 Td' and '30.00 Td', which are unique on the page and do not change with the date.