### PR TITLE
Allow 'subtable' statement in other than PairPos Format 2

### DIFF
--- a/docs/OpenTypeFeatureFileSpecification.html
+++ b/docs/OpenTypeFeatureFileSpecification.html
@@ -717,7 +717,7 @@ This software is licensed as OpenSource, under the Apache License, Version 2.0. 
 <pre>
   <b>subtable</b>;</pre>
 <p>to explicitly force a subtable break after the previous rule.</p>
-<p>This is intended for use with only Pair Adjustment Positioning Format 2 (i.e. pair class kerning). See <a href="#6.b.iii"><i>6.b.iii</i></a> for details. This hint to the compiler is required for class kerning, as it is difficult for a compiler to determine where to best place a subtable break in this lookup type, in order to reduce lookup size.</p>
+<p>This statement must be respected in Pair Adjustment Positioning Format 2 (i.e. pair class kerning) but in other cases may be ignored and the implementation software may insert its own subtable breaks. See <a href="#6.b.iii"><i>6.b.iii</i></a> for details. This hint to the compiler is required for class kerning, as it is difficult for a compiler to determine where to best place a subtable break in this lookup type, in order to reduce lookup size.</p>
 <p><a name="4.h"></a><b>4.h. Examples</b></p>
 <p><b>Example 1.</b> The following is an example of an entire feature file and demonstrates the two ways to register features under language systems (see &sect;<a href="#4.b">4.b</a> above):</p>
 <pre>


### PR DESCRIPTION
As a follow up to [[feaLib] Support subtable statement in more places](https://github.com/fonttools/fonttools/pull/1520). This changes the description of the `subtable` statement, allowing it for other than PairPos Format 2, in which case it may be ignored by implementation software.