### PR TITLE
[mergefonts] explicitly zero out new dynamic array memory

### DIFF
--- a/c/mergefonts/build/osx/xcode/mergeFonts.xcodeproj/project.pbxproj
+++ b/c/mergefonts/build/osx/xcode/mergeFonts.xcodeproj/project.pbxproj
@@ -1005,13 +1005,14 @@
 			};
 			buildConfigurationList = 1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "mergeFonts" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
+				ja,
+				en,
+				de,
+				Base,
+				fr,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* cvt2sing */;
 			projectDirPath = "";

--- a/c/public/lib/build/absfont/osx/xcode/absfont.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/absfont/osx/xcode/absfont.xcodeproj/project.pbxproj
@@ -152,13 +152,14 @@
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "absfont" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
+				de,
+				ja,
+				fr,
+				en,
+				Base,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";

--- a/c/public/lib/build/cfembed/osx/xcode/cfembed.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/cfembed/osx/xcode/cfembed.xcodeproj/project.pbxproj
@@ -125,14 +125,15 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "cfembed" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";
@@ -176,6 +177,7 @@
 			baseConfigurationReference = BDA34BAE0D6F46BD0009FF85 /* debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -210,6 +212,7 @@
 			baseConfigurationReference = BDA34BAE0D6F46BD0009FF85 /* debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;

--- a/c/public/lib/build/cffread/osx/xcode/cffread.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/cffread/osx/xcode/cffread.xcodeproj/project.pbxproj
@@ -129,13 +129,14 @@
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "cffread" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
+				de,
+				ja,
+				fr,
+				Base,
+				en,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";

--- a/c/public/lib/build/cffwrite/osx/xcode/cffwrite.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/cffwrite/osx/xcode/cffwrite.xcodeproj/project.pbxproj
@@ -195,13 +195,14 @@
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "cffwrite" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
+				de,
+				fr,
+				Base,
+				ja,
+				en,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";

--- a/c/public/lib/build/ctutil/osx/xcode/ctutil.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/ctutil/osx/xcode/ctutil.xcodeproj/project.pbxproj
@@ -125,14 +125,15 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "ctutil" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";
@@ -178,6 +179,7 @@
 			baseConfigurationReference = BDA34BAE0D6F46BD0009FF85 /* debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -212,6 +214,7 @@
 			baseConfigurationReference = BDA34BAF0D6F46BD0009FF85 /* release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;

--- a/c/public/lib/build/dynarr/osx/xcode/dynarr.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/dynarr/osx/xcode/dynarr.xcodeproj/project.pbxproj
@@ -125,14 +125,15 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "dynarr" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";
@@ -178,6 +179,7 @@
 			baseConfigurationReference = BDA34BAE0D6F46BD0009FF85 /* debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -212,6 +214,7 @@
 			baseConfigurationReference = BDA34BAF0D6F46BD0009FF85 /* release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;

--- a/c/public/lib/build/nameread/osx/xcode/nameread.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/nameread/osx/xcode/nameread.xcodeproj/project.pbxproj
@@ -131,13 +131,14 @@
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "nameread" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
+				en,
+				ja,
+				Base,
+				fr,
+				de,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";

--- a/c/public/lib/build/pdfwrite/osx/xcode/pdfwrite.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/pdfwrite/osx/xcode/pdfwrite.xcodeproj/project.pbxproj
@@ -127,14 +127,15 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "pdfwrite" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";
@@ -180,6 +181,7 @@
 			baseConfigurationReference = BD8A5ABA0D6F8FA900301916 /* debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -214,6 +216,7 @@
 			baseConfigurationReference = BD8A5AB90D6F8FA900301916 /* release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;

--- a/c/public/lib/build/pstoken/osx/xcode/pstoken.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/pstoken/osx/xcode/pstoken.xcodeproj/project.pbxproj
@@ -133,14 +133,15 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "pstoken" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";
@@ -186,6 +187,7 @@
 			baseConfigurationReference = BDA34BAE0D6F46BD0009FF85 /* debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -220,6 +222,7 @@
 			baseConfigurationReference = BDA34BAF0D6F46BD0009FF85 /* release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;

--- a/c/public/lib/build/sfntread/osx/xcode/sfntread.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/sfntread/osx/xcode/sfntread.xcodeproj/project.pbxproj
@@ -125,14 +125,15 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "sfntread" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";
@@ -178,6 +179,7 @@
 			baseConfigurationReference = BDA34BAE0D6F46BD0009FF85 /* debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -212,6 +214,7 @@
 			baseConfigurationReference = BDA34BAF0D6F46BD0009FF85 /* release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;

--- a/c/public/lib/build/sfntwrite/osx/xcode/sfntwrite.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/sfntwrite/osx/xcode/sfntwrite.xcodeproj/project.pbxproj
@@ -125,14 +125,15 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "sfntwrite" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";
@@ -178,6 +179,7 @@
 			baseConfigurationReference = BDA34BAE0D6F46BD0009FF85 /* debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -212,6 +214,7 @@
 			baseConfigurationReference = BDA34BAF0D6F46BD0009FF85 /* release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;

--- a/c/public/lib/build/sha1/osx/xcode/sha1.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/sha1/osx/xcode/sha1.xcodeproj/project.pbxproj
@@ -119,14 +119,15 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "sha1" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";
@@ -172,6 +173,7 @@
 			baseConfigurationReference = BD8A5ABA0D6F8FA900301916 /* debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -206,6 +208,7 @@
 			baseConfigurationReference = BD8A5AB90D6F8FA900301916 /* release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;

--- a/c/public/lib/build/support/osx/xcode/support.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/support/osx/xcode/support.xcodeproj/project.pbxproj
@@ -145,14 +145,15 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "support" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";
@@ -200,6 +201,7 @@
 			baseConfigurationReference = BD8A5ABA0D6F8FA900301916 /* debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -234,6 +236,7 @@
 			baseConfigurationReference = BD8A5AB90D6F8FA900301916 /* release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;

--- a/c/public/lib/build/svgwrite/osx/xcode/svgwrite.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/svgwrite/osx/xcode/svgwrite.xcodeproj/project.pbxproj
@@ -139,13 +139,14 @@
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "svgwrite" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
+				de,
+				Base,
+				fr,
+				en,
+				ja,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";

--- a/c/public/lib/build/svread/osx/xcode/svread.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/svread/osx/xcode/svread.xcodeproj/project.pbxproj
@@ -137,13 +137,14 @@
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "svread" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
+				en,
+				fr,
+				de,
+				Base,
+				ja,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";

--- a/c/public/lib/build/t1cstr/osx/xcode/t1cstr.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/t1cstr/osx/xcode/t1cstr.xcodeproj/project.pbxproj
@@ -133,13 +133,14 @@
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "t1cstr" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
+				de,
+				ja,
+				en,
+				Base,
+				fr,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";

--- a/c/public/lib/build/t1read/osx/xcode/t1read.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/t1read/osx/xcode/t1read.xcodeproj/project.pbxproj
@@ -133,13 +133,14 @@
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "t1read" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
+				en,
+				ja,
+				fr,
+				de,
+				Base,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";

--- a/c/public/lib/build/t1write/osx/xcode/t1write.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/t1write/osx/xcode/t1write.xcodeproj/project.pbxproj
@@ -171,13 +171,14 @@
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "t1write" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
+				de,
+				en,
+				Base,
+				fr,
+				ja,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";

--- a/c/public/lib/build/t2cstr/osx/xcode/t2cstr.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/t2cstr/osx/xcode/t2cstr.xcodeproj/project.pbxproj
@@ -133,13 +133,14 @@
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "t2cstr" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
+				en,
+				Base,
+				ja,
+				fr,
+				de,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";

--- a/c/public/lib/build/ttread/osx/xcode/ttread.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/ttread/osx/xcode/ttread.xcodeproj/project.pbxproj
@@ -129,13 +129,14 @@
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "ttread" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
+				de,
+				Base,
+				en,
+				fr,
+				ja,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";

--- a/c/public/lib/build/tx_shared/osx/xcode/tx_shared.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/tx_shared/osx/xcode/tx_shared.xcodeproj/project.pbxproj
@@ -110,7 +110,7 @@
 		DE8577C52192544500D4F584 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = Adobe;
 				TargetAttributes = {
 					DE8577CC2192544500D4F584 = {
@@ -124,6 +124,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = DE8577C42192544500D4F584;
 			productRefGroup = DE8577CE2192544500D4F584 /* Products */;
