### PR TITLE
[python] drop use of fontTools.misc.py23

### DIFF
--- a/python/afdko/autohint.py
+++ b/python/afdko/autohint.py
@@ -441,7 +441,6 @@ import os
 import re
 import time
 import tempfile
-from fontTools.misc.py23 import open, tounicode
 from fontTools.ttLib import TTFont, getTableModule
 import plistlib
 import warnings
@@ -834,17 +833,20 @@ def  openFontPlistFile(psName, dirPath):
 		filePath = pPath1
 	else:
 		try:
-			fontPlist = plistlib.Plist.fromFile(filePath)
+			with open(filePath, 'rb') as f:
+				fontPlist = plistlib.load(f)
 			isNewPlistFile = 0
 		except (IOError, OSError):
 			raise ACFontError("\tError: font plist file exists, but coud not be read <%s>." % filePath)
 		except:
 			raise ACFontError("\tError: font plist file exists, but coud not be parsed <%s>." % filePath)
 
-	if  fontPlist == None:
-		fontPlist =  plistlib.Plist()
-	if not fontPlist.has_key(kACIDKey):
+	if  fontPlist is None:
+		fontPlist = dict()
+
+	if kACIDKey not in fontPlist:
 		fontPlist[kACIDKey] = {}
+
 	return fontPlist, filePath, isNewPlistFile
 
 
@@ -1106,7 +1108,7 @@ def hintFile(options):
 	if fdGlyphDict == None:
 		fdDict = fontDictList[0]
 		with open(tempFI, "w") as fp:
-			fp.write(tounicode(fdDict.getFontInfo()))
+			fp.write(fdDict.getFontInfo())
 	else:
 		if not options.verbose:
 			logMsg("Note: Using alternate FDDict global values from fontinfo file for some glyphs. Remove option '-q' to see which dict is used for which glyphs.")
@@ -1170,7 +1172,7 @@ def hintFile(options):
 				lastFDIndex = fdIndex
 				fdDict = fontData.getFontInfo(psName, path, options.allow_no_blues, options.noFlex, options.vCounterGlyphs, options.hCounterGlyphs, fdIndex)
 				with open(tempFI, "w") as fp:
-					fp.write(tounicode(fdDict.getFontInfo()))
+					fp.write(fdDict.getFontInfo())
 		else:
 			if (fdGlyphDict != None):
 				try:
@@ -1182,7 +1184,7 @@ def hintFile(options):
 					lastFDIndex = fdIndex
 					fdDict = fontDictList[fdIndex]
 					with open(tempFI, "w") as fp:
-						fp.write(tounicode(fdDict.getFontInfo()))
+						fp.write(fdDict.getFontInfo())
 
 
 		# 	Build autohint point list identifier
@@ -1223,7 +1225,7 @@ def hintFile(options):
 
 		# 	Call auto-hint library on bez string.
 		with open(tempBez, "wt") as bp:
-			bp.write(tounicode(bezString))
+			bp.write(bezString)
 
 		#print "oldBezString", oldBezString
 		#print ""
@@ -1303,11 +1305,15 @@ def hintFile(options):
 					logMsg("No new hints. All glyphs were already hinted.")
 			else:
 				logMsg("No glyphs were hinted.")
+
 	if options.usePlistFile and (anyGlyphChanged or pListChanged):
 		#  save font plist file.
-		fontPlist.write(fontPlistFilePath)
+		with open(fontPlistFilePath, 'wb') as f:
+			plistlib.writePlist(fontPlist, f)
+
 	if processedGlyphCount != seenGlyphCount:
 		logMsg("Skipped %s of %s glyphs." % (seenGlyphCount - processedGlyphCount, seenGlyphCount))
+
 	logMsg("Done with font %s. End time: %s." % (path, time.asctime()))
 
 def main():

--- a/python/afdko/beztools.py
+++ b/python/afdko/beztools.py
@@ -14,7 +14,6 @@ import time
 import os
 from afdko import fdkutils, convertfonttocid
 from fontTools.misc.psCharStrings import T2OutlineExtractor, SimpleT2Decompiler
-from fontTools.misc.py23 import byteord, bytechr
 from fontTools.pens.basePen import BasePen
 debug = 0
 def debugMsg(*args):
@@ -29,11 +28,14 @@ class ACFontError(Exception):
 class SEACError(Exception):
 	pass
 
-def hintOn( i, hintMaskBytes):
-	# used to add the active hints to the bez string, when a  T2 hintmask operator is encountered.
+
+def hintOn(i, hintMaskBytes):
+	# used to add the active hints to the bez string, when a T2 hintmask
+	# operator is encountered.
 	byteIndex = i // 8
-	byteValue = byteord(hintMaskBytes[byteIndex])
-	offset = 7 -  (i %8)
+	byteValue = hintMaskBytes[byteIndex]
+	offset = 7 - (i % 8)
+
 	return ((2**offset) & byteValue) > 0
 
 
@@ -234,7 +236,7 @@ class T2ToBezExtractor(T2OutlineExtractor):
 		if not  self.removeHints:
 			curhhints, curvhints = self.getCurHints( self.hintMaskString)
 			strout = ""
-			mask = [strout + hex(byteord(ch)) for ch in self.hintMaskString]
+			mask = [strout + hex(ch) for ch in self.hintMaskString]
 			debugMsg(bezCommand, mask, curhhints, curvhints, args)
 
 			self.bezProgram.append("beginsubr snc\n")
