### PR TITLE
fix for [tx] -dcf fails to print CFF2 global subrs #678

### DIFF
--- a/c/public/lib/source/tx_shared/tx_shared.c
+++ b/c/public/lib/source/tx_shared/tx_shared.c
@@ -4156,6 +4156,7 @@ static void dcf_BegFont(txCtx h, abfTopDict *top) {
         h->maxOpStack = CFF2_MAX_OP_STACK;
         initCstrs(h, top);
         dcf_DumpTopDICT2(h, &single->TopDICTINDEX);
+        dcf_DumpGlobalSubrINDEX(h, &single->GlobalSubrINDEX);
     }
     dcf_DumpFDSelect(h, &single->FDSelect);
     dcf_DumpVarStore(h, &single->VarStore);

--- a/tests/tx_data/expected_output/cff2_vf.dcf.txt
+++ b/tests/tx_data/expected_output/cff2_vf.dcf.txt
@@ -9,6 +9,8 @@ offSize=0
   18 VarStore
   1336 FDArray
 }
+### GlobalSubrINDEX (0000000e-00000011)
+empty
 ### VarStore (00000012-00000039)
 length =38
 format = 1


### PR DESCRIPTION
Fix for the issue #678.
Attached a new output from a command line:
`tx -dcf AdobeVFPrototype.abc.subr.otf`

[after.dcf.txt](https://github.com/adobe-type-tools/afdko/files/2568870/after.dcf.txt)