### PR TITLE
[makeotfexe] added some boundary checks and iteration & recursion limits

### DIFF
--- a/c/makeotf/makeotf_lib/source/hotconv/hot.c
+++ b/c/makeotf/makeotf_lib/source/hotconv/hot.c
@@ -1853,8 +1853,7 @@ void CDECL hotMsg(hotCtx g, int level, char *fmt, ...) {
 #define MAX_NOTE_LEN 1024
             char message[MAX_NOTE_LEN + 1024];
             char *p;
-
-            if (g->font.FontName.cnt != 0) {
+            if ((g->font.FontName.cnt != 0) && (lenName < MAX_NOTE_LEN)) {
                 sprintf(message, "<%s> ", g->font.FontName.array);
                 p = &message[lenName];
             } else {

--- a/c/makeotf/makeotf_lib/source/hotconv/name.c
+++ b/c/makeotf/makeotf_lib/source/hotconv/name.c
@@ -281,13 +281,17 @@ static void addStdNames(nameCtx h, int win, int mac) {
         /* Add Unique name */
         /* xxx is this really needed or just a waste of space? */
         if (g->font.licenseID != NULL) {
-            sprintf(buf, "%.3f;%s;%s;%s",
+            snprintf(buf,
+                    sizeof(buf),
+                    "%.3f;%s;%s;%s",
                     dFontVersion,
                     g->font.vendId,
                     g->font.FontName.array,
                     g->font.licenseID);
         } else {
-            sprintf(buf, "%.3f;%s;%s",
+            snprintf(buf,
+                    sizeof(buf),
+                    "%.3f;%s;%s",
                     dFontVersion,
                     g->font.vendId,
                     g->font.FontName.array);

--- a/c/makeotf/makeotf_lib/source/pstoken/pstoken.c
+++ b/c/makeotf/makeotf_lib/source/pstoken/pstoken.c
@@ -44,13 +44,13 @@ static char class[256] = {
     /* -- Rest are zero -- */
 };
 
-#define ISWHITE(c) (class[(int)(c)] & W_)
-#define ISNEWLINE(c) (class[(int)(c)] & N_)
-#define ISSPECIAL(c) (class[(int)(c)] & S_)
-#define ISDELIMETER(c) (class[(int)(c)] & (S_ | W_))
-#define ISNUMBER(c) (class[(int)(c)] & (D_ | G_ | P_))
-#define ISSIGN(c) (class[(int)(c)] & G_)
-#define ISEXPONENT(c) (class[(int)(c)] & E_)
+#define ISWHITE(c) (class[(uint8_t)(c)] & W_)
+#define ISNEWLINE(c) (class[(uint8_t)(c)] & N_)
+#define ISSPECIAL(c) (class[(uint8_t)(c)] & S_)
+#define ISDELIMETER(c) (class[(uint8_t)(c)] & (S_ | W_))
+#define ISNUMBER(c) (class[(uint8_t)(c)] & (D_ | G_ | P_))
+#define ISSIGN(c) (class[(uint8_t)(c)] & G_)
+#define ISEXPONENT(c) (class[(uint8_t)(c)] & E_)
 
 /* Index by ascii character and return digit value or error (255) */
 static unsigned char digit[256] = {
@@ -72,9 +72,9 @@ static unsigned char digit[256] = {
     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, /* f0-ff */
 };
 
-#define ISDIGIT(c) (digit[(int)(c)] < 10)
-#define ISHEX(c) (digit[(int)(c)] < 16)
-#define ISRADIX(c, b) (digit[(int)(c)] < (b))
+#define ISDIGIT(c) (digit[(uint8_t)(c)] < 10)
+#define ISHEX(c) (digit[(uint8_t)(c)] < 16)
+#define ISRADIX(c, b) (digit[(uint8_t)(c)] < (b))
 
 /* Parse context */
 struct psCtx_ {
@@ -117,11 +117,11 @@ static int hexdecrypt(psCtx h, int check) {
     int plain;
 
     /* Form cipher byte from 2 hexadecimal characters */
-    while ((nibble = digit[(int)GETRAW(1)]) > 15) {
+    while ((nibble = digit[(uint8_t)GETRAW(1)]) > 15) {
     }
     cipher = nibble << 4;
 
-    while ((nibble = digit[(int)GETRAW(1)]) > 15) {
+    while ((nibble = digit[(uint8_t)GETRAW(1)]) > 15) {
     }
     cipher |= nibble;
 
@@ -659,7 +659,7 @@ int32_t psConvInteger(psCtx h, psToken *token) {
             base = value;
             value = 0;
         } else {
-            value = value * base + digit[(int)(*p)];
+            value = value * base + digit[(uint8_t)(*p)];
         }
     } while (++p < end);
 

--- a/c/makeotf/makeotf_lib/source/typecomp/recode.c
+++ b/c/makeotf/makeotf_lib/source/typecomp/recode.c
@@ -2867,6 +2867,9 @@ static void recodePath(recodeCtx h) {
 
     /* Create optimized Type 2 charstring from operators and segments */
     iSeg = 0;
+    if (h->path.ops.cnt == 0) {
+        badChar(h);
+    }
     nextop = h->path.ops.array;
     for (;;) {
         int newop;

--- a/c/makeotf/makeotf_lib/source/typecomp/tc.c
+++ b/c/makeotf/makeotf_lib/source/typecomp/tc.c
@@ -224,7 +224,11 @@ static void calcSizes(tcprivCtx h) {
 
 /* Fill initial sizes in font */
 static void fillInitialSizes(tcprivCtx h, Font *font) {
-    font->size.FontName = strlen(font->FontName);
+    if (font->FontName != NULL) {
+        font->size.FontName = strlen(font->FontName);
+    } else{
+        font->size.FontName = 0;
+    }
     font->size.dict = font->dict.cnt;
     font->size.CharStrings =
         (font->flags & FONT_CHAMELEON) ? 0 : csSizeChars(h->g, font);

--- a/c/makeotf/source/cbpriv.c
+++ b/c/makeotf/source/cbpriv.c
@@ -18,7 +18,7 @@ void cbFatal(cbCtx h, char *fmt, ...) {
     char text[512];
     va_list ap;
     va_start(ap, fmt);
-    vsprintf(text, fmt, ap);
+    vsnprintf(text, sizeof(text), fmt, ap);
     message(h, hotFATAL, text);
     va_end(ap);
     if (!KeepGoing) {
@@ -31,7 +31,7 @@ void cbWarning(cbCtx h, char *fmt, ...) {
     char text[512];
     va_list ap;
     va_start(ap, fmt);
-    vsprintf(text, fmt, ap);
+    vsnprintf(text, sizeof(text), fmt, ap);
     message(h, hotWARNING, text);
     va_end(ap);
 }

--- a/c/makeotf/source/fcdb.c
+++ b/c/makeotf/source/fcdb.c
@@ -18,6 +18,10 @@
 #include "file.h"
 #include "ctutil.h"
 
+#ifndef MIN
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
 /* Keyword ids */
 enum {
     kFamily,         /* "f", "family" */
@@ -666,10 +670,12 @@ static void buildDefaultRec(fcdbCtx h, char *FontName) {
 
     if ((sepIndex > -1) && (FontName[sepIndex] == '-')) { /* On Windows, strcspn returns the string length when the char is not found! */
         subFamily = &FontName[sepIndex + 1];
+        sepIndex = MIN(sepIndex, sizeof(familyName) - 1);
         strncpy(familyName, FontName, sepIndex);
         familyName[sepIndex] = 0;
     } else {
-        strcpy(familyName, FontName);
+        strncpy(familyName, FontName, sizeof(familyName));
+        familyName[sizeof(familyName) - 1] = 0;
     }
 
     nameId = HOT_NAME_FAMILY; /* family */


### PR DESCRIPTION
`cffread.c`
* added iteration count limit to `flatten()`
* added recursion depth limit to `flatten()`

`hot.c`
* added check to ensure `message` buffer size not exceeded

`name.c`
* replaced a couple of `sprintf()` calls with `snprintf()`

`pstoken.c`
* cast indices for `class[]` to `uint8_t` to prevent negative index with `c >= 0x80`
* cast indices for `digits[]` to `uint8_t` to prevent negative index with `c >= 0x80`

`recode.c`
* check if there are any operators before processing them in `recodePath()`

`tc.c`
* check `FontName` for `NULL` pointer before taking length of it in `fillInitialSizes()`

`cbpriv.c`
* replaced a couple of `vsprintf()` calls with `vsnprintf()`

`fcdb.c`
* added a boundary check before a call to `strncpy()` in `buildDefaultRec()`
* replaced a call to `strcpy()` with a call to `strncpy()` in `buildDefaultRec()`