@@ -301,7 +303,7 @@ class HintMask:
 				continue	# we get here if some hints have been dropped because of the stack limit
 			newbyteIndex = (i//8)
 			if newbyteIndex != byteIndex:
-				mask += bytechr(maskVal)
+				mask += bytes((maskVal,))
 				byteIndex +=1
 				while byteIndex < newbyteIndex:
 					mask += b"\0"
@@ -317,7 +319,7 @@ class HintMask:
 				continue	# we get here if some hints have been dropped because of the stack limit
 			newbyteIndex = (i//8)
 			if newbyteIndex != byteIndex:
-				mask += bytechr(maskVal)
+				mask += bytes((maskVal,))
 				byteIndex +=1
 				while byteIndex < newbyteIndex:
 					mask += b"\0"
@@ -326,7 +328,7 @@ class HintMask:
 			maskVal += 2**(7 - (i %8))
 
 		if maskVal:
-			mask += bytechr(maskVal)
+			mask += bytes((maskVal,))
 
 		if len(mask) < byteLength:
 			mask += b"\0"*(byteLength - len(mask))
@@ -767,9 +769,9 @@ def  bezDecrypt(bezDataBuffer):
 			if not ch.islower():
 				ch = ch.lower()
 			if ch.isdigit():
-				ch = byteord(ch) - byteord('0')
+				ch = ord(ch) - ord('0')
 			else:
-				ch = byteord(ch) - byteord('a') + 10
+				ch = ord(ch) - ord('a') + 10
 			cipher = (cipher << 4) & 0xFFFF
 			cipher = cipher | ch
 			i += 1
@@ -780,7 +782,7 @@ def  bezDecrypt(bezDataBuffer):
 			r = r & 0xFFFF
 		byteCnt +=1
 		if (byteCnt > LEN_IV):
-			newBuffer += bytechr(plain)
+			newBuffer += bytes((plain,))
 		if i >= lenBuffer:
 			break
 

--- a/python/afdko/comparefamily.py
+++ b/python/afdko/comparefamily.py
@@ -8,7 +8,7 @@ __copyright__ = """Copyright 2015 Adobe Systems Incorporated (http://www.adobe.c
 """
 
 __usage__ = """
-comparefamily 2.1.4 Jul 12 2019
+comparefamily 2.1.5 Jul 15 2019
 
 comparefamily [u] -h] [-d <directory path>] [-tolerance <n>] -rm] [-rn] [-rp] [-nohints] [-l] [-rf] [-st n1,..] [-ft n1,..]
 where 'n1' stands for the number of a test, such as "-st 26" to run Single Test 26.
@@ -23,7 +23,7 @@ feel free to edit or disable them in the source script file at:
 See 'comparefamily -h' for details.
 """
 
-__version__ = "2.1.4"
+__version__ = "2.1.5"
 
 __help__ = """
 
@@ -95,7 +95,6 @@ import copy
 import math
 
 from fontTools import ttLib
-from fontTools.misc.py23 import tounicode, byteord
 
 from afdko import fdkutils
 
@@ -1127,120 +1126,120 @@ def readNameTable(cmpfFont):
 	if cmpfFont.hasMacNames:
 		# Fill in font info with Mac Names from Mac Platform, Roman Encoding, English Language
 		try:
-			cmpfFont.PostScriptName1 = tounicode(cmpfFont.nameIDDict[(1, 0, 0, 6)].decode('mac_roman'))
+			cmpfFont.PostScriptName1 = cmpfFont.nameIDDict[(1, 0, 0, 6)].decode('mac_roman')
 		except KeyError:
 			print("	Error: Missing Mac Postcriptname from name table! Should be in record", (1, 0, 0, 6))
 			cmpfFont.PostScriptName1 = ""
 
 		try:
-			cmpfFont.compatibleFamilyName1 = tounicode(cmpfFont.nameIDDict[(1, 0, 0, 1)].decode('mac_roman'))
+			cmpfFont.compatibleFamilyName1 = cmpfFont.nameIDDict[(1, 0, 0, 1)].decode('mac_roman')
 		except KeyError:
 			print("	Error: Missing Mac Compatible Family Name from name table! Should be in record", (1, 0, 0, 1) , cmpfFont.PostScriptName1)
 			cmpfFont.compatibleFamilyName1 = ""
 
 		try:
-			cmpfFont.compatibleSubFamilyName1 = tounicode(cmpfFont.nameIDDict[(1, 0, 0, 2)].decode('mac_roman'))
+			cmpfFont.compatibleSubFamilyName1 = cmpfFont.nameIDDict[(1, 0, 0, 2)].decode('mac_roman')
 		except KeyError:
 			print("	Error: Missing Mac Compatible SubFamily Name from name table! Should be in record", (1, 0, 0, 2), cmpfFont.PostScriptName1)
 			cmpfFont.compatibleSubFamilyName1 = ""
 
 		if (1, 0, 0, 16) in cmpfFont.nameIDDict:
-			cmpfFont.preferredFamilyName1 = tounicode(cmpfFont.nameIDDict[(1, 0, 0, 16)].decode('mac_roman'))
+			cmpfFont.preferredFamilyName1 = cmpfFont.nameIDDict[(1, 0, 0, 16)].decode('mac_roman')
 		else:
 			cmpfFont.preferredFamilyName1 = cmpfFont.compatibleFamilyName1
 
 		if (1, 0, 0, 17) in cmpfFont.nameIDDict:
-			cmpfFont.preferredSubFamilyName1 = tounicode(cmpfFont.nameIDDict[(1, 0, 0, 17)].decode('mac_roman'))
+			cmpfFont.preferredSubFamilyName1 = cmpfFont.nameIDDict[(1, 0, 0, 17)].decode('mac_roman')
 		else:
 			cmpfFont.preferredSubFamilyName1 = cmpfFont.compatibleSubFamilyName1
 
 
 		try:
-			cmpfFont.FullFontName1 = tounicode(cmpfFont.nameIDDict[(1, 0, 0, 4)].decode('mac_roman'))
+			cmpfFont.FullFontName1 = cmpfFont.nameIDDict[(1, 0, 0, 4)].decode('mac_roman')
 		except KeyError:
 			print("	Error: Missing Mac Full Font Name from name table! Should be in record", (1, 0, 0, 4), cmpfFont.PostScriptName1)
 			cmpfFont.FullFontName1 = ""
 
 		try:
-			cmpfFont.VersionStr1 = tounicode(cmpfFont.nameIDDict[(1, 0, 0, 5)].decode('mac_roman'))
+			cmpfFont.VersionStr1 = cmpfFont.nameIDDict[(1, 0, 0, 5)].decode('mac_roman')
 		except KeyError:
 			print("	Warning: Missing Mac Version String from name table! Should be in record", (1, 0, 0, 5), cmpfFont.PostScriptName1)
 			cmpfFont.VersionStr1 = ""
 
 		try:
-			cmpfFont.copyrightStr1 = tounicode(cmpfFont.nameIDDict[(1, 0, 0, 0)].decode('mac_roman'))
+			cmpfFont.copyrightStr1 = cmpfFont.nameIDDict[(1, 0, 0, 0)].decode('mac_roman')
 		except KeyError:
 			print("	Warning: Missing Mac Copyright String from name table! Should be in record", (1, 0, 0, 0), cmpfFont.PostScriptName1)
 			cmpfFont.copyrightStr1 = ""
 
 		try:
-			cmpfFont.trademarkStr1 = tounicode(cmpfFont.nameIDDict[(1, 0, 0, 7)].decode('mac_roman'))
+			cmpfFont.trademarkStr1 = cmpfFont.nameIDDict[(1, 0, 0, 7)].decode('mac_roman')
 		except KeyError:
 			print("	Warning: Missing Mac Trademark String from name table! Should be in record", (1, 0, 0, 7), cmpfFont.PostScriptName1)
 			cmpfFont.trademarkStr1 = ""
 
 
 		try:
-			tounicode(cmpfFont.nameIDDict[(1, 0, 0, 14)].decode('mac_roman'))
+			cmpfFont.nameIDDict[(1, 0, 0, 14)].decode('mac_roman')
 		except KeyError:
 			print("	Warning: Missing Mac platform License Notice URL  from name table! Should be in record", (1, 0, 0, 14))
 
 		if (1, 0, 0, 18) in cmpfFont.nameIDDict:
-			cmpfFont.MacCompatibleFullName1 = tounicode(cmpfFont.nameIDDict[(1, 0, 0, 18)].decode('mac_roman'))
+			cmpfFont.MacCompatibleFullName1 = cmpfFont.nameIDDict[(1, 0, 0, 18)].decode('mac_roman')
 		else:
 			cmpfFont.MacCompatibleFullName1 = cmpfFont.FullFontName1
 
 # Fill in font info with Win Names from Win Platform, Unicode Encoding, English Language
 	try:
-		cmpfFont.PostScriptName3 = tounicode(cmpfFont.nameIDDict[(3, 1, 1033, 6)].decode('utf_16_be'))
+		cmpfFont.PostScriptName3 = cmpfFont.nameIDDict[(3, 1, 1033, 6)].decode('utf_16_be')
 	except KeyError:
 		print("	Error: Missing Windows PostScript Name/Unicode encoding from name table! Should be in record", (3, 1, 1033, 6), cmpfFont.PostScriptName3)
 		cmpfFont.PostScriptName3 = ""
 
 	try:
-		cmpfFont.compatibleFamilyName3 = tounicode(cmpfFont.nameIDDict[(3, 1, 1033, 1)].decode('utf_16_be'))
+		cmpfFont.compatibleFamilyName3 = cmpfFont.nameIDDict[(3, 1, 1033, 1)].decode('utf_16_be')
 	except KeyError:
 		print("	Error: Missing Windows Compatible Family Name/Unicode encoding String from name table! Should be in record", (3, 1, 1033, 1), cmpfFont.PostScriptName3)
 		cmpfFont.compatibleFamilyName3 = ""
 
 	if (3, 1, 1033, 16) in cmpfFont.nameIDDict:
-		cmpfFont.preferredFamilyName3 = tounicode(cmpfFont.nameIDDict[(3, 1, 1033, 16)].decode('utf_16_be'))
+		cmpfFont.preferredFamilyName3 = cmpfFont.nameIDDict[(3, 1, 1033, 16)].decode('utf_16_be')
 	else:
 		cmpfFont.preferredFamilyName3 = cmpfFont.compatibleFamilyName3
 
 
 	try:
-		cmpfFont.compatibleSubFamilyName3 = tounicode(cmpfFont.nameIDDict[(3, 1, 1033, 2)].decode('utf_16_be'))
+		cmpfFont.compatibleSubFamilyName3 = cmpfFont.nameIDDict[(3, 1, 1033, 2)].decode('utf_16_be')
 	except KeyError:
 		print("	Error: Missing Windows Compatible SubFamily Name/Unicode encoding String from name table! Should be in record", (3, 1, 1033, 2), cmpfFont.PostScriptName3)
 		cmpfFont.compatibleSubFamilyName3 = ""
 
 	if (3, 1, 1033, 17) in cmpfFont.nameIDDict:
-		cmpfFont.preferredSubFamilyName3 = tounicode(cmpfFont.nameIDDict[(3, 1, 1033, 17)].decode('utf_16_be'))
+		cmpfFont.preferredSubFamilyName3 = cmpfFont.nameIDDict[(3, 1, 1033, 17)].decode('utf_16_be')
 	else:
 		cmpfFont.preferredSubFamilyName3 = cmpfFont.compatibleSubFamilyName3
 
 	try:
-		cmpfFont.FullFontName3 = tounicode(cmpfFont.nameIDDict[(3, 1, 1033, 4)].decode('utf_16_be'))
+		cmpfFont.FullFontName3 = cmpfFont.nameIDDict[(3, 1, 1033, 4)].decode('utf_16_be')
 	except KeyError:
 		print("	Error: Missing Windows Full Family Name/Unicode encoding String from name table! Should be in record", (3, 1, 1033, 4), cmpfFont.PostScriptName3)
 		cmpfFont.FullFontName3 = ""
 
 	try:
-		cmpfFont.VersionStr3 = tounicode(cmpfFont.nameIDDict[(3, 1, 1033, 5)].decode('utf_16_be'))
+		cmpfFont.VersionStr3 = cmpfFont.nameIDDict[(3, 1, 1033, 5)].decode('utf_16_be')
 	except KeyError:
 		print("	Error: Missing Windows Version String/Unicode encoding String from name table! Should be in record", (3, 1, 1033, 5), cmpfFont.PostScriptName3)
 		cmpfFont.VersionStr3 = ""
 
 	try:
-		cmpfFont.copyrightStr3 = tounicode(cmpfFont.nameIDDict[(3, 1, 1033, 0)].decode('utf_16_be'))
+		cmpfFont.copyrightStr3 = cmpfFont.nameIDDict[(3, 1, 1033, 0)].decode('utf_16_be')
 	except KeyError:
 		print("	Warning: Missing Windows Copyright String/Unicode encoding String from name table! Should be in record", (3, 1, 1033, 0), cmpfFont.PostScriptName3)
 		cmpfFont.copyrightStr3 = ""
 
 
 	try:
-		cmpfFont.trademarkStr3 = tounicode(cmpfFont.nameIDDict[(3, 1, 1033, 7)].decode('utf_16_be'))
+		cmpfFont.trademarkStr3 = cmpfFont.nameIDDict[(3, 1, 1033, 7)].decode('utf_16_be')
 	except KeyError:
 		print("	Warning: Missing Windows Trademark String/Unicode encoding String from name table! Should be in record", (3, 1, 1033, 7), cmpfFont.PostScriptName3)
 		cmpfFont.trademarkStr3 = ""
@@ -3739,7 +3738,7 @@ def doFamilyTest11():
 			# might be the same!
 			isEqual = 1
 			for i in range(lenMac):
-				if byteord(macMenuName[i]) > 127:
+				if ord(macMenuName[i]) > 127:
 					continue # ignore upper ascii
 				if (winMenuName[i] == macMenuName[i]):
 					continue
@@ -3761,13 +3760,13 @@ def doFamilyTest11():
 				Platform, Encoding, Language, ID = nameIDKey
 
 				if (Platform == 1) and (Encoding == 0)  and (ID == 18) and Language == 0:
-					macMenuName = tounicode(font.nameIDDict[nameIDKey])
+					macMenuName = font.nameIDDict[nameIDKey].decode('macroman')
 
 				if (Platform == 1) and (Encoding == 0) and (ID == 4) and Language == 0 and not macMenuName:
-					macMenuName = tounicode(font.nameIDDict[nameIDKey])
+					macMenuName = font.nameIDDict[nameIDKey].decode('macroman')
 
 				if Platform == 3 and Encoding == 1 and ID == 1 and Language == 1033:
-					winMenuName = tounicode(font.nameIDDict[nameIDKey].decode('utf_16_be'))
+					winMenuName = font.nameIDDict[nameIDKey].decode('utf_16_be')
 			if font.isBold or font.isItalic:
 				if not font.isCID:
 					if CompareWinToMacMenuName(winMenuName, macMenuName):

--- a/python/afdko/convertfonttocid.py
+++ b/python/afdko/convertfonttocid.py
@@ -57,8 +57,6 @@ import os
 import re
 import sys
 
-from fontTools.misc.py23 import open, tounicode, tobytes
-
 from afdko import fdkutils
 
 __version__ = "1.13.1"
@@ -960,7 +958,7 @@ def makeCIDFontInfo(fontPath, cidfontinfoPath):
                     continue
                 if value[0] == "\"":
                     value = "(" + value[1:-1] + ")"
-                string = tounicode("%s\t%s\n" % (key, value))
+                string = "%s\t%s\n" % (key, value)
                 fp.write(string)
     except (IOError, OSError):
         raise FontInfoParseError(
@@ -999,8 +997,8 @@ def makeGAFile(gaPath, fontPath, glyphList, fontDictList, fdGlyphDict,
     lineList.append("")
     gaText = "mergefonts %s%s%s" % (dictName, langGroup, '\n'.join(lineList))
 
-    with open(gaPath, "wb") as gf:
-        gf.write(tobytes(gaText))
+    with open(gaPath, "w") as gf:
+        gf.write(gaText)
 
 
 def merge_fonts(inputFontPath, outputPath, fontList, glyphList, fontDictList,

--- a/python/afdko/fdkutils.py
+++ b/python/afdko/fdkutils.py
@@ -1,18 +1,15 @@
 # Copyright 2016 Adobe. All rights reserved.
 
 """
-fdkutils.py v1.3.1 Jul 12 2019
+fdkutils.py v1.3.2 Jul 15 2019
 A module of functions that are needed by several of the AFDKO scripts.
 """
 
 import os
-import sys
 import subprocess
 import tempfile
 
-from fontTools.misc.py23 import tounicode, tostr
-
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 
 def get_temp_file_path():
@@ -84,17 +81,18 @@ def get_shell_command_output(args, std_error=False):
     Unicode-encoded string, or None.
     """
     stderr = subprocess.STDOUT if std_error else None
+
     try:
         bytes_output = subprocess.check_output(args, stderr=stderr)
-        try:
-            str_output = tounicode(bytes_output, encoding='utf-8')
-        except UnicodeDecodeError:
-            str_output = tounicode(bytes_output,
-                                   encoding=sys.getfilesystemencoding())
-        return True, str_output
+        str_output = bytes_output.decode('utf-8', 'backslashreplace')
+        success = True
+
     except (subprocess.CalledProcessError, OSError) as err:
         print(err)
-        return False, None
+        success = False
+        str_output = None
+
+    return success, str_output
 
 
 def runShellCmd(cmd):
@@ -102,14 +100,14 @@ def runShellCmd(cmd):
         p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT)
         stdoutdata, _ = p.communicate()
-        try:
-            return tounicode(stdoutdata, encoding='utf-8')
-        except UnicodeDecodeError:
-            return tounicode(stdoutdata, encoding=sys.getfilesystemencoding())
+        str_output = stdoutdata.decode('utf-8', 'backslashreplace')
+
     except (subprocess.CalledProcessError, OSError) as err:
-        msg = "Error executing command '%s'\n%s" % (cmd, err)
+        msg = f"Error executing command '{cmd}'\n{err}"
         print(msg)
-        return ""
+        str_output = ""
+
+    return str_output
 
 
 def runShellCmdLogging(cmd):
@@ -119,14 +117,17 @@ def runShellCmdLogging(cmd):
         while 1:
             output = proc.stdout.readline().rstrip()
             if output:
-                print(tostr(output))
+                print(output.decode('utf-8', 'backslashreplace'))
+
             if proc.poll() is not None:
                 output = proc.stdout.readline().rstrip()
                 if output:
-                    print(tostr(output))
+                    print(output.decode('utf-8', 'backslashreplace'))
                 break
+
     except (subprocess.CalledProcessError, OSError) as err:
-        msg = "Error executing command '%s'\n%s" % (cmd, err)
+        msg = f"Error executing command '{cmd}'\n{err}"
         print(msg)
         return 1
+
     return 0

--- a/python/afdko/makeinstancesufo.py
+++ b/python/afdko/makeinstancesufo.py
@@ -16,7 +16,6 @@ from fontTools.designspaceLib import (
     DesignSpaceDocument,
     DesignSpaceDocumentError,
 )
-from fontTools.misc.py23 import open
 
 from defcon import Font
 from psautohint.__main__ import main as psautohint
@@ -28,7 +27,7 @@ from afdko.fdkutils import get_temp_file_path
 from afdko.ufotools import validateLayers
 
 
-__version__ = '2.3.2'
+__version__ = '2.3.3'
 
 logger = logging.getLogger(__name__)
 
@@ -244,7 +243,7 @@ def collect_features_content(instances, inst_idx_lst):
         ufo_pth = os.path.abspath(os.path.realpath(ufo_pth))
         fea_pth = os.path.join(ufo_pth, FEATURES_FILENAME)
         if os.path.isfile(fea_pth):
-            with open(fea_pth, 'rb') as fp:
+            with open(fea_pth, 'r') as fp:
                 fea_cntnts = fp.read()
             fea_dict[fea_pth] = fea_cntnts
     return fea_dict
@@ -326,7 +325,7 @@ def run(options):
 
     # Restore the contents of the instances' 'features.fea' files
     for fea_pth, fea_cntnts in features_store.items():
-        with open(fea_pth, 'wb') as fp:
+        with open(fea_pth, 'w') as fp:
             fp.write(fea_cntnts)
 
 

--- a/python/afdko/makeotf.py
+++ b/python/afdko/makeotf.py
@@ -8,7 +8,6 @@ import sys
 
 from fontTools.ttLib import TTFont, TTLibError
 from fontTools.ttLib.tables.DefaultTable import DefaultTable
-from fontTools.misc.py23 import open, tounicode, tobytes
 
 from afdko import convertfonttocid, fdkutils, ufotools
 
@@ -26,7 +25,7 @@ if needed.
 """
 
 __version__ = """\
-makeotf.py v2.7.5 Jul 12 2019
+makeotf.py v2.7.6 Jul 15 2019
 """
 
 __methods__ = """
@@ -679,8 +678,8 @@ def writeOptionsFile(makeOTFParams, filePath):
         if makeOTFParams.verbose:
             print("makeotf [Note] Writing options file %s" % filePath)
         try:
-            with open(filePath, "wb") as fp:
-                fp.write(tobytes(data, encoding='utf-8'))
+            with open(filePath, "w", encoding='utf-8') as fp:
+                fp.write(data)
         except (IOError, OSError):
             print("makeotf [Warning] Could not write the options file %s. "
                   "Please check the file protection settings for the file "
@@ -1639,7 +1638,7 @@ def getROS(fontPath):
     """
     Reg = Ord = Sup = None
     with open(fontPath, "r", encoding='macroman') as fp:
-        data = tounicode(fp.read(5000))
+        data = fp.read(5000)
     match = re.search(r"/Registry\s+\((\S+)\)", data)
     if not match:
         return Reg, Ord, Sup
@@ -1960,11 +1959,11 @@ def convertFontIfNeeded(makeOTFParams):
     else:
         try:
             with open(filePath, "rb") as fp:
-                data = tounicode(fp.read(1024))
-            if ("%" not in data[:4]) and ('/FontName' not in data):
+                data = fp.read(1024)
+            if (b"%" not in data[:4]) and (b'/FontName' not in data):
                 needsConversion = True
             else:
-                if "/Private" in data:
+                if b"/Private" in data:
                     isTextPS = True
                     needsConversion = True
         except (IOError, OSError):
@@ -2084,8 +2083,8 @@ def updateFontRevision(featuresPath, fontRevision):
     newData = re.sub(match.group(0), "FontRevision %s.%s;" % (major, minor),
                      data)
     try:
-        with open(featuresPath, "wb") as fp:
-            fp.write(tobytes(newData, encoding='utf-8'))
+        with open(featuresPath, "w", encoding='utf-8') as fp:
+            fp.write(newData)
     except (IOError, OSError):
         print("makeotf [Error] When trying to update the head table "
               "fontRevision field, failed to write the new data to '%s'." %

--- a/python/afdko/otc2otf.py
+++ b/python/afdko/otc2otf.py
@@ -1,6 +1,6 @@
-# otc2otf.py v1.4.1 Jul 12 2019
+# otc2otf.py v1.4.2 Jul 15 2019
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 
 __copyright__ = """Copyright 2014 Adobe Systems Incorporated (http://www.adobe.com/). All Rights Reserved.
 """
@@ -27,11 +27,9 @@ import sys
 import os
 import struct
 
-from fontTools.misc.py23 import tostr
-
 
 class OTCError(TypeError):
-	pass
+    pass
 
 class FontEntry:
 
@@ -183,7 +181,7 @@ def getPSName(data):
 
 	if psName == None:
 		psName = "PSNameUndefined"
-	return tostr(psName)
+	return psName
 
 def readFontFile(fontOffset, data, tableDict, doReportOnly):
 	sfntType, numTables, searchRange, entrySelector, rangeShift = struct.unpack(sfntDirectoryFormat, data[fontOffset:fontOffset + sfntDirectorySize])

--- a/python/afdko/otf2otc.py
+++ b/python/afdko/otf2otc.py
@@ -1,7 +1,5 @@
 # otf2otc.py v1.5 October 12 2017
 
-from fontTools.misc.py23 import tostr
-
 __copyright__ = """Copyright 2014,2017 Adobe Systems Incorporated (http://www.adobe.com/). All Rights Reserved.
 """
 
@@ -310,9 +308,9 @@ def run(args):
 	unSharedTables = []
 	for tableEntryList in tableList:
 		if len(tableEntryList) > 1:
-			unSharedTables.append(tostr(tableEntryList[0].tag.decode('ascii')))
+			unSharedTables.append(tableEntryList[0].tag.decode('ascii'))
 		else:
-			sharedTables.append(tostr(tableEntryList[0].tag.decode('ascii')))
+			sharedTables.append(tableEntryList[0].tag.decode('ascii'))
 	if len(sharedTables) == 0:
 		print("No tables are shared")
 	else:

--- a/python/afdko/otfpdf.py
+++ b/python/afdko/otfpdf.py
@@ -1,17 +1,16 @@
 # Copyright 2014 Adobe. All rights reserved.
 """
-otfpdf v1.6.2 Jul 12 2019
+otfpdf v1.6.3 Jul 15 2019
 provides support for the proofpdf script, for working with OpenType/CFF
 fonts. Provides an implementation of the fontpdf font object. Cannot be
 run alone.
 """
 from fontTools.pens.boundsPen import BoundsPen
 from fontTools.misc.psCharStrings import T2OutlineExtractor
-from fontTools.misc.py23 import byteord, round
 
 from afdko.fontpdf import FontPDFGlyph, FontPDFFont, FontPDFPen
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"
 
 
 class txPDFFont(FontPDFFont):
@@ -150,7 +149,7 @@ def hintOn(i, hintMaskBytes):
     # used to add the active hints to the bez string,
     # when a T2 hintmask operator is encountered.
     byteIndex = i // 8
-    byteValue = byteord(hintMaskBytes[byteIndex])
+    byteValue = hintMaskBytes[byteIndex]
     offset = 7 - (i % 8)
     return ((2 ** offset) & byteValue) > 0
 

--- a/python/afdko/pdfdoc.py
+++ b/python/afdko/pdfdoc.py
@@ -1,4 +1,4 @@
-#pdfdoc.py
+# pdfdoc.py
 """
 PDFgen is a library to generate PDF files containing text and graphics.  It is the
 foundation for a complete reporting solution in Python.
@@ -17,8 +17,6 @@ Modified 7/25/2006 read rooberts. Added supported for embedding fonts.
 
 import sys
 import time
-
-from fontTools.misc.py23 import open, tobytes
 
 from afdko import pdfutils
 from afdko.pdfutils import LINEEND   # this constant needed in both
@@ -144,11 +142,11 @@ class PDFDocument:
 
     def writeXref(self, f):
         self.startxref = f.tell()
-        f.write(tobytes('xref' + LINEEND, encoding='utf-8'))
-        f.write(tobytes('0 %d' % (len(self.objects) + 1) + LINEEND, encoding='utf-8'))
-        f.write(tobytes('0000000000 65535 f' + LINEEND, encoding='utf-8'))
+        f.write(('xref' + LINEEND).encode('utf-8'))
+        f.write(('0 %d' % (len(self.objects) + 1) + LINEEND).encode('utf-8'))
+        f.write(('0000000000 65535 f' + LINEEND).encode('utf-8'))
         for pos in self.xref:
-            f.write(tobytes('%0.10d 00000 n' % pos + LINEEND, encoding='utf-8'))
+            f.write(('%0.10d 00000 n' % pos + LINEEND).encode('utf-8'))
 
     def printTrailer(self):
         print('trailer')
@@ -158,10 +156,10 @@ class PDFDocument:
         print(self.startxref)
 
     def writeTrailer(self, f):
-        f.write(tobytes('trailer' + LINEEND, encoding='utf-8'))
-        f.write(tobytes('<< /Size %d /Root %d 0 R /Info %d 0 R>>' % (len(self.objects) + 1, 1, self.infopos)  + LINEEND, encoding='utf-8'))
-        f.write(tobytes('startxref' + LINEEND, encoding='utf-8'))
-        f.write(tobytes(str(self.startxref)  + LINEEND, encoding='utf-8'))
+        f.write(('trailer' + LINEEND).encode('utf-8'))
+        f.write(('<< /Size %d /Root %d 0 R /Info %d 0 R>>' % (len(self.objects) + 1, 1, self.infopos)  + LINEEND).encode('utf-8'))
+        f.write(('startxref' + LINEEND).encode('utf-8'))
+        f.write((str(self.startxref)  + LINEEND).encode('utf-8'))
 
     def SaveToFile(self, filename):
         with open(filename, 'wb') as fileobj:
@@ -173,17 +171,17 @@ class PDFDocument:
         use in the index at the end"""
         f = fileobj
         self.xref = []
-        f.write(tobytes("%PDF-1.2" + LINEEND, encoding='utf-8'))  # for CID support
-        f.write(tobytes(b"%\xed\xec\xb6\xbe\r\n", encoding='utf-8'))
+        f.write(("%PDF-1.2" + LINEEND).encode('utf-8'))  # for CID support
+        f.write(b"%\xed\xec\xb6\xbe\r\n")
         for i, obj in enumerate(self.objects, 1):
             pos = f.tell()
             self.xref.append(pos)
-            f.write(tobytes(str(i) + ' 0 obj' + LINEEND, encoding='utf-8'))
+            f.write((str(i) + ' 0 obj' + LINEEND).encode('utf-8'))
             obj.save(f)
-            f.write(tobytes('endobj' + LINEEND, encoding='utf-8'))
+            f.write(('endobj' + LINEEND).encode('utf-8'))
         self.writeXref(f)
         self.writeTrailer(f)
-        f.write(tobytes('%%EOF', encoding='utf-8'))  # no lineend needed on this one!
+        f.write(('%%EOF').encode('utf-8'))  # no lineend needed on this one!
 
     def printPDF(self):
         "prints it to standard output.  Logs positions for doing trailer"
@@ -421,7 +419,7 @@ class PDFCatalog(PDFObject):
                         '>>'
                         ])
     def save(self, file):
-        file.write(tobytes(self.template % (self.RefPages, self.RefOutlines) + LINEEND, encoding='utf-8'))
+        file.write((self.template % (self.RefPages, self.RefOutlines) + LINEEND).encode('utf-8'))
 
 
 class PDFInfo(PDFObject):
@@ -437,7 +435,7 @@ class PDFInfo(PDFObject):
         self.datestr = '%04d%02d%02d%02d%02d%02d' % tuple(now[0:6])
 
     def save(self, file):
-        file.write(tobytes(LINEEND.join([
+        file.write((LINEEND.join([
                 "<</Title (%s)",
                 "/Author (%s)",
                 "/CreationDate (D:%s)",
@@ -449,7 +447,7 @@ class PDFInfo(PDFObject):
     pdfutils._escape(self.author),
     self.datestr,
     pdfutils._escape(self.subject)
-    ) + LINEEND, encoding='utf-8'))
+    ) + LINEEND).encode('utf-8'))
 
 
 class PDFOutline(PDFObject):
@@ -461,7 +459,7 @@ class PDFOutline(PDFObject):
                 '/Count 0',
                 '>>'])
     def save(self, file):
-        file.write(tobytes(self.template + LINEEND, encoding='utf-8'))
+        file.write((self.template + LINEEND).encode('utf-8'))
 
 
 class PDFPageCollection(PDFObject):
@@ -480,7 +478,7 @@ class PDFPageCollection(PDFObject):
         lines.append(']')
         lines.append('>>')
         text = LINEEND.join(lines)
-        file.write(tobytes(text + LINEEND, encoding='utf-8'))
+        file.write((text + LINEEND).encode('utf-8'))
 
 
 class PDFPage(PDFObject):
@@ -525,7 +523,7 @@ class PDFPage(PDFObject):
             self.info['procsettext'] = '[/PDF /Text]'
         self.info['transitionString'] = self.pageTransitionString
 
-        file.write(tobytes(self.template % self.info + LINEEND, encoding='utf-8'))
+        file.write((self.template % self.info + LINEEND).encode('utf-8'))
 
     def clear(self):
         self.drawables = []
@@ -553,7 +551,7 @@ class PDFStream(PDFObject):
              self.data = TestStream
 
         if self.compression == 1:
-            comp = zlib.compress(tobytes(self.data, encoding='utf-8'))   #this bit is very fast...
+            comp = zlib.compress((self.data).encode('utf-8'))   #this bit is very fast...
             base85 = pdfutils._AsciiBase85Encode(comp) #...sadly this isn't
             wrapped = pdfutils._wrap(base85)
             data_to_write = wrapped
@@ -566,12 +564,12 @@ class PDFStream(PDFObject):
         #length = len(self.data) + lines   # one extra LF each
         length = len(data_to_write) + len(LINEEND)    #AR 19980202
         if self.compression:
-            file.write(tobytes('<< /Length %d /Filter [/ASCII85Decode /FlateDecode]>>' % length + LINEEND, encoding='utf-8'))
+            file.write(('<< /Length %d /Filter [/ASCII85Decode /FlateDecode]>>' % length + LINEEND).encode('utf-8'))
         else:
-            file.write(tobytes('<< /Length %d >>' % length + LINEEND, encoding='utf-8'))
-        file.write(tobytes('stream' + LINEEND, encoding='utf-8'))
-        file.write(tobytes(data_to_write + LINEEND, encoding='latin-1'))
-        file.write(tobytes('endstream' + LINEEND, encoding='utf-8'))
+            file.write(('<< /Length %d >>' % length + LINEEND).encode('utf-8'))
+        file.write(('stream' + LINEEND).encode('utf-8'))
+        file.write((data_to_write + LINEEND).encode('latin-1'))  # Really?
+        file.write(('endstream' + LINEEND).encode('utf-8'))
 
 class PDFImage(PDFObject):
     # sample one while developing.  Currently, images go in a literals
@@ -625,12 +623,12 @@ class PDFEmbddedFont(PDFStream):
             fontStreamEntry = "/Subtype %s" % (self.fontType)
 
         if self.compression:
-            file.write(tobytes('<<  %s /Length %d /Filter [/ASCII85Decode /FlateDecode] >>' % (fontStreamEntry, length) + LINEEND, encoding='utf-8'))
+            file.write(('<<  %s /Length %d /Filter [/ASCII85Decode /FlateDecode] >>' % (fontStreamEntry, length) + LINEEND).encode('utf-8'))
         else:
-            file.write(tobytes('<< /Length %d %s >>' % (length,  fontStreamEntry) + LINEEND, encoding='utf-8'))
-        file.write(tobytes('stream' + LINEEND, encoding='utf-8'))
+            file.write(('<< /Length %d %s >>' % (length,  fontStreamEntry) + LINEEND).encode('utf-8'))
+        file.write(('stream' + LINEEND).encode('utf-8'))
         file.write(data_to_write + b'\r\n')
-        file.write(tobytes('endstream' + LINEEND, encoding='utf-8'))
+        file.write(('endstream' + LINEEND).encode('utf-8'))
 
 class PDFType1Font(PDFObject):
     def __init__(self, key, psName, encoding=kDefaultEncoding, fontDescriptObjectNumber = None, type = kDefaultFontType, firstChar = None, lastChar = None, widths = None):
@@ -654,7 +652,7 @@ class PDFType1Font(PDFObject):
         self.template = LINEEND.join(textList)
 
     def save(self, file):
-        file.write(tobytes(self.template % (self.keyname, self.fontname) + LINEEND, encoding='utf-8'))
+        file.write((self.template % (self.keyname, self.fontname) + LINEEND).encode('utf-8'))
 
 
 class PDFType0Font(PDFType1Font):
@@ -665,7 +663,7 @@ class PDFontDescriptor(PDFObject):
         self.text = text
 
     def save(self, file):
-        file.write(tobytes(self.text + LINEEND, encoding='utf-8'))
+        file.write((self.text + LINEEND).encode('utf-8'))
 
 
 

--- a/python/afdko/pdfutils.py
+++ b/python/afdko/pdfutils.py
@@ -9,8 +9,6 @@ try:
 except ImportError:
     from io import StringIO
 
-from fontTools.misc.py23 import byteord
-
 LINEEND = '\015\012'
 
 ##########################################################
@@ -118,7 +116,7 @@ def _AsciiHexEncode(input):
     "Helper function used by images"
     output = StringIO()
     for char in input:
-        output.write('%02x' % byteord(char))
+        output.write('%02x' % ord(char))
     output.write('>')
     output.seek(0)
     return output.read()
@@ -135,10 +133,10 @@ def _AsciiBase85Encode(input):
 
     for i in range(whole_word_count):
         offset = i*4
-        b1 = byteord(body[offset])
-        b2 = byteord(body[offset+1])
-        b3 = byteord(body[offset+2])
-        b4 = byteord(body[offset+3])
+        b1 = body[offset]
+        b2 = body[offset+1]
+        b3 = body[offset+2]
+        b4 = body[offset+3]
 
         num = 16777216 * b1 + 65536 * b2 + 256 * b3 + b4
 
@@ -166,10 +164,10 @@ def _AsciiBase85Encode(input):
     if remainder_size > 0:
         while len(lastbit) < 4:
             lastbit = lastbit + b'\000'
-        b1 = byteord(lastbit[0])
-        b2 = byteord(lastbit[1])
-        b3 = byteord(lastbit[2])
-        b4 = byteord(lastbit[3])
+        b1 = lastbit[0]
+        b2 = lastbit[1]
+        b3 = lastbit[2]
+        b4 = lastbit[3]
 
         num = 16777216 * b1 + 65536 * b2 + 256 * b3 + b4
 
@@ -212,11 +210,11 @@ def _AsciiBase85Decode(input):
 
     for i in range(whole_word_count):
         offset = i*5
-        c1 = byteord(body[offset]) - 33
-        c2 = byteord(body[offset+1]) - 33
-        c3 = byteord(body[offset+2]) - 33
-        c4 = byteord(body[offset+3]) - 33
-        c5 = byteord(body[offset+4]) - 33
+        c1 = ord(body[offset]) - 33
+        c2 = ord(body[offset+1]) - 33
+        c3 = ord(body[offset+2]) - 33
+        c4 = ord(body[offset+3]) - 33
+        c5 = ord(body[offset+4]) - 33
 
         num = ((85**4) * c1) + ((85**3) * c2) + ((85**2) * c3) + (85*c4) + c5
 
@@ -234,11 +232,11 @@ def _AsciiBase85Decode(input):
     if remainder_size > 0:
         while len(lastbit) < 5:
             lastbit = lastbit + '!'
-        c1 = byteord(lastbit[0]) - 33
-        c2 = byteord(lastbit[1]) - 33
-        c3 = byteord(lastbit[2]) - 33
-        c4 = byteord(lastbit[3]) - 33
-        c5 = byteord(lastbit[4]) - 33
+        c1 = ord(lastbit[0]) - 33
+        c2 = ord(lastbit[1]) - 33
+        c3 = ord(lastbit[2]) - 33
+        c4 = ord(lastbit[3]) - 33
+        c5 = ord(lastbit[4]) - 33
         num = ((85**4) * c1) + ((85**3) * c2) + ((85**2) * c3) + (85*c4) + c5
         temp, b4 = divmod(num,256)
         temp, b3 = divmod(temp,256)

--- a/python/afdko/proofpdf.py
+++ b/python/afdko/proofpdf.py
@@ -16,10 +16,8 @@ import sys
 import tempfile
 import time
 import traceback
-import subprocess
 
 from fontTools.ttLib import TTFont, getTableModule, TTLibError
-from fontTools.misc.py23 import open
 
 from afdko.fontpdf import (FontPDFParams, makePDF, makeFontSetPDF, kDrawTag,
                            kDrawPointTag, kShowMetaTag, params_doc)

--- a/python/afdko/stemhist.py
+++ b/python/afdko/stemhist.py
@@ -104,20 +104,18 @@ A range of glyphs may be specified by providing two names separated only
 """
 
 
-
-import sys
+from collections import defaultdict
 import os
-import re
+import sys
 import time
+import traceback
+
 from fontTools.ttLib import TTFont, getTableModule
-from fontTools.misc.py23 import open, tounicode
 from afdko.autohint import (
 	parseGlyphListArg, getGlyphID, getGlyphNames, filterGlyphList, openFile,
 	ACOptionParseError, ACFontError, logMsg, ACreport, expandNames,
 	AUTOHINTEXE)
 from afdko import fdkutils, ufotools
-import traceback
-from collections import defaultdict
 
 
 rawData = []
@@ -438,10 +436,10 @@ def PrintReports(path, h_stem_list, v_stem_list, top_zone_list, bot_zone_list):
 		header = headers[i]
 		try:
 			with open(fName, "w") as fp:
-				fp.write(tounicode(title))
-				fp.write(tounicode(header))
+				fp.write(title)
+				fp.write(header)
 				for item in formatReport(rep_list, sortFunc):
-					fp.write(tounicode(item))
+					fp.write(item)
 				print("Wrote %s" % fName)
 		except (IOError, OSError):
 			print("Error creating file %s!" % fName)
@@ -488,7 +486,7 @@ def collectStemsFont(path, options):
 	if fdGlyphDict == None:
 		fdDict = fontDictList[0]
 		with open(tempFI, "w") as fp:
-			fp.write(tounicode(fdDict.getFontInfo()))
+			fp.write(fdDict.getFontInfo())
 	else:
 		if not options.verbose:
 			logMsg("Note: Using alternate FDDict global values from fontinfo file for some glyphs. Remove option '-q' to see which dict is used for which glyphs.")
@@ -536,7 +534,7 @@ def collectStemsFont(path, options):
 				lastFDIndex = fdIndex
 				fdDict = fontData.getFontInfo(psName, path, options.allow_no_blues, options.noFlex, options.vCounterGlyphs, options.hCounterGlyphs, fdIndex)
 				with open(tempFI, "w") as fp:
-					fp.write(tounicode(fdDict.getFontInfo()))
+					fp.write(fdDict.getFontInfo())
 		else:
 			if (fdGlyphDict != None):
 				try:
@@ -548,14 +546,14 @@ def collectStemsFont(path, options):
 					lastFDIndex = fdIndex
 					fdDict = fontDictList[fdIndex]
 					with open(tempFI, "w") as fp:
-						fp.write(tounicode(fdDict.getFontInfo()))
+						fp.write(fdDict.getFontInfo())
 
 		glyphReports.startGlyphName(name)
 
 
 		# 	Call auto-hint library on bez string.
 		with open(tempBez, "w") as bp:
-			bp.write(tounicode(bezString))
+			bp.write(bezString)
 
 		if options.doAlign:
 			doAlign = "-ra"
@@ -635,7 +633,7 @@ def main():
 			return 1
 		if options.debug:
 			with open("rawdata.txt", "w") as fp:
-				fp.write(tounicode('\n'.join(rawData)))
+				fp.write('\n'.join(rawData))
 
 
 if __name__=='__main__':

--- a/python/afdko/ttfcomponentizer.py
+++ b/python/afdko/ttfcomponentizer.py
@@ -10,13 +10,12 @@ import argparse
 import os
 import sys
 
-from fontTools.misc.py23 import open
 from fontTools.ttLib import TTFont, getTableModule
 from fontTools.ufoLib.errors import UFOLibError
 from defcon import Font
 
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 
 PUBLIC_PSNAMES = "public.postscriptNames"

--- a/python/afdko/ttfpdf.py
+++ b/python/afdko/ttfpdf.py
@@ -1,5 +1,5 @@
 """
-otfpdf v1.4.1 Feb 17 2019
+otfpdf v1.4.2 Jul 15 2019
 provides support for the proofpdf script,  for working with OpenType/TTF
 fonts. Provides an implementation of the fontpdf font object. Cannot be
 run alone.
@@ -8,11 +8,12 @@ __copyright__ = """Copyright 2014 Adobe Systems Incorporated (http://www.adobe.c
 """
 
 from fontTools.pens.boundsPen import BoundsPen
-from fontTools.misc.py23 import round
 from afdko.fontpdf import FontPDFGlyph, FontPDFFont, FontPDFPen
 
+__version__ = "1.4.2"
 
-class  txPDFFont(FontPDFFont):
+
+class txPDFFont(FontPDFFont):
 
 	def __init__(self, clientFont, params):
 		self.clientFont = clientFont

--- a/python/afdko/ttxn.py
+++ b/python/afdko/ttxn.py
@@ -60,7 +60,7 @@ Get feat tag list. For each tag:
 """
 
 __help__ = """
-ttxn v1.21.1 Jan 30 2019
+ttxn v1.21.2 Jul 15 2019
 
 Based on the ttx tool, with the same options, except that it is limited to
 dumping, and cannot compile. Makes a normalized dump of the font, or of
@@ -79,7 +79,6 @@ from fontTools import ttx
 from fontTools.ttLib import TTFont, tagToXML, TTLibError
 from fontTools.ttLib.tables.DefaultTable import DefaultTable
 from fontTools.misc.loggingTools import Timer
-from fontTools.misc.py23 import open, basestring
 import copy
 import subprocess
 import re
@@ -91,6 +90,7 @@ import logging
 
 from afdko.fdkutils import get_temp_file_path
 
+__version__ = "1.21.2"
 
 log = logging.getLogger('fontTools.ttx')
 
@@ -253,7 +253,7 @@ def checkGlyphInSequence(glyphName, contextSequence, i):
         if isinstance(input_seq, list):
             if glyphName in input_seq:
                 retVal = 1
-        elif isinstance(input_seq, basestring):
+        elif isinstance(input_seq, str):
             if glyphName == input_seq:
                 retVal = 1
     except IndexError:

--- a/python/afdko/ufotools.py
+++ b/python/afdko/ufotools.py
@@ -8,7 +8,6 @@ from collections import OrderedDict
 
 from fontTools.misc import etree as ET
 from fontTools.misc import plistlib
-from fontTools.misc.py23 import open, tounicode, tostr, round
 from fontTools.ufoLib import UFOReader
 from fontTools.ufoLib.glifLib import Glyph
 
@@ -17,10 +16,10 @@ from psautohint.ufoFont import (norm_float, HashPointPen,
 
 from afdko import convertfonttocid, fdkutils
 
-__version__ = '1.34.3'
+__version__ = '1.34.4'
 
 __doc__ = """
-ufotools.py v1.34.3 Jul 12 2019
+ufotools.py v1.34.4 Jul 15 2019
 
 This module supports using the Adobe FDK tools which operate on 'bez'
 files with UFO fonts. It provides low level utilities to manipulate UFO
@@ -394,7 +393,7 @@ class BezParseError(Exception):
 
 class UFOFontData(object):
     def __init__(self, parentPath, useHashMap, programName):
-        self.parentPath = tounicode(parentPath, encoding='utf-8')
+        self.parentPath = parentPath
         self.glyphMap = {}
         self.processedLayerGlyphMap = {}
         self.newGlyphMap = {}
@@ -410,7 +409,7 @@ class UFOFontData(object):
         # hash matches hash of current glyph data.
         self.hashMap = {}
         self.fontDict = None
-        self.programName = tostr(programName)
+        self.programName = programName
         self.curSrcDir = None
         self.hashMapChanged = False
         self.glyphDefaultDir = os.path.join(self.parentPath, "glyphs")
@@ -561,7 +560,7 @@ class UFOFontData(object):
         data.append("")
         data = '\n'.join(data)
         with open(hashPath, "w") as fp:
-            fp.write(tounicode(data))
+            fp.write(data)
 
     def getCurGlyphPath(self, glyphName):
         if self.curSrcDir is None:
@@ -631,7 +630,7 @@ class UFOFontData(object):
         # and we have just created a new glyph in the processed layer,
         # then reset the history.
         if (not self.useProcessedLayer) and changed:
-            self.hashMap[glyphName] = [tostr(srcHash), [self.programName]]
+            self.hashMap[glyphName] = [srcHash, [self.programName]]
         # If the program is not in the history list, add it.
         elif self.programName not in historyList:
             historyList.append(self.programName)
@@ -644,7 +643,7 @@ class UFOFontData(object):
         hashAfter = hash_pen.getHash()
 
         if hashAfter != hashBefore:
-            self.hashMap[glyphName] = [tostr(hashAfter), historyList]
+            self.hashMap[glyphName] = [hashAfter, historyList]
             self.hashMapChanged = True
 
     def checkSkipGlyph(self, glyphName, newSrcHash, doAll):
@@ -681,8 +680,7 @@ class UFOFontData(object):
                 # case for Checkoutlines
                 if not self.useProcessedLayer:
                     self.hashMapChanged = True
-                    self.hashMap[glyphName] = [tostr(newSrcHash),
-                                               [self.programName]]
+                    self.hashMap[glyphName] = [newSrcHash, [self.programName]]
                     glyphPath = self.getGlyphProcessedPath(glyphName)
                     if glyphPath and os.path.exists(glyphPath):
                         os.remove(glyphPath)
@@ -710,7 +708,7 @@ class UFOFontData(object):
             # If the source hash has changed, we need to
             # delete the processed layer glyph.
             self.hashMapChanged = True
-            self.hashMap[glyphName] = [tostr(newSrcHash), [self.programName]]
+            self.hashMap[glyphName] = [newSrcHash, [self.programName]]
             glyphPath = self.getGlyphProcessedPath(glyphName)
             if glyphPath and os.path.exists(glyphPath):
                 os.remove(glyphPath)
@@ -1926,7 +1924,7 @@ def regenerate_glyph_hashes(ufo_font_data):
             continue
         ghash, _ = ufo_font_data.buildGlyphHashValue(
             gwidth, outline_xml, gname, True)
-        hash_entry[0] = tostr(ghash)
+        hash_entry[0] = ghash
 
 
 def checkHashMaps(fontPath, doSync):
@@ -2153,8 +2151,7 @@ def validateLayers(ufoFontPath, doWarning=True):
 
 
 def makeUFOFMNDB(srcFontPath):
-    fontInfoPath = os.path.join(tounicode(srcFontPath, encoding='utf-8'),
-                                kFontInfoName)  # default
+    fontInfoPath = os.path.join(srcFontPath, kFontInfoName)  # default
     fiMap, fiList = parsePList(fontInfoPath)
     psName = "NoFamilyName-Regular"
     familyName = "NoFamilyName"
@@ -2192,5 +2189,5 @@ def makeUFOFMNDB(srcFontPath):
     parts.append("")
     data = '\n'.join(parts)
     with open(fmndbPath, "w") as fp:
-        fp.write(tounicode(data))
+        fp.write(data)
     return fmndbPath

--- a/tests/differ.py
+++ b/tests/differ.py
@@ -13,9 +13,7 @@ import os
 import re
 import sys
 
-from fontTools.misc.py23 import open
-
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 
 logger = logging.getLogger('differ')
 

--- a/tests/otc2otf_test.py
+++ b/tests/otc2otf_test.py
@@ -2,8 +2,6 @@ import os
 import pytest
 from shutil import copy2, rmtree
 
-from fontTools.misc.py23 import tobytes
-
 from runner import main as runner
 from differ import main as differ
 from test_utils import get_input_path, get_expected_path, generate_ttx_dump
@@ -58,7 +56,7 @@ def test_convert(ttc_filename, otf_filenames, diff_index):
 
     with open(stdout_path, 'rb') as f:
         output = f.read()
-    assert tobytes(fonts_msg) in output
+    assert fonts_msg.encode('ascii') in output
 
     # diff only one of the OTFs
     otf_filename = otf_filenames[diff_index]

--- a/tests/otf2otc_test.py
+++ b/tests/otf2otc_test.py
@@ -1,8 +1,6 @@
 import os
 import pytest
 
-from fontTools.misc.py23 import tobytes
-
 from runner import main as runner
 from differ import main as differ
 from test_utils import get_expected_path, get_temp_file_path
@@ -14,16 +12,18 @@ REGULAR = 'SourceSansPro-Regular.otf'
 ITALIC = 'SourceSansPro-It.otf'
 BOLD = 'SourceSansPro-Bold.otf'
 
-MSG_1 = tobytes(
+MSG_1 = (
     "Shared tables: "
     "['BASE', 'DSIG', 'GDEF', 'GSUB', 'cmap', 'maxp', 'post']%s"
     "Un-shared tables: "
-    "['CFF ', 'GPOS', 'OS/2', 'head', 'hhea', 'hmtx', 'name']" % os.linesep)
+    "['CFF ', 'GPOS', 'OS/2', 'head', 'hhea', 'hmtx', 'name']" %
+    os.linesep).encode('ascii')
 
-MSG_2 = tobytes(
+MSG_2 = (
     "Shared tables: ['BASE', 'DSIG']%s"
     "Un-shared tables: ['CFF ', 'GDEF', 'GPOS', 'GSUB', 'OS/2', 'cmap', "
-    "'head', 'hhea', 'hmtx', 'maxp', 'name', 'post']" % os.linesep)
+    "'head', 'hhea', 'hmtx', 'maxp', 'name', 'post']" %
+    os.linesep).encode('ascii')
 
 
 # -----


### PR DESCRIPTION
- numerous modules
- also simplified `fdkutils.py` routines that do shell output (see [#847](https://github.com/adobe-type-tools/afdko/issues/847))