@@ -264,7 +265,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DEB51F1521936C12003011C0 /* debug.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "compiler-default";
 				CLANG_CXX_LIBRARY = "compiler-default";
@@ -296,7 +296,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DEB51F1621936C1F003011C0 /* release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "compiler-default";
 				CLANG_CXX_LIBRARY = "compiler-default";

--- a/c/public/lib/build/uforead/osx/xcode/uforead.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/uforead/osx/xcode/uforead.xcodeproj/project.pbxproj
@@ -137,13 +137,14 @@
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "uforead" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
+				en,
+				fr,
+				ja,
+				de,
+				Base,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";

--- a/c/public/lib/build/ufowrite/osx/xcode/ufowrite.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/ufowrite/osx/xcode/ufowrite.xcodeproj/project.pbxproj
@@ -139,13 +139,14 @@
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "ufowrite" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
+				Base,
+				en,
+				ja,
+				fr,
+				de,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";

--- a/c/public/lib/build/varread/osx/xcode/varread.xcodeproj/project.pbxproj
+++ b/c/public/lib/build/varread/osx/xcode/varread.xcodeproj/project.pbxproj
@@ -127,14 +127,15 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "varread" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* absfont */;
 			projectDirPath = "";
@@ -180,6 +181,7 @@
 			baseConfigurationReference = BD8A5ABA0D6F8FA900301916 /* debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -214,6 +216,7 @@
 			baseConfigurationReference = BD8A5AB90D6F8FA900301916 /* release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;

--- a/c/public/lib/source/dynarr/dynarr.c
+++ b/c/public/lib/source/dynarr/dynarr.c
@@ -99,6 +99,10 @@ long dnaGrow(void *object, size_t elemsize, long index) {
     if (new_ptr == NULL) {
         return -1; /* Allocation failed */
     }
