### PR TITLE
[otf2ttf] Remove VORG table

### DIFF
--- a/python/afdko/otf2ttf.py
+++ b/python/afdko/otf2ttf.py
@@ -47,6 +47,8 @@ def otf_to_ttf(ttFont, post_format=POST_FORMAT, **kwargs):
     glyf.glyphOrder = glyphOrder
     glyf.glyphs = glyphs_to_quadratic(ttFont.getGlyphSet(), **kwargs)
     del ttFont["CFF "]
+    if "VORG" in ttFont:
+        del ttFont["VORG"]
     glyf.compile(ttFont)
 
     ttFont["maxp"] = maxp = newTable("maxp")

--- a/tests/otf2ttf_data/expected_output/kanjicid.ttx
+++ b/tests/otf2ttf_data/expected_output/kanjicid.ttx
@@ -11638,13 +11638,6 @@
     </VertAxis>
   </BASE>
 
-  <VORG>
-    <majorVersion value="1"/>
-    <minorVersion value="0"/>
-    <defaultVertOriginY value="880"/>
-    <numVertOriginYMetrics value="0"/>
-  </VORG>
-
   <vhea>
     <tableVersion value="0x00011000"/>
     <ascent value="500"/>


### PR DESCRIPTION
@kenlunde pointed out that it shouldn't be present in TTFs
https://docs.microsoft.com/en-us/typography/opentype/spec/vorg