### PR TITLE
[ufotools] avoid FutureWarning

### DIFF
--- a/python/afdko/ufotools.py
+++ b/python/afdko/ufotools.py
@@ -1961,7 +1961,7 @@ def checkHashMaps(fontPath, doSync):
 
         width, _, outlineXML = ufoFontData.getGlyphXML(
             ufoFontData.glyphDefaultDir, glyphFileName)
-        if not outlineXML:
+        if outlineXML is None:
             continue
 
         newHash, _ = ufoFontData.buildGlyphHashValue(


### PR DESCRIPTION
`if not XXXXXX` construct raises a FutureWarning, originating in `lxml`. Now does an explicit check for `None`-ness. Closes #854.