### PR TITLE
[ci] flake8 config & file update

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,8 +4,5 @@
 # (override default ignore list)
 select = E,F,W
 
-# except this one:
-ignore = W504
-
 # explicitly set line length limitation
 max-line-length = 79

--- a/.flake8
+++ b/.flake8
@@ -4,5 +4,8 @@
 # (override default ignore list)
 select = E,F,W
 
+# ignore W504 line break before binary operator
+ignore = W504
+
 # explicitly set line length limitation
 max-line-length = 79

--- a/python/afdko/makeotf.py
+++ b/python/afdko/makeotf.py
@@ -2365,7 +2365,8 @@ def adjustPaths(makeOTFParams):
         setattr(makeOTFParams, kFileOptPrefix + kUVSPath, uvsFilePath)
 
     if makeOTFParams.tempFontPath:
-        makeOTFParams.tempFontPath = os.path.abspath(makeOTFParams.tempFontPath)
+        makeOTFParams.tempFontPath = os.path.abspath(
+            makeOTFParams.tempFontPath)
 
     return fontDir
 

--- a/tests/spot_test.py
+++ b/tests/spot_test.py
@@ -108,7 +108,8 @@ def test_buffer_overrun_bug465():
     current spot code correctly reports the test font GPOS table."""
     file_name = "bug465/bug465.otf"
     expected_path = get_expected_path('bug465_otf.txt')
-    actual_path = runner(CMD + ['-s', expected_path, '-o', 't', '_GPOS=7', '-f', file_name])
+    actual_path = runner(
+        CMD + ['-s', expected_path, '-o', 't', '_GPOS=7', '-f', file_name])
     assert differ([expected_path, actual_path])
 
 


### PR DESCRIPTION
Attempted update of flake8, but ended up reverting to ignoring W504 because enabling all warnings results in conflicting W503; the two are directly contradictory. In the process of this update, attempted to confirm that .flake8 file is actually being used for all flake8 tests in CircleCI (confirmed by tests). One test file and one other file had E501 errors that were fixed as a result.