### PR TITLE
[makeinstancesufo] update instance filtering, improve tests

### DIFF
--- a/tests/convertfonttocid_test.py
+++ b/tests/convertfonttocid_test.py
@@ -20,6 +20,7 @@ def setup_module():
     """
     Create the temporary output directory
     """
+    rmtree(TEMP_DIR, ignore_errors=True)
     os.mkdir(TEMP_DIR)
 
 

--- a/tests/makeinstancesufo_data/input/badsource.designspace
+++ b/tests/makeinstancesufo_data/input/badsource.designspace
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='utf-8'?>
+<designspace format="3">
+    <axes>
+        <axis default="0.0" maximum="1000.0" minimum="0.0" name="weight" tag="wght" />
+    </axes>
+    <sources>
+        <source filename="nonexistent.ufo" name="master_0">
+            <lib copy="1" />
+            <groups copy="1" />
+            <info copy="1" />
+            <location>
+                <dimension name="weight" xvalue="0" />
+            </location>
+        </source>
+    </sources>
+    <instances>
+        <instance familyname="Source Serif Pro" filename="../temp_output/ufo3regular.ufo" postscriptfontname="SourceSerifPro-Regular" stylename="Regular">
+            <location>
+                <dimension name="weight" xvalue="394" />
+            </location>
+            <kerning />
+            <info />
+        </instance>
+        <instance familyname="Source Serif Pro" filename="../temp_output/ufo3medium.ufo" postscriptfontname="SourceSerifPro-Medium" stylename="Medium">
+            <location>
+                <dimension name="weight" xvalue="505" />
+            </location>
+            <kerning />
+            <info />
+        </instance>
+        <instance familyname="Source Serif Pro" filename="../temp_output/ufo3semibold.ufo" postscriptfontname="SourceSerifPro-Semibold" stylename="Semibold">
+            <location>
+                <dimension name="weight" xvalue="600" />
+            </location>
+            <kerning />
+            <info />
+        </instance>
+    </instances>
+</designspace>

--- a/tests/makeinstancesufo_data/input/noinstances.designspace
+++ b/tests/makeinstancesufo_data/input/noinstances.designspace
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<designspace format="3">
+    <axes>
+        <axis default="0.0" maximum="1000.0" minimum="0.0" name="weight" tag="wght" />
+    </axes>
+    <sources>
+        <source filename="master0.ufo" name="master_0">
+            <lib copy="1" />
+            <groups copy="1" />
+            <info copy="1" />
+            <location>
+                <dimension name="weight" xvalue="0" />
+            </location>
+        </source>
+    </sources>
+</designspace>

--- a/tests/makeinstancesufo_test.py
+++ b/tests/makeinstancesufo_test.py
@@ -13,17 +13,26 @@ from test_utils import get_input_path
 TOOL = 'makeinstancesufo'
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), TOOL + '_data')
+TEMP_DIR = os.path.join(DATA_DIR, "temp_output")
 
 
 def _get_output_path(file_name, dir_name):
     return os.path.join(DATA_DIR, dir_name, file_name)
 
 
+def setup_module():
+    """
+    Create the temporary output directory
+    """
+    rmtree(TEMP_DIR, ignore_errors=True)
+    os.mkdir(TEMP_DIR)
+
+
 def teardown_module():
     """
     teardown the temporary UFOs or the directory that holds them
     """
-    rmtree(os.path.join(DATA_DIR, 'temp_output'), True)
+    rmtree(os.path.join(TEMP_DIR), True)
     rmtree(os.path.join(DATA_DIR, 'input', 'same_dir.ufo'), True)
 
 

--- a/tests/makeinstancesufo_test.py
+++ b/tests/makeinstancesufo_test.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division, absolute_import
 import os
 import pytest
 from shutil import rmtree
+import subprocess32 as subprocess
 
 from fontTools.misc.py23 import tobytes
 
@@ -100,3 +101,17 @@ def test_features_copy(filename, exp_content):
         if 'nocopy' in filename:
             exp_content = exp_content_orig + tobytes(str(i), encoding='utf-8')
         assert exp_content == act_content
+
+
+def test_bad_source():
+    with pytest.raises(subprocess.CalledProcessError) as err:
+        runner(['-t', TOOL, '-o', 'd',
+                '_{}'.format(get_input_path('badsource.designspace'))])
+        assert err.value.returncode == 1
+
+
+def test_no_instances():
+    with pytest.raises(subprocess.CalledProcessError) as err:
+        runner(['-t', TOOL, '-o', 'd',
+                '_{}'.format(get_input_path('noinstances.designspace'))])
+        assert err.value.returncode == 1

--- a/tests/makeotf_test.py
+++ b/tests/makeotf_test.py
@@ -52,6 +52,7 @@ def setup_module():
     """
     Create the temporary output directory
     """
+    rmtree(TEMP_DIR, ignore_errors=True)
     os.mkdir(TEMP_DIR)
 
 

--- a/tests/otc2otf_test.py
+++ b/tests/otc2otf_test.py
@@ -25,6 +25,7 @@ def setup_module():
     """
     Create the temporary output directory
     """
+    rmtree(TEMP_DIR, ignore_errors=True)
     os.mkdir(TEMP_DIR)
 
 


### PR DESCRIPTION
- replace `readDesignSpaceFile` with `filterDesignspaceInstances` , use fontTools.designspaceLib
- add `validateDesignspaceFile` to check for module-specific conditions
- add tests to exercise ^^
- updated `setup_module` in several test modules to remove stale/leftover temp output dir
- modified how exceptions/etc. are handled for `import` case vs CLI/`subprocess` case
- additional items flagged by @miguelsousa