### PR TITLE
[makeinstancesufo] Fix RuntimeError

### DIFF
--- a/python/afdko/makeinstancesufo.py
+++ b/python/afdko/makeinstancesufo.py
@@ -267,7 +267,7 @@ def updateInstance(options, fontInstancePath):
 
 
 def clearCustomLibs(dFont):
-    for key in dFont.lib.keys():
+    for key in list(dFont.lib.keys()):
         if key not in ['public.glyphOrder', 'public.postscriptNames']:
             del(dFont.lib[key])
 


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "c:\program files\python36\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\program files\python36\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "c:\Program Files\Python36\Scripts\makeInstancesUFO.exe\__main__.py", line 9, in <module>
  File "c:\program files\python36\lib\site-packages\afdko\makeinstancesufo.py", line 421, in main
    run(sys.argv[1:])
  File "c:\program files\python36\lib\site-packages\afdko\makeinstancesufo.py", line 389, in run
    postProcessInstance(instancePath, options)
  File "c:\program files\python36\lib\site-packages\afdko\makeinstancesufo.py", line 357, in postProcessInstance
    clearCustomLibs(dFont)
  File "c:\program files\python36\lib\site-packages\afdko\makeinstancesufo.py", line 270, in clearCustomLibs
    for key in dFont.lib.keys():

RuntimeError: dictionary changed size during iteration
```