### PR TITLE
[makeotfexe] Fix infinite loop

### DIFF
--- a/c/makeotf/makeotf_lib/source/hotconv/otl.c
+++ b/c/makeotf/makeotf_lib/source/hotconv/otl.c
@@ -1575,7 +1575,7 @@ static Offset fillFeatureList(hotCtx g, otlTbl t) {
     /* This works becuase prepFeature has sorted the subtables so that anon subtabes are last, preceded by Stand-Alone subtables */
     int spanLimit = t->subtable.cnt - (t->nAnonSubtables + t->nStandAloneSubtables);
 
-    nFeatures = t->subtable.array[spanLimit - 1].index.feature + 1;
+    nFeatures = spanLimit ? t->subtable.array[spanLimit - 1].index.feature + 1 : 0;
     /* Allocate features */
     t->tbl.FeatureList_.FeatureCount = nFeatures;
     t->tbl.FeatureList_.FeatureRecord =


### PR DESCRIPTION
On my system, `makeotfexe_test.py` enters into, what appears to be, an infinite loop in test_duplicate_single_sub test.

This seems to be caused by `nFeatures` variable in `fillFeatureList()` getting a random huge value when there are no features in the file, as `spanLimit` can be 0 and the code ends up trying to access `t->subtable.array[-1].index.feature`.