### PR TITLE
[buildmasterotfs] designspace file updates

### DIFF
--- a/tests/buildmasterotfs_data/input/bad_dsfile/TestVF.designspace
+++ b/tests/buildmasterotfs_data/input/bad_dsfile/TestVF.designspace
@@ -1,0 +1,76 @@
+<?xml version='1.0' encoding='utf-8'?>
+<designspace format="3">
+    <axes>
+        <axis default="389.34426" maximum="900.0" minimum="200.0" name="weight" tag="wght">
+            <map input="200" output="0" />   <!-- ExtraLight -->
+            <map input="300" output="150" /> <!-- Light -->
+            <map input="389.34426" output="368" /> <!-- default -->
+            <map input="400" output="394" /> <!-- Regular -->
+            <map input="600" output="600" /> <!-- Semibold -->
+            <map input="700" output="824" /> <!-- Bold -->
+            <map input="900" output="1000" /><!-- Black -->
+        </axis>
+    </axes>
+    <sources>
+        <source filename="Masters/master_0/TestVF_0.ufo" name="master_0">
+            <location>
+                <dimension name="weight" xvalue="0" />
+            </location>
+        </source>
+        <source filename="Masters/master_1/TestVF_1.ufo" name="master_1">
+            <info copy="1" />
+            <location>
+                <dimension name="weight" xvalue="368" />
+            </location>
+        </source>
+        <source filename="Masters/master_2/TestVF_2.ufo" name="master_2">
+            <location>
+                <dimension name="weight" xvalue="1000" />
+            </location>
+        </source>
+    </sources>
+    <instances>
+        <instance filename="TestVF-ExtraLight.otf" familyname="Test VF Roman" postscriptfontname="TestVF-ExtraLight" stylename="ExtraLight">
+            <location>
+                <dimension name="weight" xvalue="0" />
+            </location>
+            <kerning />
+            <info />
+        </instance>
+        <instance filename="TestVF-Light.otf" familyname="Test VF Roman" postscriptfontname="TestVF-Light" stylename="Light">
+            <location>
+                <dimension name="weight" xvalue="150" />
+            </location>
+            <kerning />
+            <info />
+        </instance>
+        <instance filename="TestVF-Regular.otf" familyname="Test VF Roman" postscriptfontname="TestVF-Regular" stylename="Regular">
+            <location>
+                <dimension name="weight" xvalue="394" />
+            </location>
+            <kerning />
+            <info />
+        </instance>
+        <instance filename="TestVF-Semibold.otf" familyname="Test VF Roman" postscriptfontname="TestVF-Semibold" stylename="Semibold">
+            <location>
+                <dimension name="weight" xvalue="600" />
+            </location>
+            <kerning />
+            <info />
+        </instance>
+        <instance filename="TestVF-Bold.otf" familyname="Test VF Roman" postscriptfontname="TestVF-Bold" stylename="Bold">
+            <location>
+                <dimension name="weight" xvalue="824" />
+            </location>
+            <kerning />
+            <info />
+        </instance>
+        <instance filename="TestVF-Black.otf" familyname="Test VF Roman" postscriptfontname="TestVF-Black" stylename="Black">
+            <location>
+                <dimension name="weight" xvalue="1000" />
+            </location>
+            <kerning />
+            <info />
+        </instance>
+    </instances>
+</designspace>

--- a/tests/buildmasterotfs_test.py
+++ b/tests/buildmasterotfs_test.py
@@ -2,7 +2,10 @@ from __future__ import print_function, division, absolute_import
 
 import os
 from shutil import copytree
+import subprocess32 as subprocess
 import tempfile
+
+import pytest
 
 from runner import main as runner
 from differ import main as differ, SPLIT_MARKER
@@ -43,3 +46,16 @@ def test_cjk_var():
                        '    <created value=' + SPLIT_MARKER +
                        '    <modified value=',
                        '-r', r'^\s+Version.*;hotconv.*;makeotfexe'])
+
+
+def test_bad_designspace():
+    """
+    Purposely fail on bad designspace file.
+    """
+    input_dir = get_input_path('bad_dsfile')
+    ds_path = os.path.join(input_dir, 'TestVF.designspace')
+
+    with pytest.raises(subprocess.CalledProcessError) as err:
+        runner(CMD + ['-o', 'd', '_{}'.format(ds_path), 'vv'])
+
+    assert err.value.returncode == 1


### PR DESCRIPTION
- bump version to 1.9.1
- use fontTools.designspaceLib/remove xml.etree
- add designspace file validation
- add test to exercise validation
- improve error/returncode for `import` vs CLI/subprocess use