+
+    /* explictly zero out the new memory before initialization */
+    memset((char *)new_ptr + (da->size * elemsize), 0, (new_size - da->size) * elemsize);
+
     if (da->func != NULL) {
         /* Initialize newly allocated elements */
         /* 64-bit warning fixed by cast here */

--- a/c/public/lib/source/uforead/uforead.c
+++ b/c/public/lib/source/uforead/uforead.c
@@ -3607,7 +3607,6 @@ int ufoBegFont(ufoCtx h, long flags, abfTopDict** top, char* altLayerDir) {
 int ufoEndFont(ufoCtx h) {
     if (h->stm.src)
         h->cb.stm.close(&h->cb.stm, h->stm.src);
-    memFree(h, h->top.FullName.ptr);
     return ufoSuccess;
 }
 

--- a/c/public/lib/source/uforead/uforead.c
+++ b/c/public/lib/source/uforead/uforead.c
@@ -1106,10 +1106,10 @@ static int matchGLIFOrderRec(const void* key, const void* value, void* ctx) {
 
 static long getGlyphOrderIndex(ufoCtx h, char* glyphName) {
     long orderIndex = ABF_UNSET_INT;
-    int recIndex = 0;
+    size_t recIndex = 0;
 
     if (ctuLookup(glyphName, h->data.glifOrder.array, h->data.glifOrder.cnt,
-                  sizeof(h->data.glifOrder.array[0]), matchGLIFOrderRec, (size_t*)&recIndex, h)) {
+                  sizeof(h->data.glifOrder.array[0]), matchGLIFOrderRec, &recIndex, h)) {
         orderIndex = h->data.glifOrder.array[recIndex].order;
     } else {
         message(h, "Warning: glyph order does not contain glyph name '%s'.", glyphName);


### PR DESCRIPTION
The primary change in this PR is the addition of code to explicitly set new memory to zero when a dynamic array grows. This fixes a bug in `mergefonts` in which it would fail on a semi-random glyph with the message `mergefonts: (cfr) charstring parse error`.

In the process of tracking down that problem, I fixed a couple of other memory issues which reported by Xcode's memory diagnostics. One was memory that was getting freed before it was used. The other was an incorrect variable type that was causing a pointer alignment issue.

Along the way, I also updated several Xcode project files semi-automatically with the changes recommended by Xcode 10.2.1.
