### PR TITLE
[ci] Fix flake8 step

### DIFF
--- a/.circleci/check_source_code.sh
+++ b/.circleci/check_source_code.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # activate virtual environment
 source venv/bin/activate
 # check source files


### PR DESCRIPTION
Without "set -e" the exit code is the code of the last command ran by the shell script; if the last command is successful any previous errors are ignored and the shell script exits successfully (i.e. zero exit code).

Fixes #834