### PR TITLE
[python] pin lxml version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+lxml==4.4.0
 booleanOperations==0.8.2
 cu2qu[cli]==1.6.5
 defcon[lxml,pens]==0.6.0

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/A_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/A_.glif
@@ -7,26 +7,26 @@
   <anchor x="270.04" y="-14.999999999999996" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="8.38" y="6.56" name="hintSet0000"/>
-      <point type="line" x="91.68" y="6.56"/>
-      <point type="line" x="204.38" y="366.22"/>
+      <point x="8.38" y="6.56" type="line" name="hintSet0000"/>
+      <point x="91.68" y="6.56" type="line"/>
+      <point x="204.38" y="366.22" type="line"/>
       <point x="227.9" y="437.76"/>
       <point x="248.48" y="508.32"/>
-      <point type="curve" x="268.08" y="582.8"/>
-      <point type="line" x="272" y="582.8"/>
+      <point x="268.08" y="582.8" type="curve"/>
+      <point x="272" y="582.8" type="line"/>
       <point x="292.58" y="508.32"/>
       <point x="313.16" y="437.76"/>
-      <point type="curve" x="336.68" y="366.22"/>
-      <point type="line" x="448.4" y="6.56"/>
-      <point type="line" x="535.62" y="6.56"/>
-      <point type="line" x="318.06" y="649.44"/>
-      <point type="line" x="225.94" y="649.44"/>
+      <point x="336.68" y="366.22" type="curve"/>
+      <point x="448.4" y="6.56" type="line"/>
+      <point x="535.62" y="6.56" type="line"/>
+      <point x="318.06" y="649.44" type="line"/>
+      <point x="225.94" y="649.44" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="122.06" y="202.56"/>
-      <point type="line" x="419" y="202.56"/>
-      <point type="line" x="419" y="268.22"/>
-      <point type="line" x="122.06" y="268.22"/>
+      <point x="122.06" y="202.56" type="line"/>
+      <point x="419" y="202.56" type="line"/>
+      <point x="419" y="268.22" type="line"/>
+      <point x="122.06" y="268.22" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/B_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/B_.glif
@@ -6,44 +6,44 @@
   <anchor x="302.34" y="-14.999999999999996" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="94.58" y="6.56" name="hintSet0000"/>
-      <point type="line" x="299.4" y="6.56"/>
+      <point x="94.58" y="6.56" type="line" name="hintSet0000"/>
+      <point x="299.4" y="6.56" type="line"/>
       <point x="443.46" y="6.56"/>
       <point x="543.42" y="68.3"/>
-      <point type="curve" x="543.42" y="194.72"/>
+      <point x="543.42" y="194.72" type="curve"/>
       <point x="543.42" y="282.92"/>
       <point x="489.52" y="333.88"/>
-      <point type="curve" x="412.1" y="348.58"/>
-      <point type="line" x="412.1" y="352.5"/>
+      <point x="412.1" y="348.58" type="curve"/>
+      <point x="412.1" y="352.5" type="line"/>
       <point x="472.86" y="372.1" name="hintSet0005"/>
       <point x="506.18" y="428.94"/>
-      <point type="curve" x="506.18" y="492.64"/>
+      <point x="506.18" y="492.64" type="curve"/>
       <point x="506.18" y="605.34"/>
       <point x="416.02" y="649.44"/>
-      <point type="curve" x="285.68" y="649.44"/>
-      <point type="line" x="94.58" y="649.44"/>
+      <point x="285.68" y="649.44" type="curve"/>
+      <point x="94.58" y="649.44" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="175.92" y="376.02"/>
-      <point type="line" x="175.92" y="584.76"/>
-      <point type="line" x="274.9" y="584.76"/>
+      <point x="175.92" y="376.02" type="line"/>
+      <point x="175.92" y="584.76" type="line"/>
+      <point x="274.9" y="584.76" type="line"/>
       <point x="374.86" y="584.76"/>
       <point x="425.82" y="556.34"/>
-      <point type="curve" x="425.82" y="481.86"/>
+      <point x="425.82" y="481.86" type="curve"/>
       <point x="425.82" y="416.2"/>
       <point x="380.74" y="376.02"/>
-      <point type="curve" x="270.98" y="376.02"/>
+      <point x="270.98" y="376.02" type="curve"/>
     </contour>
     <contour>
-      <point type="line" x="175.92" y="71.24"/>
-      <point type="line" x="175.92" y="313.3"/>
-      <point type="line" x="287.64" y="313.3"/>
+      <point x="175.92" y="71.24" type="line"/>
+      <point x="175.92" y="313.3" type="line"/>
+      <point x="287.64" y="313.3" type="line"/>
       <point x="400.34" y="313.3" name="hintSet0016"/>
       <point x="463.06" y="277.04"/>
-      <point type="curve" x="463.06" y="197.66"/>
+      <point x="463.06" y="197.66" type="curve"/>
       <point x="463.06" y="111.42"/>
       <point x="398.38" y="71.24"/>
-      <point type="curve" x="287.64" y="71.24"/>
+      <point x="287.64" y="71.24" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/C_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/C_.glif
@@ -7,30 +7,30 @@
   <anchor x="274.40000000000003" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="270.4" y="-9.6" name="hintSet0000"/>
+      <point x="270.4" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="338.4" y="-9.6"/>
       <point x="389.6" y="18.4"/>
-      <point type="curve" x="431.2" y="66.4"/>
-      <point type="line" x="394.4" y="108"/>
+      <point x="431.2" y="66.4" type="curve"/>
+      <point x="394.4" y="108" type="line"/>
       <point x="360.8" y="71.2"/>
       <point x="323.2" y="48.8"/>
-      <point type="curve" x="272.8" y="48.8"/>
+      <point x="272.8" y="48.8" type="curve"/>
       <point x="173.6" y="48.8"/>
       <point x="110.4" y="132"/>
-      <point type="curve" x="110.4" y="264"/>
+      <point x="110.4" y="264" type="curve"/>
       <point x="110.4" y="394.4"/>
       <point x="176" y="476"/>
-      <point type="curve" x="275.2" y="476"/>
+      <point x="275.2" y="476" type="curve"/>
       <point x="320" y="476"/>
       <point x="354.4" y="456"/>
-      <point type="curve" x="382.4" y="426.4"/>
-      <point type="line" x="418.4" y="469.6"/>
+      <point x="382.4" y="426.4" type="curve"/>
+      <point x="418.4" y="469.6" type="line"/>
       <point x="388" y="504"/>
       <point x="338.4" y="534.4"/>
-      <point type="curve" x="274.4" y="534.4"/>
+      <point x="274.4" y="534.4" type="curve"/>
       <point x="140.8" y="534.4"/>
       <point x="41.6" y="431.2"/>
-      <point type="curve" x="41.6" y="262.4"/>
+      <point x="41.6" y="262.4" type="curve"/>
       <point x="41.6" y="91.2"/>
       <point x="139.2" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/D_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/D_.glif
@@ -6,26 +6,26 @@
   <anchor x="244.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="206.4" y="0"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="206.4" y="0" type="line"/>
       <point x="364.8" y="0"/>
       <point x="451.2" y="97.6"/>
-      <point type="curve" x="451.2" y="264.8"/>
+      <point x="451.2" y="264.8" type="curve"/>
       <point x="451.2" y="431.2"/>
       <point x="364.8" y="524.8"/>
-      <point type="curve" x="203.2" y="524.8"/>
-      <point type="line" x="72" y="524.8"/>
+      <point x="203.2" y="524.8" type="curve"/>
+      <point x="72" y="524.8" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="138.4" y="54.4"/>
-      <point type="line" x="138.4" y="470.4"/>
-      <point type="line" x="198.4" y="470.4"/>
+      <point x="138.4" y="54.4" type="line"/>
+      <point x="138.4" y="470.4" type="line"/>
+      <point x="198.4" y="470.4" type="line"/>
       <point x="320.8" y="470.4"/>
       <point x="382.4" y="396.8"/>
-      <point type="curve" x="382.4" y="264.8"/>
+      <point x="382.4" y="264.8" type="curve"/>
       <point x="382.4" y="132"/>
       <point x="320.8" y="54.4"/>
-      <point type="curve" x="198.4" y="54.4"/>
+      <point x="198.4" y="54.4" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/E_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/E_.glif
@@ -7,18 +7,18 @@
   <anchor x="238.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="382.4" y="0"/>
-      <point type="line" x="382.4" y="56.8"/>
-      <point type="line" x="138.4" y="56.8"/>
-      <point type="line" x="138.4" y="247.2"/>
-      <point type="line" x="337.6" y="247.2"/>
-      <point type="line" x="337.6" y="304"/>
-      <point type="line" x="138.4" y="304"/>
-      <point type="line" x="138.4" y="468.8"/>
-      <point type="line" x="374.4" y="468.8"/>
-      <point type="line" x="374.4" y="524.8"/>
-      <point type="line" x="72" y="524.8"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="382.4" y="0" type="line"/>
+      <point x="382.4" y="56.8" type="line"/>
+      <point x="138.4" y="56.8" type="line"/>
+      <point x="138.4" y="247.2" type="line"/>
+      <point x="337.6" y="247.2" type="line"/>
+      <point x="337.6" y="304" type="line"/>
+      <point x="138.4" y="304" type="line"/>
+      <point x="138.4" y="468.8" type="line"/>
+      <point x="374.4" y="468.8" type="line"/>
+      <point x="374.4" y="524.8" type="line"/>
+      <point x="72" y="524.8" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/F_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/F_.glif
@@ -6,16 +6,16 @@
   <anchor x="108.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="138.4" y="0"/>
-      <point type="line" x="138.4" y="235.2"/>
-      <point type="line" x="338.4" y="235.2"/>
-      <point type="line" x="338.4" y="291.2"/>
-      <point type="line" x="138.4" y="291.2"/>
-      <point type="line" x="138.4" y="468.8"/>
-      <point type="line" x="374.4" y="468.8"/>
-      <point type="line" x="374.4" y="524.8"/>
-      <point type="line" x="72" y="524.8"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="138.4" y="0" type="line"/>
+      <point x="138.4" y="235.2" type="line"/>
+      <point x="338.4" y="235.2" type="line"/>
+      <point x="338.4" y="291.2" type="line"/>
+      <point x="138.4" y="291.2" type="line"/>
+      <point x="138.4" y="468.8" type="line"/>
+      <point x="374.4" y="468.8" type="line"/>
+      <point x="374.4" y="524.8" type="line"/>
+      <point x="72" y="524.8" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/G_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/G_.glif
@@ -6,34 +6,34 @@
   <anchor x="278.40000000000003" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="278.4" y="-9.6" name="hintSet0000"/>
+      <point x="278.4" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="348.8" y="-9.6"/>
       <point x="406.4" y="16"/>
-      <point type="curve" x="440" y="51.2"/>
-      <point type="line" x="440" y="272"/>
-      <point type="line" x="268" y="272" name="hintSet0003"/>
-      <point type="line" x="268" y="216.8"/>
-      <point type="line" x="379.2" y="216.8" name="hintSet0005"/>
-      <point type="line" x="379.2" y="80"/>
+      <point x="440" y="51.2" type="curve"/>
+      <point x="440" y="272" type="line"/>
+      <point x="268" y="272" type="line" name="hintSet0003"/>
+      <point x="268" y="216.8" type="line"/>
+      <point x="379.2" y="216.8" type="line" name="hintSet0005"/>
+      <point x="379.2" y="80" type="line"/>
       <point x="358.4" y="60.8"/>
       <point x="322.4" y="48.8"/>
-      <point type="curve" x="284.8" y="48.8"/>
+      <point x="284.8" y="48.8" type="curve"/>
       <point x="172.8" y="48.8"/>
       <point x="110.4" y="132"/>
-      <point type="curve" x="110.4" y="264"/>
+      <point x="110.4" y="264" type="curve"/>
       <point x="110.4" y="394.4"/>
       <point x="178.4" y="476"/>
-      <point type="curve" x="284" y="476"/>
+      <point x="284" y="476" type="curve"/>
       <point x="336.8" y="476"/>
       <point x="370.4" y="453.6"/>
-      <point type="curve" x="396.8" y="426.4"/>
-      <point type="line" x="433.6" y="469.6"/>
+      <point x="396.8" y="426.4" type="curve"/>
+      <point x="433.6" y="469.6" type="line"/>
       <point x="403.2" y="501.6"/>
       <point x="355.2" y="534.4"/>
-      <point type="curve" x="282.4" y="534.4"/>
+      <point x="282.4" y="534.4" type="curve"/>
       <point x="143.2" y="534.4"/>
       <point x="41.6" y="431.2"/>
-      <point type="curve" x="41.6" y="262.4"/>
+      <point x="41.6" y="262.4" type="curve"/>
       <point x="41.6" y="91.2"/>
       <point x="140" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/H_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/H_.glif
@@ -6,18 +6,18 @@
   <anchor x="260.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="138.4" y="0"/>
-      <point type="line" x="138.4" y="247.2"/>
-      <point type="line" x="382.4" y="247.2"/>
-      <point type="line" x="382.4" y="0"/>
-      <point type="line" x="449.6" y="0"/>
-      <point type="line" x="449.6" y="524.8"/>
-      <point type="line" x="382.4" y="524.8"/>
-      <point type="line" x="382.4" y="304.8"/>
-      <point type="line" x="138.4" y="304.8"/>
-      <point type="line" x="138.4" y="524.8"/>
-      <point type="line" x="72" y="524.8"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="138.4" y="0" type="line"/>
+      <point x="138.4" y="247.2" type="line"/>
+      <point x="382.4" y="247.2" type="line"/>
+      <point x="382.4" y="0" type="line"/>
+      <point x="449.6" y="0" type="line"/>
+      <point x="449.6" y="524.8" type="line"/>
+      <point x="382.4" y="524.8" type="line"/>
+      <point x="382.4" y="304.8" type="line"/>
+      <point x="138.4" y="304.8" type="line"/>
+      <point x="138.4" y="524.8" type="line"/>
+      <point x="72" y="524.8" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/I_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/I_.glif
@@ -7,10 +7,10 @@
   <anchor x="104.80000000000001" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="138.4" y="0"/>
-      <point type="line" x="138.4" y="524.8"/>
-      <point type="line" x="72" y="524.8"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="138.4" y="0" type="line"/>
+      <point x="138.4" y="524.8" type="line"/>
+      <point x="72" y="524.8" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/J_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/J_.glif
@@ -6,20 +6,20 @@
   <anchor x="202.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="169.6" y="-9.6" name="hintSet0000"/>
+      <point x="169.6" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="272" y="-9.6"/>
       <point x="314.4" y="64"/>
-      <point type="curve" x="314.4" y="154.4"/>
-      <point type="line" x="314.4" y="524.8"/>
-      <point type="line" x="247.2" y="524.8"/>
-      <point type="line" x="247.2" y="160.8"/>
+      <point x="314.4" y="154.4" type="curve"/>
+      <point x="314.4" y="524.8" type="line"/>
+      <point x="247.2" y="524.8" type="line"/>
+      <point x="247.2" y="160.8" type="line"/>
       <point x="247.2" y="80.8"/>
       <point x="219.2" y="48.8"/>
-      <point type="curve" x="163.2" y="48.8"/>
+      <point x="163.2" y="48.8" type="curve"/>
       <point x="125.6" y="48.8"/>
       <point x="96" y="66.4"/>
-      <point type="curve" x="72.8" y="108"/>
-      <point type="line" x="24.8" y="74.4"/>
+      <point x="72.8" y="108" type="curve"/>
+      <point x="24.8" y="74.4" type="line"/>
       <point x="55.2" y="19.2"/>
       <point x="103.2" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/K_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/K_.glif
@@ -6,19 +6,19 @@
   <anchor x="262.40000000000003" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="138.4" y="0"/>
-      <point type="line" x="138.4" y="166.4"/>
-      <point type="line" x="228.8" y="272.8"/>
-      <point type="line" x="385.6" y="0"/>
-      <point type="line" x="460" y="0"/>
-      <point type="line" x="270.4" y="324.8"/>
-      <point type="line" x="434.4" y="524.8"/>
-      <point type="line" x="359.2" y="524.8"/>
-      <point type="line" x="140.8" y="261.6"/>
-      <point type="line" x="138.4" y="261.6"/>
-      <point type="line" x="138.4" y="524.8"/>
-      <point type="line" x="72" y="524.8"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="138.4" y="0" type="line"/>
+      <point x="138.4" y="166.4" type="line"/>
+      <point x="228.8" y="272.8" type="line"/>
+      <point x="385.6" y="0" type="line"/>
+      <point x="460" y="0" type="line"/>
+      <point x="270.4" y="324.8" type="line"/>
+      <point x="434.4" y="524.8" type="line"/>
+      <point x="359.2" y="524.8" type="line"/>
+      <point x="140.8" y="261.6" type="line"/>
+      <point x="138.4" y="261.6" type="line"/>
+      <point x="138.4" y="524.8" type="line"/>
+      <point x="72" y="524.8" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/L_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/L_.glif
@@ -6,12 +6,12 @@
   <anchor x="231.20000000000002" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="368" y="0"/>
-      <point type="line" x="368" y="56.8"/>
-      <point type="line" x="138.4" y="56.8"/>
-      <point type="line" x="138.4" y="524.8"/>
-      <point type="line" x="72" y="524.8"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="368" y="0" type="line"/>
+      <point x="368" y="56.8" type="line"/>
+      <point x="138.4" y="56.8" type="line"/>
+      <point x="138.4" y="524.8" type="line"/>
+      <point x="72" y="524.8" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/M_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/M_.glif
@@ -6,36 +6,36 @@
   <anchor x="292.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="132" y="0"/>
-      <point type="line" x="132" y="288.8"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="132" y="0" type="line"/>
+      <point x="132" y="288.8" type="line"/>
       <point x="132" y="335.2"/>
       <point x="127.2" y="397.6"/>
-      <point type="curve" x="124" y="444"/>
-      <point type="line" x="127.2" y="444"/>
-      <point type="line" x="168.8" y="324.8"/>
-      <point type="line" x="268" y="52.8"/>
-      <point type="line" x="312" y="52.8"/>
-      <point type="line" x="411.2" y="324.8"/>
-      <point type="line" x="452.8" y="444"/>
-      <point type="line" x="456" y="444"/>
+      <point x="124" y="444" type="curve"/>
+      <point x="127.2" y="444" type="line"/>
+      <point x="168.8" y="324.8" type="line"/>
+      <point x="268" y="52.8" type="line"/>
+      <point x="312" y="52.8" type="line"/>
+      <point x="411.2" y="324.8" type="line"/>
+      <point x="452.8" y="444" type="line"/>
+      <point x="456" y="444" type="line"/>
       <point x="452.8" y="397.6"/>
       <point x="447.2" y="335.2"/>
-      <point type="curve" x="447.2" y="288.8"/>
-      <point type="line" x="447.2" y="0"/>
-      <point type="line" x="509.6" y="0"/>
-      <point type="line" x="509.6" y="524.8"/>
-      <point type="line" x="428.8" y="524.8"/>
-      <point type="line" x="329.6" y="244.8"/>
+      <point x="447.2" y="288.8" type="curve"/>
+      <point x="447.2" y="0" type="line"/>
+      <point x="509.6" y="0" type="line"/>
+      <point x="509.6" y="524.8" type="line"/>
+      <point x="428.8" y="524.8" type="line"/>
+      <point x="329.6" y="244.8" type="line"/>
       <point x="316.8" y="208.8"/>
       <point x="306.4" y="171.2"/>
-      <point type="curve" x="293.6" y="135.2"/>
-      <point type="line" x="290.4" y="135.2"/>
+      <point x="293.6" y="135.2" type="curve"/>
+      <point x="290.4" y="135.2" type="line"/>
       <point x="277.6" y="171.2"/>
       <point x="265.6" y="208.8"/>
-      <point type="curve" x="252.8" y="244.8"/>
-      <point type="line" x="152" y="524.8"/>
-      <point type="line" x="72" y="524.8"/>
+      <point x="252.8" y="244.8" type="curve"/>
+      <point x="152" y="524.8" type="line"/>
+      <point x="72" y="524.8" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/N_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/N_.glif
@@ -6,26 +6,26 @@
   <anchor x="261.6" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="135.2" y="0"/>
-      <point type="line" x="135.2" y="274.4"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="135.2" y="0" type="line"/>
+      <point x="135.2" y="274.4" type="line"/>
       <point x="135.2" y="329.6" name="hintSet0003"/>
       <point x="130.4" y="385.6"/>
-      <point type="curve" x="126.4" y="438.4"/>
-      <point type="line" x="129.6" y="438.4"/>
-      <point type="line" x="186.4" y="330.4"/>
-      <point type="line" x="376.8" y="0"/>
-      <point type="line" x="445.6" y="0"/>
-      <point type="line" x="445.6" y="524.8"/>
-      <point type="line" x="382.4" y="524.8"/>
-      <point type="line" x="382.4" y="253.6"/>
+      <point x="126.4" y="438.4" type="curve"/>
+      <point x="129.6" y="438.4" type="line"/>
+      <point x="186.4" y="330.4" type="line"/>
+      <point x="376.8" y="0" type="line"/>
+      <point x="445.6" y="0" type="line"/>
+      <point x="445.6" y="524.8" type="line"/>
+      <point x="382.4" y="524.8" type="line"/>
+      <point x="382.4" y="253.6" type="line"/>
       <point x="382.4" y="198.4" name="hintSet0011"/>
       <point x="387.2" y="139.2"/>
-      <point type="curve" x="390.4" y="86.4"/>
-      <point type="line" x="387.2" y="86.4"/>
-      <point type="line" x="330.4" y="195.2"/>
-      <point type="line" x="140.8" y="524.8"/>
-      <point type="line" x="72" y="524.8"/>
+      <point x="390.4" y="86.4" type="curve"/>
+      <point x="387.2" y="86.4" type="line"/>
+      <point x="330.4" y="195.2" type="line"/>
+      <point x="140.8" y="524.8" type="line"/>
+      <point x="72" y="524.8" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/O_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/O_.glif
@@ -8,30 +8,30 @@
   <anchor x="265.6" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="265.6" y="-9.6" name="hintSet0000"/>
+      <point x="265.6" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="397.6" y="-9.6"/>
       <point x="490.4" y="96"/>
-      <point type="curve" x="490.4" y="264.8"/>
+      <point x="490.4" y="264.8" type="curve"/>
       <point x="490.4" y="432"/>
       <point x="397.6" y="534.4"/>
-      <point type="curve" x="265.6" y="534.4"/>
+      <point x="265.6" y="534.4" type="curve"/>
       <point x="133.6" y="534.4"/>
       <point x="41.6" y="432.8"/>
-      <point type="curve" x="41.6" y="264.8"/>
+      <point x="41.6" y="264.8" type="curve"/>
       <point x="41.6" y="96"/>
       <point x="133.6" y="-9.6"/>
     </contour>
     <contour>
-      <point type="curve" x="265.6" y="48.8"/>
+      <point x="265.6" y="48.8" type="curve"/>
       <point x="172" y="48.8"/>
       <point x="110.4" y="133.6"/>
-      <point type="curve" x="110.4" y="264.8"/>
+      <point x="110.4" y="264.8" type="curve"/>
       <point x="110.4" y="395.2"/>
       <point x="172" y="476"/>
-      <point type="curve" x="265.6" y="476"/>
+      <point x="265.6" y="476" type="curve"/>
       <point x="359.2" y="476"/>
       <point x="420.8" y="395.2"/>
-      <point type="curve" x="420.8" y="264.8"/>
+      <point x="420.8" y="264.8" type="curve"/>
       <point x="420.8" y="133.6"/>
       <point x="359.2" y="48.8"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/P_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/P_.glif
@@ -6,28 +6,28 @@
   <anchor x="109.60000000000001" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="138.4" y="0"/>
-      <point type="line" x="138.4" y="208"/>
-      <point type="line" x="224.8" y="208"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="138.4" y="0" type="line"/>
+      <point x="138.4" y="208" type="line"/>
+      <point x="224.8" y="208" type="line"/>
       <point x="340" y="208"/>
       <point x="418.4" y="260"/>
-      <point type="curve" x="418.4" y="370.4"/>
+      <point x="418.4" y="370.4" type="curve"/>
       <point x="418.4" y="485.6"/>
       <point x="339.2" y="524.8"/>
-      <point type="curve" x="221.6" y="524.8"/>
-      <point type="line" x="72" y="524.8"/>
+      <point x="221.6" y="524.8" type="curve"/>
+      <point x="72" y="524.8" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="138.4" y="262.4"/>
-      <point type="line" x="138.4" y="471.2"/>
-      <point type="line" x="213.6" y="471.2"/>
+      <point x="138.4" y="262.4" type="line"/>
+      <point x="138.4" y="471.2" type="line"/>
+      <point x="213.6" y="471.2" type="line"/>
       <point x="305.6" y="471.2"/>
       <point x="352" y="446.4"/>
-      <point type="curve" x="352" y="370.4"/>
+      <point x="352" y="370.4" type="curve"/>
       <point x="352" y="296"/>
       <point x="308" y="262.4"/>
-      <point type="curve" x="216.8" y="262.4"/>
+      <point x="216.8" y="262.4" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/Q_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/Q_.glif
@@ -5,46 +5,46 @@
   <anchor x="265.6" y="542.4" name="aboveUC"/>
   <outline>
     <contour>
-      <point type="curve" x="265.6" y="-9.6" name="hintSet0000"/>
+      <point x="265.6" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="397.6" y="-9.6"/>
       <point x="490.4" y="96"/>
-      <point type="curve" x="490.4" y="264.8"/>
+      <point x="490.4" y="264.8" type="curve"/>
       <point x="490.4" y="432"/>
       <point x="397.6" y="534.4"/>
-      <point type="curve" x="265.6" y="534.4"/>
+      <point x="265.6" y="534.4" type="curve"/>
       <point x="133.6" y="534.4"/>
       <point x="41.6" y="432.8"/>
-      <point type="curve" x="41.6" y="264.8"/>
+      <point x="41.6" y="264.8" type="curve"/>
       <point x="41.6" y="96"/>
       <point x="133.6" y="-9.6"/>
     </contour>
     <contour>
-      <point type="curve" x="265.6" y="45.6" name="hintSet0005"/>
+      <point x="265.6" y="45.6" type="curve" name="hintSet0005"/>
       <point x="172" y="45.6"/>
       <point x="110.4" y="130.4"/>
-      <point type="curve" x="110.4" y="264.8"/>
+      <point x="110.4" y="264.8" type="curve"/>
       <point x="110.4" y="395.2"/>
       <point x="172" y="476"/>
-      <point type="curve" x="265.6" y="476"/>
+      <point x="265.6" y="476" type="curve"/>
       <point x="359.2" y="476"/>
       <point x="420.8" y="395.2"/>
-      <point type="curve" x="420.8" y="264.8"/>
+      <point x="420.8" y="264.8" type="curve"/>
       <point x="420.8" y="130.4"/>
       <point x="359.2" y="45.6"/>
     </contour>
     <contour>
-      <point type="curve" x="426.4" y="-132"/>
+      <point x="426.4" y="-132" type="curve"/>
       <point x="457.6" y="-132"/>
       <point x="485.6" y="-126.4"/>
-      <point type="curve" x="501.6" y="-120"/>
-      <point type="line" x="488.8" y="-68.8"/>
+      <point x="501.6" y="-120" type="curve"/>
+      <point x="488.8" y="-68.8" type="line"/>
       <point x="474.4" y="-72.8"/>
       <point x="456.8" y="-76"/>
-      <point type="curve" x="433.6" y="-76"/>
+      <point x="433.6" y="-76" type="curve"/>
       <point x="371.2" y="-76" name="hintSet0014"/>
       <point x="320" y="-48.8"/>
-      <point type="curve" x="299.2" y="7.2"/>
-      <point type="line" x="229.6" y="1.6"/>
+      <point x="299.2" y="7.2" type="curve"/>
+      <point x="229.6" y="1.6" type="line"/>
       <point x="257.6" y="-74.4" name="hintSet0016"/>
       <point x="325.6" y="-132"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/R_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/R_.glif
@@ -6,34 +6,34 @@
   <anchor x="248.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="138.4" y="0"/>
-      <point type="line" x="138.4" y="221.6"/>
-      <point type="line" x="236" y="221.6"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="138.4" y="0" type="line"/>
+      <point x="138.4" y="221.6" type="line"/>
+      <point x="236" y="221.6" type="line"/>
       <point x="343.2" y="221.6"/>
       <point x="420" y="272.8"/>
-      <point type="curve" x="420" y="377.6"/>
+      <point x="420" y="377.6" type="curve"/>
       <point x="420" y="486.4"/>
       <point x="343.2" y="524.8"/>
-      <point type="curve" x="236" y="524.8"/>
-      <point type="line" x="72" y="524.8"/>
+      <point x="236" y="524.8" type="curve"/>
+      <point x="72" y="524.8" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="138.4" y="276"/>
-      <point type="line" x="138.4" y="471.2"/>
-      <point type="line" x="226.4" y="471.2"/>
+      <point x="138.4" y="276" type="line"/>
+      <point x="138.4" y="471.2" type="line"/>
+      <point x="226.4" y="471.2" type="line"/>
       <point x="308" y="471.2"/>
       <point x="353.6" y="446.4"/>
-      <point type="curve" x="353.6" y="377.6"/>
+      <point x="353.6" y="377.6" type="curve"/>
       <point x="353.6" y="309.6"/>
       <point x="308" y="276"/>
-      <point type="curve" x="226.4" y="276"/>
+      <point x="226.4" y="276" type="curve"/>
     </contour>
     <contour>
-      <point type="line" x="360" y="0"/>
-      <point type="line" x="435.2" y="0"/>
-      <point type="line" x="275.2" y="275.2" name="hintSet0014"/>
-      <point type="line" x="223.2" y="240"/>
+      <point x="360" y="0" type="line"/>
+      <point x="435.2" y="0" type="line"/>
+      <point x="275.2" y="275.2" type="line" name="hintSet0014"/>
+      <point x="223.2" y="240" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/S_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/S_.glif
@@ -7,44 +7,44 @@
   <anchor x="218.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="217.6" y="-9.6" name="hintSet0000"/>
+      <point x="217.6" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="328" y="-9.6"/>
       <point x="396" y="56.8"/>
-      <point type="curve" x="396" y="140"/>
+      <point x="396" y="140" type="curve"/>
       <point x="396" y="217.6"/>
       <point x="348.8" y="253.6"/>
-      <point type="curve" x="288" y="280"/>
-      <point type="line" x="213.6" y="312"/>
+      <point x="288" y="280" type="curve"/>
+      <point x="213.6" y="312" type="line"/>
       <point x="172" y="329.6"/>
       <point x="126.4" y="348.8"/>
-      <point type="curve" x="126.4" y="399.2"/>
+      <point x="126.4" y="399.2" type="curve"/>
       <point x="126.4" y="446.4"/>
       <point x="165.6" y="476"/>
-      <point type="curve" x="224" y="476"/>
+      <point x="224" y="476" type="curve"/>
       <point x="272.8" y="476"/>
       <point x="311.2" y="456.8"/>
-      <point type="curve" x="343.2" y="426.4"/>
-      <point type="line" x="379.2" y="469.6"/>
+      <point x="343.2" y="426.4" type="curve"/>
+      <point x="379.2" y="469.6" type="line"/>
       <point x="341.6" y="508"/>
       <point x="286.4" y="534.4"/>
-      <point type="curve" x="224" y="534.4"/>
+      <point x="224" y="534.4" type="curve"/>
       <point x="128.8" y="534.4"/>
       <point x="59.2" y="475.2"/>
-      <point type="curve" x="59.2" y="395.2"/>
+      <point x="59.2" y="395.2" type="curve"/>
       <point x="59.2" y="318.4"/>
       <point x="116" y="280.8"/>
-      <point type="curve" x="165.6" y="260"/>
-      <point type="line" x="240.8" y="227.2"/>
+      <point x="165.6" y="260" type="curve"/>
+      <point x="240.8" y="227.2" type="line"/>
       <point x="290.4" y="204.8"/>
       <point x="328" y="188"/>
-      <point type="curve" x="328" y="134.4"/>
+      <point x="328" y="134.4" type="curve"/>
       <point x="328" y="83.2"/>
       <point x="287.2" y="48.8"/>
-      <point type="curve" x="218.4" y="48.8"/>
+      <point x="218.4" y="48.8" type="curve"/>
       <point x="164" y="48.8"/>
       <point x="111.2" y="75.2"/>
-      <point type="curve" x="73.6" y="114.4"/>
-      <point type="line" x="33.6" y="68"/>
+      <point x="73.6" y="114.4" type="curve"/>
+      <point x="33.6" y="68" type="line"/>
       <point x="79.2" y="20.8"/>
       <point x="144" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/T_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/T_.glif
@@ -7,14 +7,14 @@
   <anchor x="214.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="180.8" y="0" name="hintSet0000"/>
-      <point type="line" x="248" y="0"/>
-      <point type="line" x="248" y="468.8"/>
-      <point type="line" x="406.4" y="468.8"/>
-      <point type="line" x="406.4" y="524.8"/>
-      <point type="line" x="22.4" y="524.8"/>
-      <point type="line" x="22.4" y="468.8"/>
-      <point type="line" x="180.8" y="468.8"/>
+      <point x="180.8" y="0" type="line" name="hintSet0000"/>
+      <point x="248" y="0" type="line"/>
+      <point x="248" y="468.8" type="line"/>
+      <point x="406.4" y="468.8" type="line"/>
+      <point x="406.4" y="524.8" type="line"/>
+      <point x="22.4" y="524.8" type="line"/>
+      <point x="22.4" y="468.8" type="line"/>
+      <point x="180.8" y="468.8" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/U_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/U_.glif
@@ -8,22 +8,22 @@
   <anchor x="257.6" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="258.4" y="-9.6" name="hintSet0000"/>
+      <point x="258.4" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="365.6" y="-9.6"/>
       <point x="446.4" y="48"/>
-      <point type="curve" x="446.4" y="216.8"/>
-      <point type="line" x="446.4" y="524.8"/>
-      <point type="line" x="382.4" y="524.8"/>
-      <point type="line" x="382.4" y="215.2"/>
+      <point x="446.4" y="216.8" type="curve"/>
+      <point x="446.4" y="524.8" type="line"/>
+      <point x="382.4" y="524.8" type="line"/>
+      <point x="382.4" y="215.2" type="line"/>
       <point x="382.4" y="88.8"/>
       <point x="328" y="48.8"/>
-      <point type="curve" x="258.4" y="48.8"/>
+      <point x="258.4" y="48.8" type="curve"/>
       <point x="189.6" y="48.8"/>
       <point x="136" y="88.8"/>
-      <point type="curve" x="136" y="215.2"/>
-      <point type="line" x="136" y="524.8"/>
-      <point type="line" x="69.6" y="524.8"/>
-      <point type="line" x="69.6" y="216.8"/>
+      <point x="136" y="215.2" type="curve"/>
+      <point x="136" y="524.8" type="line"/>
+      <point x="69.6" y="524.8" type="line"/>
+      <point x="69.6" y="216.8" type="line"/>
       <point x="69.6" y="48"/>
       <point x="151.2" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/V_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/V_.glif
@@ -6,20 +6,20 @@
   <anchor x="206.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="168" y="0" name="hintSet0000"/>
-      <point type="line" x="245.6" y="0"/>
-      <point type="line" x="412" y="524.8"/>
-      <point type="line" x="344" y="524.8"/>
-      <point type="line" x="260" y="241.6"/>
+      <point x="168" y="0" type="line" name="hintSet0000"/>
+      <point x="245.6" y="0" type="line"/>
+      <point x="412" y="524.8" type="line"/>
+      <point x="344" y="524.8" type="line"/>
+      <point x="260" y="241.6" type="line"/>
       <point x="241.6" y="179.2"/>
       <point x="228.8" y="129.6"/>
-      <point type="curve" x="209.6" y="68"/>
-      <point type="line" x="206.4" y="68"/>
+      <point x="209.6" y="68" type="curve"/>
+      <point x="206.4" y="68" type="line"/>
       <point x="186.4" y="129.6"/>
       <point x="174.4" y="179.2"/>
-      <point type="curve" x="155.2" y="241.6"/>
-      <point type="line" x="71.2" y="524.8"/>
-      <point type="line" x="0" y="524.8"/>
+      <point x="155.2" y="241.6" type="curve"/>
+      <point x="71.2" y="524.8" type="line"/>
+      <point x="0" y="524.8" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/W_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/W_.glif
@@ -6,40 +6,40 @@
   <anchor x="316.8" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="129.6" y="0" name="hintSet0000"/>
-      <point type="line" x="208.8" y="0"/>
-      <point type="line" x="286.4" y="316"/>
+      <point x="129.6" y="0" type="line" name="hintSet0000"/>
+      <point x="208.8" y="0" type="line"/>
+      <point x="286.4" y="316" type="line"/>
       <point x="295.2" y="356.8" name="hintSet0003"/>
       <point x="304.8" y="394.4"/>
-      <point type="curve" x="312.8" y="435.2"/>
-      <point type="line" x="316" y="435.2"/>
+      <point x="312.8" y="435.2" type="curve"/>
+      <point x="316" y="435.2" type="line"/>
       <point x="324" y="394.4"/>
       <point x="332" y="356.8"/>
-      <point type="curve" x="341.6" y="316"/>
-      <point type="line" x="420.8" y="0"/>
-      <point type="line" x="500.8" y="0"/>
-      <point type="line" x="609.6" y="524.8"/>
-      <point type="line" x="545.6" y="524.8"/>
-      <point type="line" x="490.4" y="239.2"/>
+      <point x="341.6" y="316" type="curve"/>
+      <point x="420.8" y="0" type="line"/>
+      <point x="500.8" y="0" type="line"/>
+      <point x="609.6" y="524.8" type="line"/>
+      <point x="545.6" y="524.8" type="line"/>
+      <point x="490.4" y="239.2" type="line"/>
       <point x="480" y="183.2"/>
       <point x="470.4" y="126.4"/>
-      <point type="curve" x="460.8" y="69.6"/>
-      <point type="line" x="457.6" y="69.6"/>
+      <point x="460.8" y="69.6" type="curve"/>
+      <point x="457.6" y="69.6" type="line"/>
       <point x="444.8" y="126.4"/>
       <point x="432" y="184"/>
-      <point type="curve" x="419.2" y="239.2"/>
-      <point type="line" x="346.4" y="524.8"/>
-      <point type="line" x="285.6" y="524.8"/>
-      <point type="line" x="212.8" y="239.2"/>
+      <point x="419.2" y="239.2" type="curve"/>
+      <point x="346.4" y="524.8" type="line"/>
+      <point x="285.6" y="524.8" type="line"/>
+      <point x="212.8" y="239.2" type="line"/>
       <point x="200.8" y="183.2"/>
       <point x="188" y="126.4"/>
-      <point type="curve" x="176" y="69.6"/>
-      <point type="line" x="172.8" y="69.6"/>
+      <point x="176" y="69.6" type="curve"/>
+      <point x="172.8" y="69.6" type="line"/>
       <point x="163.2" y="126.4"/>
       <point x="152" y="182.4"/>
-      <point type="curve" x="142.4" y="239.2"/>
-      <point type="line" x="87.2" y="524.8"/>
-      <point type="line" x="18.4" y="524.8"/>
+      <point x="142.4" y="239.2" type="curve"/>
+      <point x="87.2" y="524.8" type="line"/>
+      <point x="18.4" y="524.8" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/X_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/X_.glif
@@ -6,32 +6,32 @@
   <anchor x="201.60000000000002" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="12" y="0" name="hintSet0000"/>
-      <point type="line" x="82.4" y="0"/>
-      <point type="line" x="158.4" y="141.6"/>
+      <point x="12" y="0" type="line" name="hintSet0000"/>
+      <point x="82.4" y="0" type="line"/>
+      <point x="158.4" y="141.6" type="line"/>
       <point x="171.2" y="167.2"/>
       <point x="184.8" y="193.6"/>
-      <point type="curve" x="200" y="225.6"/>
-      <point type="line" x="203.2" y="225.6"/>
+      <point x="200" y="225.6" type="curve"/>
+      <point x="203.2" y="225.6" type="line"/>
       <point x="220" y="193.6"/>
       <point x="234.4" y="167.2"/>
-      <point type="curve" x="248" y="141.6"/>
-      <point type="line" x="324.8" y="0"/>
-      <point type="line" x="398.4" y="0"/>
-      <point type="line" x="245.6" y="268"/>
-      <point type="line" x="388.8" y="524.8"/>
-      <point type="line" x="318.4" y="524.8"/>
-      <point type="line" x="248.8" y="390.4"/>
+      <point x="248" y="141.6" type="curve"/>
+      <point x="324.8" y="0" type="line"/>
+      <point x="398.4" y="0" type="line"/>
+      <point x="245.6" y="268" type="line"/>
+      <point x="388.8" y="524.8" type="line"/>
+      <point x="318.4" y="524.8" type="line"/>
+      <point x="248.8" y="390.4" type="line"/>
       <point x="236" y="366.4"/>
       <point x="225.6" y="344.8"/>
-      <point type="curve" x="211.2" y="314.4"/>
-      <point type="line" x="208" y="314.4"/>
+      <point x="211.2" y="314.4" type="curve"/>
+      <point x="208" y="314.4" type="line"/>
       <point x="192" y="344.8"/>
       <point x="180.8" y="366.4"/>
-      <point type="curve" x="167.2" y="390.4"/>
-      <point type="line" x="96" y="524.8"/>
-      <point type="line" x="22.4" y="524.8"/>
-      <point type="line" x="164.8" y="271.2"/>
+      <point x="167.2" y="390.4" type="curve"/>
+      <point x="96" y="524.8" type="line"/>
+      <point x="22.4" y="524.8" type="line"/>
+      <point x="164.8" y="271.2" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/Y_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/Y_.glif
@@ -6,22 +6,22 @@
   <anchor x="192.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="156.8" y="0" name="hintSet0000"/>
-      <point type="line" x="224" y="0"/>
-      <point type="line" x="224" y="203.2"/>
-      <point type="line" x="381.6" y="524.8"/>
-      <point type="line" x="312" y="524.8"/>
-      <point type="line" x="244.8" y="376.8"/>
+      <point x="156.8" y="0" type="line" name="hintSet0000"/>
+      <point x="224" y="0" type="line"/>
+      <point x="224" y="203.2" type="line"/>
+      <point x="381.6" y="524.8" type="line"/>
+      <point x="312" y="524.8" type="line"/>
+      <point x="244.8" y="376.8" type="line"/>
       <point x="228.8" y="338.4"/>
       <point x="210.4" y="301.6"/>
-      <point type="curve" x="192" y="262.4"/>
-      <point type="line" x="188.8" y="262.4"/>
+      <point x="192" y="262.4" type="curve"/>
+      <point x="188.8" y="262.4" type="line"/>
       <point x="171.2" y="301.6"/>
       <point x="155.2" y="338.4"/>
-      <point type="curve" x="138.4" y="376.8"/>
-      <point type="line" x="70.4" y="524.8"/>
-      <point type="line" x="-0.8" y="524.8"/>
-      <point type="line" x="156.8" y="203.2"/>
+      <point x="138.4" y="376.8" type="curve"/>
+      <point x="70.4" y="524.8" type="line"/>
+      <point x="-0.8" y="524.8" type="line"/>
+      <point x="156.8" y="203.2" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/Z_.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/Z_.glif
@@ -6,16 +6,16 @@
   <anchor x="225.60000000000002" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="36" y="0" name="hintSet0000"/>
-      <point type="line" x="397.6" y="0"/>
-      <point type="line" x="397.6" y="56.8"/>
-      <point type="line" x="118.4" y="56.8"/>
-      <point type="line" x="395.2" y="485.6"/>
-      <point type="line" x="395.2" y="524.8"/>
-      <point type="line" x="60.8" y="524.8"/>
-      <point type="line" x="60.8" y="468.8"/>
-      <point type="line" x="312" y="468.8"/>
-      <point type="line" x="36" y="40"/>
+      <point x="36" y="0" type="line" name="hintSet0000"/>
+      <point x="397.6" y="0" type="line"/>
+      <point x="397.6" y="56.8" type="line"/>
+      <point x="118.4" y="56.8" type="line"/>
+      <point x="395.2" y="485.6" type="line"/>
+      <point x="395.2" y="524.8" type="line"/>
+      <point x="60.8" y="524.8" type="line"/>
+      <point x="60.8" y="468.8" type="line"/>
+      <point x="312" y="468.8" type="line"/>
+      <point x="36" y="40" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/a.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/a.glif
@@ -7,42 +7,42 @@
   <anchor x="201.60000000000002" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="155.2" y="-9.6" name="hintSet0000"/>
+      <point x="155.2" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="204" y="-9.6" name="hintSet0001"/>
       <point x="247.2" y="16"/>
-      <point type="curve" x="284" y="46.4"/>
-      <point type="line" x="286.4" y="46.4"/>
-      <point type="line" x="292" y="0" name="hintSet0003"/>
-      <point type="line" x="346.4" y="0" name="hintSet0004"/>
-      <point type="line" x="346.4" y="238.4"/>
+      <point x="284" y="46.4" type="curve"/>
+      <point x="286.4" y="46.4" type="line"/>
+      <point x="292" y="0" type="line" name="hintSet0003"/>
+      <point x="346.4" y="0" type="line" name="hintSet0004"/>
+      <point x="346.4" y="238.4" type="line"/>
       <point x="346.4" y="335.2"/>
       <point x="306.4" y="398.4"/>
-      <point type="curve" x="211.2" y="398.4"/>
+      <point x="211.2" y="398.4" type="curve"/>
       <point x="148.8" y="398.4"/>
       <point x="94.4" y="371.2"/>
-      <point type="curve" x="58.4" y="348"/>
-      <point type="line" x="84" y="302.4"/>
+      <point x="58.4" y="348" type="curve"/>
+      <point x="84" y="302.4" type="line"/>
       <point x="114.4" y="323.2"/>
       <point x="155.2" y="344"/>
-      <point type="curve" x="200" y="344"/>
+      <point x="200" y="344" type="curve"/>
       <point x="264" y="344"/>
       <point x="280" y="296"/>
-      <point type="curve" x="280" y="246.4"/>
+      <point x="280" y="246.4" type="curve"/>
       <point x="114.4" y="228"/>
       <point x="41.6" y="185.6"/>
-      <point type="curve" x="41.6" y="100.8"/>
+      <point x="41.6" y="100.8" type="curve"/>
       <point x="41.6" y="31.2" name="hintSet0012"/>
       <point x="90.4" y="-9.6"/>
     </contour>
     <contour>
-      <point type="curve" x="174.4" y="43.2"/>
+      <point x="174.4" y="43.2" type="curve"/>
       <point x="136" y="43.2"/>
       <point x="105.6" y="61.6"/>
-      <point type="curve" x="105.6" y="105.6"/>
+      <point x="105.6" y="105.6" type="curve"/>
       <point x="105.6" y="155.2"/>
       <point x="150.4" y="187.2"/>
-      <point type="curve" x="280" y="203.2"/>
-      <point type="line" x="280" y="95.2"/>
+      <point x="280" y="203.2" type="curve"/>
+      <point x="280" y="95.2" type="line"/>
       <point x="242.4" y="61.6"/>
       <point x="212" y="43.2"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/ampersand.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/ampersand.glif
@@ -4,54 +4,54 @@
   <unicode hex="0026"/>
   <outline>
     <contour>
-      <point type="curve" x="185.6" y="-9.6" name="hintSet0000"/>
+      <point x="185.6" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="259.2" y="-9.6"/>
       <point x="315.2" y="24"/>
-      <point type="curve" x="359.2" y="72.8"/>
+      <point x="359.2" y="72.8" type="curve"/>
       <point x="410.4" y="132.8"/>
       <point x="445.6" y="204.8"/>
-      <point type="curve" x="468.8" y="283.2"/>
-      <point type="line" x="407.2" y="283.2"/>
+      <point x="468.8" y="283.2" type="curve"/>
+      <point x="407.2" y="283.2" type="line"/>
       <point x="388" y="211.2"/>
       <point x="356" y="151.2"/>
-      <point type="curve" x="313.6" y="104.8"/>
+      <point x="313.6" y="104.8" type="curve"/>
       <point x="278.4" y="68"/>
       <point x="236.8" y="43.2"/>
-      <point type="curve" x="192.8" y="43.2"/>
+      <point x="192.8" y="43.2" type="curve"/>
       <point x="135.2" y="43.2"/>
       <point x="89.6" y="81.6"/>
-      <point type="curve" x="89.6" y="140"/>
+      <point x="89.6" y="140" type="curve"/>
       <point x="89.6" y="255.2"/>
       <point x="319.2" y="296"/>
-      <point type="curve" x="319.2" y="430.4"/>
+      <point x="319.2" y="430.4" type="curve"/>
       <point x="319.2" y="492"/>
       <point x="280.8" y="534.4"/>
-      <point type="curve" x="216" y="534.4"/>
+      <point x="216" y="534.4" type="curve"/>
       <point x="143.2" y="534.4" name="hintSet0009"/>
       <point x="94.4" y="480"/>
-      <point type="curve" x="94.4" y="410.4"/>
+      <point x="94.4" y="410.4" type="curve"/>
       <point x="94.4" y="299.2"/>
       <point x="205.6" y="152.8"/>
-      <point type="curve" x="320" y="63.2"/>
+      <point x="320" y="63.2" type="curve"/>
       <point x="368" y="26.4"/>
       <point x="416" y="2.4"/>
-      <point type="curve" x="457.6" y="-9.6"/>
-      <point type="line" x="475.2" y="44.8"/>
+      <point x="457.6" y="-9.6" type="curve"/>
+      <point x="475.2" y="44.8" type="line"/>
       <point x="441.6" y="54.4"/>
       <point x="401.6" y="76"/>
-      <point type="curve" x="360" y="107.2"/>
+      <point x="360" y="107.2" type="curve"/>
       <point x="259.2" y="182.4"/>
       <point x="151.2" y="312.8"/>
-      <point type="curve" x="151.2" y="411.2"/>
+      <point x="151.2" y="411.2" type="curve"/>
       <point x="151.2" y="454.4"/>
       <point x="176.8" y="487.2"/>
-      <point type="curve" x="216" y="487.2"/>
+      <point x="216" y="487.2" type="curve"/>
       <point x="251.2" y="487.2"/>
       <point x="265.6" y="460"/>
-      <point type="curve" x="265.6" y="429.6"/>
+      <point x="265.6" y="429.6" type="curve"/>
       <point x="265.6" y="316.8" name="hintSet0017"/>
       <point x="25.6" y="291.2"/>
-      <point type="curve" x="25.6" y="136"/>
+      <point x="25.6" y="136" type="curve"/>
       <point x="25.6" y="51.2"/>
       <point x="90.4" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/asciicircum.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/asciicircum.glif
@@ -4,16 +4,16 @@
   <unicode hex="005E"/>
   <outline>
     <contour>
-      <point type="line" x="48" y="227.2" name="hintSet0000"/>
-      <point type="line" x="105.6" y="227.2"/>
-      <point type="line" x="157.6" y="368"/>
-      <point type="line" x="197.6" y="474.4"/>
-      <point type="line" x="200.8" y="474.4"/>
-      <point type="line" x="240" y="368"/>
-      <point type="line" x="292" y="227.2"/>
-      <point type="line" x="349.6" y="227.2"/>
-      <point type="line" x="228" y="536"/>
-      <point type="line" x="169.6" y="536"/>
+      <point x="48" y="227.2" type="line" name="hintSet0000"/>
+      <point x="105.6" y="227.2" type="line"/>
+      <point x="157.6" y="368" type="line"/>
+      <point x="197.6" y="474.4" type="line"/>
+      <point x="200.8" y="474.4" type="line"/>
+      <point x="240" y="368" type="line"/>
+      <point x="292" y="227.2" type="line"/>
+      <point x="349.6" y="227.2" type="line"/>
+      <point x="228" y="536" type="line"/>
+      <point x="169.6" y="536" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/asciitilde.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/asciitilde.glif
@@ -4,24 +4,24 @@
   <unicode hex="007E"/>
   <outline>
     <contour>
-      <point type="curve" x="268.8" y="205.6" name="hintSet0000"/>
+      <point x="268.8" y="205.6" type="curve" name="hintSet0000"/>
       <point x="303.2" y="205.6"/>
       <point x="340" y="226.4"/>
-      <point type="curve" x="368.8" y="276.8"/>
-      <point type="line" x="332" y="304"/>
+      <point x="368.8" y="276.8" type="curve"/>
+      <point x="332" y="304" type="line"/>
       <point x="313.6" y="269.6"/>
       <point x="293.6" y="255.2"/>
-      <point type="curve" x="270.4" y="255.2"/>
+      <point x="270.4" y="255.2" type="curve"/>
       <point x="225.6" y="255.2" name="hintSet0004"/>
       <point x="192" y="322.4"/>
-      <point type="curve" x="128.8" y="322.4"/>
+      <point x="128.8" y="322.4" type="curve"/>
       <point x="94.4" y="322.4"/>
       <point x="57.6" y="301.6"/>
-      <point type="curve" x="28.8" y="250.4"/>
-      <point type="line" x="65.6" y="224"/>
+      <point x="28.8" y="250.4" type="curve"/>
+      <point x="65.6" y="224" type="line"/>
       <point x="84" y="258.4"/>
       <point x="104" y="272.8"/>
-      <point type="curve" x="127.2" y="272.8"/>
+      <point x="127.2" y="272.8" type="curve"/>
       <point x="172" y="272.8" name="hintSet0008"/>
       <point x="205.6" y="205.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/asterisk.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/asterisk.glif
@@ -4,21 +4,21 @@
   <unicode hex="002A"/>
   <outline>
     <contour>
-      <point type="line" x="110.4" y="336" name="hintSet0000"/>
-      <point type="line" x="167.2" y="404.8"/>
-      <point type="line" x="224" y="336"/>
-      <point type="line" x="255.2" y="359.2"/>
-      <point type="line" x="210.4" y="434.4"/>
-      <point type="line" x="288" y="466.4"/>
-      <point type="line" x="276" y="503.2"/>
-      <point type="line" x="193.6" y="484"/>
-      <point type="line" x="186.4" y="569.6"/>
-      <point type="line" x="147.2" y="569.6"/>
-      <point type="line" x="140" y="483.2"/>
-      <point type="line" x="58.4" y="503.2"/>
-      <point type="line" x="46.4" y="466.4"/>
-      <point type="line" x="124" y="434.4"/>
-      <point type="line" x="78.4" y="359.2"/>
+      <point x="110.4" y="336" type="line" name="hintSet0000"/>
+      <point x="167.2" y="404.8" type="line"/>
+      <point x="224" y="336" type="line"/>
+      <point x="255.2" y="359.2" type="line"/>
+      <point x="210.4" y="434.4" type="line"/>
+      <point x="288" y="466.4" type="line"/>
+      <point x="276" y="503.2" type="line"/>
+      <point x="193.6" y="484" type="line"/>
+      <point x="186.4" y="569.6" type="line"/>
+      <point x="147.2" y="569.6" type="line"/>
+      <point x="140" y="483.2" type="line"/>
+      <point x="58.4" y="503.2" type="line"/>
+      <point x="46.4" y="466.4" type="line"/>
+      <point x="124" y="434.4" type="line"/>
+      <point x="78.4" y="359.2" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/at.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/at.glif
@@ -4,73 +4,73 @@
   <unicode hex="0040"/>
   <outline>
     <contour>
-      <point type="curve" x="322.4" y="-124" name="hintSet0000"/>
+      <point x="322.4" y="-124" type="curve" name="hintSet0000"/>
       <point x="377.6" y="-124"/>
       <point x="428" y="-111.2"/>
-      <point type="curve" x="474.4" y="-83.2"/>
-      <point type="line" x="456.8" y="-44"/>
+      <point x="474.4" y="-83.2" type="curve"/>
+      <point x="456.8" y="-44" type="line"/>
       <point x="420.8" y="-64.8"/>
       <point x="376" y="-80"/>
-      <point type="curve" x="327.2" y="-80"/>
+      <point x="327.2" y="-80" type="curve"/>
       <point x="191.2" y="-80"/>
       <point x="88.8" y="8.8"/>
-      <point type="curve" x="88.8" y="164.8"/>
+      <point x="88.8" y="164.8" type="curve"/>
       <point x="88.8" y="352"/>
       <point x="226.4" y="472.8"/>
-      <point type="curve" x="368.8" y="472.8"/>
+      <point x="368.8" y="472.8" type="curve"/>
       <point x="514.4" y="472.8"/>
       <point x="590.4" y="378.4"/>
-      <point type="curve" x="590.4" y="249.6"/>
+      <point x="590.4" y="249.6" type="curve"/>
       <point x="590.4" y="145.6"/>
       <point x="533.6" y="84"/>
-      <point type="curve" x="483.2" y="84"/>
+      <point x="483.2" y="84" type="curve"/>
       <point x="439.2" y="84"/>
       <point x="424" y="114.4"/>
-      <point type="curve" x="440" y="177.6"/>
-      <point type="line" x="471.2" y="337.6"/>
-      <point type="line" x="427.2" y="337.6"/>
-      <point type="line" x="418.4" y="305.6"/>
-      <point type="line" x="416.8" y="305.6"/>
+      <point x="440" y="177.6" type="curve"/>
+      <point x="471.2" y="337.6" type="line"/>
+      <point x="427.2" y="337.6" type="line"/>
+      <point x="418.4" y="305.6" type="line"/>
+      <point x="416.8" y="305.6" type="line"/>
       <point x="402.4" y="332"/>
       <point x="380" y="344"/>
-      <point type="curve" x="352.8" y="344"/>
+      <point x="352.8" y="344" type="curve"/>
       <point x="259.2" y="344"/>
       <point x="199.2" y="244"/>
-      <point type="curve" x="199.2" y="158.4"/>
+      <point x="199.2" y="158.4" type="curve"/>
       <point x="199.2" y="85.6" name="hintSet0015"/>
       <point x="240.8" y="45.6"/>
-      <point type="curve" x="295.2" y="45.6"/>
+      <point x="295.2" y="45.6" type="curve"/>
       <point x="330.4" y="45.6"/>
       <point x="366.4" y="68.8"/>
-      <point type="curve" x="392.8" y="100"/>
-      <point type="line" x="394.4" y="100"/>
+      <point x="392.8" y="100" type="curve"/>
+      <point x="394.4" y="100" type="line"/>
       <point x="400" y="60" name="hintSet0018"/>
       <point x="433.6" y="39.2"/>
-      <point type="curve" x="476.8" y="39.2"/>
+      <point x="476.8" y="39.2" type="curve"/>
       <point x="549.6" y="39.2"/>
       <point x="636.8" y="112"/>
-      <point type="curve" x="636.8" y="252"/>
+      <point x="636.8" y="252" type="curve"/>
       <point x="636.8" y="409.6"/>
       <point x="536" y="516.8"/>
-      <point type="curve" x="374.4" y="516.8"/>
+      <point x="374.4" y="516.8" type="curve"/>
       <point x="195.2" y="516.8"/>
       <point x="40.8" y="376.8"/>
-      <point type="curve" x="40.8" y="162.4"/>
+      <point x="40.8" y="162.4" type="curve"/>
       <point x="40.8" y="-24"/>
       <point x="165.6" y="-124"/>
     </contour>
     <contour>
-      <point type="curve" x="308" y="90.4" name="hintSet0023"/>
+      <point x="308" y="90.4" type="curve" name="hintSet0023"/>
       <point x="276" y="90.4"/>
       <point x="252" y="111.2"/>
-      <point type="curve" x="252" y="162.4"/>
+      <point x="252" y="162.4" type="curve"/>
       <point x="252" y="222.4"/>
       <point x="290.4" y="298.4"/>
-      <point type="curve" x="353.6" y="298.4"/>
+      <point x="353.6" y="298.4" type="curve"/>
       <point x="375.2" y="298.4"/>
       <point x="389.6" y="289.6"/>
-      <point type="curve" x="404.8" y="264.8"/>
-      <point type="line" x="381.6" y="137.6"/>
+      <point x="404.8" y="264.8" type="curve"/>
+      <point x="381.6" y="137.6" type="line"/>
       <point x="354.4" y="104.8"/>
       <point x="330.4" y="90.4"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/b.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/b.glif
@@ -6,38 +6,38 @@
   <anchor x="227.20000000000002" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="237.6" y="-9.6" name="hintSet0000"/>
+      <point x="237.6" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="326.4" y="-9.6"/>
       <point x="405.6" y="68"/>
-      <point type="curve" x="405.6" y="200.8"/>
+      <point x="405.6" y="200.8" type="curve"/>
       <point x="405.6" y="320.8"/>
       <point x="352" y="398.4"/>
-      <point type="curve" x="251.2" y="398.4"/>
+      <point x="251.2" y="398.4" type="curve"/>
       <point x="208" y="398.4"/>
       <point x="164.8" y="375.2"/>
-      <point type="curve" x="129.6" y="344"/>
-      <point type="line" x="131.2" y="414.4"/>
-      <point type="line" x="131.2" y="569.6"/>
-      <point type="line" x="65.6" y="569.6"/>
-      <point type="line" x="65.6" y="0" name="hintSet0007"/>
-      <point type="line" x="118.4" y="0" name="hintSet0008"/>
-      <point type="line" x="124" y="40" name="hintSet0009"/>
-      <point type="line" x="126.4" y="40"/>
+      <point x="129.6" y="344" type="curve"/>
+      <point x="131.2" y="414.4" type="line"/>
+      <point x="131.2" y="569.6" type="line"/>
+      <point x="65.6" y="569.6" type="line"/>
+      <point x="65.6" y="0" type="line" name="hintSet0007"/>
+      <point x="118.4" y="0" type="line" name="hintSet0008"/>
+      <point x="124" y="40" type="line" name="hintSet0009"/>
+      <point x="126.4" y="40" type="line"/>
       <point x="160.8" y="8.8" name="hintSet0011"/>
       <point x="201.6" y="-9.6"/>
     </contour>
     <contour>
-      <point type="curve" x="226.4" y="45.6"/>
+      <point x="226.4" y="45.6" type="curve"/>
       <point x="200.8" y="45.6"/>
       <point x="165.6" y="56.8"/>
-      <point type="curve" x="131.2" y="86.4"/>
-      <point type="line" x="131.2" y="290.4"/>
+      <point x="131.2" y="86.4" type="curve"/>
+      <point x="131.2" y="290.4" type="line"/>
       <point x="168" y="324.8"/>
       <point x="202.4" y="343.2"/>
-      <point type="curve" x="235.2" y="343.2"/>
+      <point x="235.2" y="343.2" type="curve"/>
       <point x="308.8" y="343.2"/>
       <point x="337.6" y="285.6"/>
-      <point type="curve" x="337.6" y="200"/>
+      <point x="337.6" y="200" type="curve"/>
       <point x="337.6" y="104"/>
       <point x="290.4" y="45.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/backslash.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/backslash.glif
@@ -4,10 +4,10 @@
   <unicode hex="005C"/>
   <outline>
     <contour>
-      <point type="line" x="224.8" y="-128" name="hintSet0000"/>
-      <point type="line" x="272" y="-128"/>
-      <point type="line" x="58.4" y="568"/>
-      <point type="line" x="11.2" y="568"/>
+      <point x="224.8" y="-128" type="line" name="hintSet0000"/>
+      <point x="272" y="-128" type="line"/>
+      <point x="58.4" y="568" type="line"/>
+      <point x="11.2" y="568" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/bar.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/bar.glif
@@ -4,10 +4,10 @@
   <unicode hex="007C"/>
   <outline>
     <contour>
-      <point type="line" x="73.6" y="-200" name="hintSet0000"/>
-      <point type="line" x="120" y="-200"/>
-      <point type="line" x="120" y="600"/>
-      <point type="line" x="73.6" y="600"/>
+      <point x="73.6" y="-200" type="line" name="hintSet0000"/>
+      <point x="120" y="-200" type="line"/>
+      <point x="120" y="600" type="line"/>
+      <point x="73.6" y="600" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/braceleft.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/braceleft.glif
@@ -4,48 +4,48 @@
   <unicode hex="007B"/>
   <outline>
     <contour>
-      <point type="curve" x="182.4" y="-121.6" name="hintSet0000"/>
-      <point type="line" x="218.4" y="-121.6"/>
-      <point type="line" x="218.4" y="-84"/>
-      <point type="line" x="196.8" y="-84"/>
+      <point x="182.4" y="-121.6" type="curve" name="hintSet0000"/>
+      <point x="218.4" y="-121.6" type="line"/>
+      <point x="218.4" y="-84" type="line"/>
+      <point x="196.8" y="-84" type="line"/>
       <point x="153.6" y="-84"/>
       <point x="142.4" y="-63.2"/>
-      <point type="curve" x="142.4" y="-11.2"/>
+      <point x="142.4" y="-11.2" type="curve"/>
       <point x="142.4" y="37.6"/>
       <point x="147.2" y="79.2"/>
-      <point type="curve" x="147.2" y="133.6"/>
+      <point x="147.2" y="133.6" type="curve"/>
       <point x="147.2" y="184.8"/>
       <point x="133.6" y="211.2"/>
-      <point type="curve" x="99.2" y="220.8"/>
-      <point type="line" x="99.2" y="224"/>
+      <point x="99.2" y="220.8" type="curve"/>
+      <point x="99.2" y="224" type="line"/>
       <point x="133.6" y="233.6"/>
       <point x="147.2" y="259.2"/>
-      <point type="curve" x="147.2" y="311.2"/>
+      <point x="147.2" y="311.2" type="curve"/>
       <point x="147.2" y="365.6"/>
       <point x="142.4" y="407.2"/>
-      <point type="curve" x="142.4" y="456"/>
+      <point x="142.4" y="456" type="curve"/>
       <point x="142.4" y="508"/>
       <point x="153.6" y="528.8"/>
-      <point type="curve" x="196.8" y="528.8"/>
-      <point type="line" x="218.4" y="528.8"/>
-      <point type="line" x="218.4" y="566.4"/>
-      <point type="line" x="182.4" y="566.4"/>
+      <point x="196.8" y="528.8" type="curve"/>
+      <point x="218.4" y="528.8" type="line"/>
+      <point x="218.4" y="566.4" type="line"/>
+      <point x="182.4" y="566.4" type="line"/>
       <point x="119.2" y="566.4"/>
       <point x="88.8" y="542.4"/>
-      <point type="curve" x="88.8" y="460"/>
+      <point x="88.8" y="460" type="curve"/>
       <point x="88.8" y="401.6"/>
       <point x="96" y="359.2"/>
-      <point type="curve" x="96" y="304.8"/>
+      <point x="96" y="304.8" type="curve"/>
       <point x="96" y="274.4" name="hintSet0016"/>
       <point x="81.6" y="244"/>
-      <point type="curve" x="27.2" y="243.2"/>
-      <point type="line" x="27.2" y="201.6"/>
+      <point x="27.2" y="243.2" type="curve"/>
+      <point x="27.2" y="201.6" type="line"/>
       <point x="81.6" y="200.8" name="hintSet0018"/>
       <point x="96" y="170.4"/>
-      <point type="curve" x="96" y="139.2"/>
+      <point x="96" y="139.2" type="curve"/>
       <point x="96" y="85.6" name="hintSet0019"/>
       <point x="88.8" y="43.2"/>
-      <point type="curve" x="88.8" y="-15.2"/>
+      <point x="88.8" y="-15.2" type="curve"/>
       <point x="88.8" y="-97.6"/>
       <point x="119.2" y="-121.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/braceright.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/braceright.glif
@@ -4,50 +4,50 @@
   <unicode hex="007D"/>
   <outline>
     <contour>
-      <point type="line" x="24.8" y="-121.6" name="hintSet0000"/>
-      <point type="line" x="60" y="-121.6"/>
+      <point x="24.8" y="-121.6" type="line" name="hintSet0000"/>
+      <point x="60" y="-121.6" type="line"/>
       <point x="124" y="-121.6"/>
       <point x="153.6" y="-97.6"/>
-      <point type="curve" x="153.6" y="-15.2"/>
+      <point x="153.6" y="-15.2" type="curve"/>
       <point x="153.6" y="43.2"/>
       <point x="146.4" y="85.6"/>
-      <point type="curve" x="146.4" y="139.2"/>
+      <point x="146.4" y="139.2" type="curve"/>
       <point x="146.4" y="170.4" name="hintSet0004"/>
       <point x="161.6" y="200.8"/>
-      <point type="curve" x="215.2" y="201.6"/>
-      <point type="line" x="215.2" y="243.2"/>
+      <point x="215.2" y="201.6" type="curve"/>
+      <point x="215.2" y="243.2" type="line"/>
       <point x="161.6" y="244" name="hintSet0006"/>
       <point x="146.4" y="274.4"/>
-      <point type="curve" x="146.4" y="304.8"/>
+      <point x="146.4" y="304.8" type="curve"/>
       <point x="146.4" y="359.2" name="hintSet0007"/>
       <point x="153.6" y="401.6"/>
-      <point type="curve" x="153.6" y="460"/>
+      <point x="153.6" y="460" type="curve"/>
       <point x="153.6" y="542.4"/>
       <point x="124" y="566.4"/>
-      <point type="curve" x="60" y="566.4"/>
-      <point type="line" x="24.8" y="566.4"/>
-      <point type="line" x="24.8" y="528.8"/>
-      <point type="line" x="45.6" y="528.8"/>
+      <point x="60" y="566.4" type="curve"/>
+      <point x="24.8" y="566.4" type="line"/>
+      <point x="24.8" y="528.8" type="line"/>
+      <point x="45.6" y="528.8" type="line"/>
       <point x="88.8" y="528.8"/>
       <point x="100" y="508"/>
-      <point type="curve" x="100" y="456"/>
+      <point x="100" y="456" type="curve"/>
       <point x="100" y="407.2"/>
       <point x="96" y="365.6"/>
-      <point type="curve" x="96" y="311.2"/>
+      <point x="96" y="311.2" type="curve"/>
       <point x="96" y="259.2"/>
       <point x="108.8" y="233.6"/>
-      <point type="curve" x="143.2" y="224"/>
-      <point type="line" x="143.2" y="220.8"/>
+      <point x="143.2" y="224" type="curve"/>
+      <point x="143.2" y="220.8" type="line"/>
       <point x="108.8" y="211.2"/>
       <point x="96" y="184.8"/>
-      <point type="curve" x="96" y="133.6"/>
+      <point x="96" y="133.6" type="curve"/>
       <point x="96" y="79.2"/>
       <point x="100" y="37.6"/>
-      <point type="curve" x="100" y="-11.2"/>
+      <point x="100" y="-11.2" type="curve"/>
       <point x="100" y="-63.2"/>
       <point x="88.8" y="-84"/>
-      <point type="curve" x="45.6" y="-84"/>
-      <point type="line" x="24.8" y="-84"/>
+      <point x="45.6" y="-84" type="curve"/>
+      <point x="24.8" y="-84" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/bracketleft.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/bracketleft.glif
@@ -4,14 +4,14 @@
   <unicode hex="005B"/>
   <outline>
     <contour>
-      <point type="line" x="75.2" y="-121.6" name="hintSet0000"/>
-      <point type="line" x="218.4" y="-121.6"/>
-      <point type="line" x="218.4" y="-84"/>
-      <point type="line" x="124.8" y="-84"/>
-      <point type="line" x="124.8" y="528.8"/>
-      <point type="line" x="218.4" y="528.8"/>
-      <point type="line" x="218.4" y="566.4"/>
-      <point type="line" x="75.2" y="566.4"/>
+      <point x="75.2" y="-121.6" type="line" name="hintSet0000"/>
+      <point x="218.4" y="-121.6" type="line"/>
+      <point x="218.4" y="-84" type="line"/>
+      <point x="124.8" y="-84" type="line"/>
+      <point x="124.8" y="528.8" type="line"/>
+      <point x="218.4" y="528.8" type="line"/>
+      <point x="218.4" y="566.4" type="line"/>
+      <point x="75.2" y="566.4" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/bracketright.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/bracketright.glif
@@ -4,14 +4,14 @@
   <unicode hex="005D"/>
   <outline>
     <contour>
-      <point type="line" x="24.8" y="-121.6" name="hintSet0000"/>
-      <point type="line" x="167.2" y="-121.6"/>
-      <point type="line" x="167.2" y="566.4"/>
-      <point type="line" x="24.8" y="566.4"/>
-      <point type="line" x="24.8" y="528.8"/>
-      <point type="line" x="117.6" y="528.8"/>
-      <point type="line" x="117.6" y="-84"/>
-      <point type="line" x="24.8" y="-84"/>
+      <point x="24.8" y="-121.6" type="line" name="hintSet0000"/>
+      <point x="167.2" y="-121.6" type="line"/>
+      <point x="167.2" y="566.4" type="line"/>
+      <point x="24.8" y="566.4" type="line"/>
+      <point x="24.8" y="528.8" type="line"/>
+      <point x="117.6" y="528.8" type="line"/>
+      <point x="117.6" y="-84" type="line"/>
+      <point x="24.8" y="-84" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/c.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/c.glif
@@ -7,30 +7,30 @@
   <anchor x="216.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="219.2" y="-9.6" name="hintSet0000"/>
+      <point x="219.2" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="265.6" y="-9.6"/>
       <point x="309.6" y="8.8"/>
-      <point type="curve" x="344.8" y="40"/>
-      <point type="line" x="316" y="84"/>
+      <point x="344.8" y="40" type="curve"/>
+      <point x="316" y="84" type="line"/>
       <point x="292" y="62.4"/>
       <point x="260.8" y="44.8"/>
-      <point type="curve" x="224.8" y="44.8"/>
+      <point x="224.8" y="44.8" type="curve"/>
       <point x="153.6" y="44.8"/>
       <point x="104.8" y="104.8"/>
-      <point type="curve" x="104.8" y="193.6"/>
+      <point x="104.8" y="193.6" type="curve"/>
       <point x="104.8" y="283.2"/>
       <point x="156" y="344"/>
-      <point type="curve" x="226.4" y="344"/>
+      <point x="226.4" y="344" type="curve"/>
       <point x="257.6" y="344"/>
       <point x="281.6" y="329.6"/>
-      <point type="curve" x="304" y="309.6"/>
-      <point type="line" x="337.6" y="352.8"/>
+      <point x="304" y="309.6" type="curve"/>
+      <point x="337.6" y="352.8" type="line"/>
       <point x="310.4" y="377.6"/>
       <point x="275.2" y="398.4"/>
-      <point type="curve" x="224" y="398.4"/>
+      <point x="224" y="398.4" type="curve"/>
       <point x="124" y="398.4"/>
       <point x="36.8" y="324"/>
-      <point type="curve" x="36.8" y="193.6"/>
+      <point x="36.8" y="193.6" type="curve"/>
       <point x="36.8" y="64.8"/>
       <point x="116" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/colon.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/colon.glif
@@ -4,30 +4,30 @@
   <unicode hex="003A"/>
   <outline>
     <contour>
-      <point type="curve" x="80" y="281.12" name="hintSet0000"/>
+      <point x="80" y="281.12" type="curve" name="hintSet0000"/>
       <point x="100.48" y="281.12"/>
       <point x="117.76" y="297.76"/>
-      <point type="curve" x="117.76" y="320.8"/>
+      <point x="117.76" y="320.8" type="curve"/>
       <point x="117.76" y="345.12"/>
       <point x="100.48" y="361.76"/>
-      <point type="curve" x="80" y="361.76"/>
+      <point x="80" y="361.76" type="curve"/>
       <point x="58.88" y="361.76"/>
       <point x="41.6" y="345.12"/>
-      <point type="curve" x="41.6" y="320.8"/>
+      <point x="41.6" y="320.8" type="curve"/>
       <point x="41.6" y="297.76"/>
       <point x="58.88" y="281.12"/>
     </contour>
     <contour>
-      <point type="curve" x="80" y="-7.68"/>
+      <point x="80" y="-7.68" type="curve"/>
       <point x="100.48" y="-7.68"/>
       <point x="117.76" y="8.96"/>
-      <point type="curve" x="117.76" y="32"/>
+      <point x="117.76" y="32" type="curve"/>
       <point x="117.76" y="56.32" name="hintSet0007"/>
       <point x="100.48" y="72.96"/>
-      <point type="curve" x="80" y="72.96"/>
+      <point x="80" y="72.96" type="curve"/>
       <point x="58.88" y="72.96"/>
       <point x="41.6" y="56.32"/>
-      <point type="curve" x="41.6" y="32"/>
+      <point x="41.6" y="32" type="curve"/>
       <point x="41.6" y="8.96" name="hintSet0009"/>
       <point x="58.88" y="-7.68"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/comma.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/comma.glif
@@ -4,27 +4,27 @@
   <unicode hex="002C"/>
   <outline>
     <contour>
-      <point type="line" x="53.6" y="-136" name="hintSet0000"/>
+      <point x="53.6" y="-136" type="line" name="hintSet0000"/>
       <point x="118.4" y="-108.8"/>
       <point x="158.4" y="-55.2"/>
-      <point type="curve" x="158.4" y="13.6"/>
+      <point x="158.4" y="13.6" type="curve"/>
       <point x="158.4" y="61.6"/>
       <point x="137.6" y="91.2"/>
-      <point type="curve" x="103.2" y="91.2"/>
+      <point x="103.2" y="91.2" type="curve"/>
       <point x="76.8" y="91.2" name="hintSet0003"/>
       <point x="54.4" y="73.6"/>
-      <point type="curve" x="54.4" y="44.8"/>
+      <point x="54.4" y="44.8" type="curve"/>
       <point x="54.4" y="15.2"/>
       <point x="76" y="-0.8"/>
-      <point type="curve" x="101.6" y="-0.8"/>
+      <point x="101.6" y="-0.8" type="curve"/>
       <point x="114.4" y="-0.8" name="hintSet0005"/>
       <point x="126.4" y="2.4"/>
-      <point type="curve" x="135.2" y="12.8"/>
-      <point type="line" x="102.4" y="60.8"/>
-      <point type="line" x="109.6" y="1.6"/>
+      <point x="135.2" y="12.8" type="curve"/>
+      <point x="102.4" y="60.8" type="line"/>
+      <point x="109.6" y="1.6" type="line"/>
       <point x="110.4" y="-42.4"/>
       <point x="83.2" y="-77.6"/>
-      <point type="curve" x="37.6" y="-97.6"/>
+      <point x="37.6" y="-97.6" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/d.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/d.glif
@@ -6,38 +6,38 @@
   <anchor x="240.8" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="198.4" y="-9.6" name="hintSet0000"/>
+      <point x="198.4" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="244" y="-9.6" name="hintSet0001"/>
       <point x="285.6" y="16"/>
-      <point type="curve" x="316" y="45.6"/>
-      <point type="line" x="318.4" y="45.6"/>
-      <point type="line" x="324" y="0" name="hintSet0003"/>
-      <point type="line" x="378.4" y="0" name="hintSet0004"/>
-      <point type="line" x="378.4" y="569.6"/>
-      <point type="line" x="312" y="569.6"/>
-      <point type="line" x="312" y="420"/>
-      <point type="line" x="315.2" y="353.6"/>
+      <point x="316" y="45.6" type="curve"/>
+      <point x="318.4" y="45.6" type="line"/>
+      <point x="324" y="0" type="line" name="hintSet0003"/>
+      <point x="378.4" y="0" type="line" name="hintSet0004"/>
+      <point x="378.4" y="569.6" type="line"/>
+      <point x="312" y="569.6" type="line"/>
+      <point x="312" y="420" type="line"/>
+      <point x="315.2" y="353.6" type="line"/>
       <point x="280.8" y="381.6"/>
       <point x="251.2" y="398.4"/>
-      <point type="curve" x="206.4" y="398.4"/>
+      <point x="206.4" y="398.4" type="curve"/>
       <point x="117.6" y="398.4"/>
       <point x="37.6" y="320"/>
-      <point type="curve" x="37.6" y="193.6"/>
+      <point x="37.6" y="193.6" type="curve"/>
       <point x="37.6" y="64" name="hintSet0011"/>
       <point x="100.8" y="-9.6"/>
     </contour>
     <contour>
-      <point type="curve" x="212.8" y="45.6"/>
+      <point x="212.8" y="45.6" type="curve"/>
       <point x="144.8" y="45.6"/>
       <point x="105.6" y="101.6"/>
-      <point type="curve" x="105.6" y="194.4"/>
+      <point x="105.6" y="194.4" type="curve"/>
       <point x="105.6" y="283.2"/>
       <point x="155.2" y="343.2"/>
-      <point type="curve" x="217.6" y="343.2"/>
+      <point x="217.6" y="343.2" type="curve"/>
       <point x="249.6" y="343.2"/>
       <point x="279.2" y="332"/>
-      <point type="curve" x="312" y="302.4"/>
-      <point type="line" x="312" y="99.2"/>
+      <point x="312" y="302.4" type="curve"/>
+      <point x="312" y="99.2" type="line"/>
       <point x="280" y="63.2"/>
       <point x="248.8" y="45.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/dollar.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/dollar.glif
@@ -4,50 +4,50 @@
   <unicode hex="0024"/>
   <outline>
     <contour>
-      <point type="curve" x="196" y="-9.6" name="hintSet0000"/>
+      <point x="196" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="288.8" y="-9.6"/>
       <point x="349.6" y="46.4"/>
-      <point type="curve" x="349.6" y="132"/>
+      <point x="349.6" y="132" type="curve"/>
       <point x="349.6" y="304" name="hintSet0002"/>
       <point x="126.4" y="272"/>
-      <point type="curve" x="126.4" y="388"/>
+      <point x="126.4" y="388" type="curve"/>
       <point x="126.4" y="434.4"/>
       <point x="157.6" y="464.8"/>
-      <point type="curve" x="206.4" y="464.8"/>
+      <point x="206.4" y="464.8" type="curve"/>
       <point x="249.6" y="464.8"/>
       <point x="274.4" y="448"/>
-      <point type="curve" x="304" y="419.2"/>
-      <point type="line" x="339.2" y="458.4" name="hintSet0005"/>
+      <point x="304" y="419.2" type="curve"/>
+      <point x="339.2" y="458.4" type="line" name="hintSet0005"/>
       <point x="306.4" y="492.8"/>
       <point x="268" y="520"/>
-      <point type="curve" x="204.8" y="520"/>
+      <point x="204.8" y="520" type="curve"/>
       <point x="120" y="520"/>
       <point x="61.6" y="464.8"/>
-      <point type="curve" x="61.6" y="384.8"/>
+      <point x="61.6" y="384.8" type="curve"/>
       <point x="61.6" y="228.8"/>
       <point x="284.8" y="256.8"/>
-      <point type="curve" x="284.8" y="127.2"/>
+      <point x="284.8" y="127.2" type="curve"/>
       <point x="284.8" y="77.6"/>
       <point x="255.2" y="44.8"/>
-      <point type="curve" x="196" y="44.8"/>
+      <point x="196" y="44.8" type="curve"/>
       <point x="147.2" y="44.8"/>
       <point x="106.4" y="68.8"/>
-      <point type="curve" x="72" y="98.4"/>
-      <point type="line" x="41.6" y="52.8" name="hintSet0011"/>
+      <point x="72" y="98.4" type="curve"/>
+      <point x="41.6" y="52.8" type="line" name="hintSet0011"/>
       <point x="79.2" y="17.6"/>
       <point x="138.4" y="-9.6"/>
     </contour>
     <contour>
-      <point type="line" x="177.6" y="-88"/>
-      <point type="line" x="225.6" y="-88"/>
-      <point type="line" x="225.6" y="13.6"/>
-      <point type="line" x="177.6" y="13.6"/>
+      <point x="177.6" y="-88" type="line"/>
+      <point x="225.6" y="-88" type="line"/>
+      <point x="225.6" y="13.6" type="line"/>
+      <point x="177.6" y="13.6" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="177.6" y="495.2"/>
-      <point type="line" x="225.6" y="495.2"/>
-      <point type="line" x="225.6" y="598.4" name="hintSet0019"/>
-      <point type="line" x="177.6" y="598.4"/>
+      <point x="177.6" y="495.2" type="line"/>
+      <point x="225.6" y="495.2" type="line"/>
+      <point x="225.6" y="598.4" type="line" name="hintSet0019"/>
+      <point x="177.6" y="598.4" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/e.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/e.glif
@@ -7,38 +7,38 @@
   <anchor x="209.60000000000002" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="223.2" y="-9.6" name="hintSet0000"/>
+      <point x="223.2" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="276" y="-9.6"/>
       <point x="317.6" y="8.8"/>
-      <point type="curve" x="351.2" y="30.4"/>
-      <point type="line" x="328" y="73.6"/>
+      <point x="351.2" y="30.4" type="curve"/>
+      <point x="328" y="73.6" type="line"/>
       <point x="299.2" y="55.2"/>
       <point x="268" y="43.2"/>
-      <point type="curve" x="231.2" y="43.2"/>
+      <point x="231.2" y="43.2" type="curve"/>
       <point x="156.8" y="43.2" name="hintSet0004"/>
       <point x="106.4" y="96"/>
-      <point type="curve" x="101.6" y="178.4"/>
-      <point type="line" x="364" y="178.4"/>
+      <point x="101.6" y="178.4" type="curve"/>
+      <point x="364" y="178.4" type="line"/>
       <point x="365.6" y="188"/>
       <point x="366.4" y="202.4"/>
-      <point type="curve" x="366.4" y="216"/>
+      <point x="366.4" y="216" type="curve"/>
       <point x="366.4" y="327.2"/>
       <point x="310.4" y="398.4"/>
-      <point type="curve" x="211.2" y="398.4"/>
+      <point x="211.2" y="398.4" type="curve"/>
       <point x="122.4" y="398.4" name="hintSet0008"/>
       <point x="36.8" y="320.8"/>
-      <point type="curve" x="36.8" y="193.6"/>
+      <point x="36.8" y="193.6" type="curve"/>
       <point x="36.8" y="66.4"/>
       <point x="119.2" y="-9.6"/>
     </contour>
     <contour>
-      <point type="line" x="100.8" y="225.6"/>
+      <point x="100.8" y="225.6" type="line"/>
       <point x="108.8" y="302.4"/>
       <point x="158.4" y="346.4"/>
-      <point type="curve" x="212.8" y="346.4"/>
+      <point x="212.8" y="346.4" type="curve"/>
       <point x="273.6" y="346.4"/>
       <point x="308.8" y="304"/>
-      <point type="curve" x="308.8" y="225.6"/>
+      <point x="308.8" y="225.6" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/eight.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/eight.glif
@@ -4,58 +4,58 @@
   <unicode hex="0038"/>
   <outline>
     <contour>
-      <point type="curve" x="200" y="-9.6" name="hintSet0000"/>
+      <point x="200" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="299.2" y="-9.6"/>
       <point x="364.8" y="50.4"/>
-      <point type="curve" x="364.8" y="126.4"/>
+      <point x="364.8" y="126.4" type="curve"/>
       <point x="364.8" y="195.2"/>
       <point x="321.6" y="231.2"/>
-      <point type="curve" x="276" y="257.6"/>
-      <point type="line" x="276" y="260.8"/>
+      <point x="276" y="257.6" type="curve"/>
+      <point x="276" y="260.8" type="line"/>
       <point x="307.2" y="284.8" name="hintSet0004"/>
       <point x="346.4" y="330.4"/>
-      <point type="curve" x="346.4" y="384"/>
+      <point x="346.4" y="384" type="curve"/>
       <point x="346.4" y="463.2"/>
       <point x="291.2" y="520"/>
-      <point type="curve" x="202.4" y="520"/>
+      <point x="202.4" y="520" type="curve"/>
       <point x="120" y="520"/>
       <point x="57.6" y="467.2"/>
-      <point type="curve" x="57.6" y="388.8"/>
+      <point x="57.6" y="388.8" type="curve"/>
       <point x="57.6" y="335.2"/>
       <point x="91.2" y="297.6"/>
-      <point type="curve" x="128.8" y="271.2"/>
-      <point type="line" x="128.8" y="268"/>
+      <point x="128.8" y="271.2" type="curve"/>
+      <point x="128.8" y="268" type="line"/>
       <point x="80.8" y="242.4" name="hintSet0009"/>
       <point x="32.8" y="196.8"/>
-      <point type="curve" x="32.8" y="130.4"/>
+      <point x="32.8" y="130.4" type="curve"/>
       <point x="32.8" y="49.6"/>
       <point x="104" y="-9.6"/>
     </contour>
     <contour>
-      <point type="curve" x="236" y="278.4" name="hintSet0011"/>
+      <point x="236" y="278.4" type="curve" name="hintSet0011"/>
       <point x="174.4" y="302.4"/>
       <point x="118.4" y="328"/>
-      <point type="curve" x="118.4" y="388.8"/>
+      <point x="118.4" y="388.8" type="curve"/>
       <point x="118.4" y="438.4"/>
       <point x="153.6" y="471.2"/>
-      <point type="curve" x="200.8" y="471.2"/>
+      <point x="200.8" y="471.2" type="curve"/>
       <point x="256.8" y="471.2"/>
       <point x="289.6" y="431.2"/>
-      <point type="curve" x="289.6" y="380.8"/>
+      <point x="289.6" y="380.8" type="curve"/>
       <point x="289.6" y="343.2"/>
       <point x="270.4" y="308.8"/>
     </contour>
     <contour>
-      <point type="curve" x="201.6" y="39.2" name="hintSet0016"/>
+      <point x="201.6" y="39.2" type="curve" name="hintSet0016"/>
       <point x="139.2" y="39.2"/>
       <point x="92" y="80"/>
-      <point type="curve" x="92" y="136.8"/>
+      <point x="92" y="136.8" type="curve"/>
       <point x="92" y="183.2"/>
       <point x="122.4" y="220.8"/>
-      <point type="curve" x="163.2" y="248"/>
+      <point x="163.2" y="248" type="curve"/>
       <point x="236.8" y="218.4"/>
       <point x="301.6" y="194.4"/>
-      <point type="curve" x="301.6" y="128.8"/>
+      <point x="301.6" y="128.8" type="curve"/>
       <point x="301.6" y="76"/>
       <point x="260.8" y="39.2"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/exclam.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/exclam.glif
@@ -4,24 +4,24 @@
   <unicode hex="0021"/>
   <outline>
     <contour>
-      <point type="line" x="92.8" y="158.4" name="hintSet0000"/>
-      <point type="line" x="138.4" y="158.4"/>
-      <point type="line" x="147.2" y="460.8"/>
-      <point type="line" x="148.8" y="536"/>
-      <point type="line" x="82.4" y="536"/>
-      <point type="line" x="84" y="460.8"/>
+      <point x="92.8" y="158.4" type="line" name="hintSet0000"/>
+      <point x="138.4" y="158.4" type="line"/>
+      <point x="147.2" y="460.8" type="line"/>
+      <point x="148.8" y="536" type="line"/>
+      <point x="82.4" y="536" type="line"/>
+      <point x="84" y="460.8" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="116" y="-9.6" name="hintSet0006"/>
+      <point x="116" y="-9.6" type="curve" name="hintSet0006"/>
       <point x="141.6" y="-9.6"/>
       <point x="163.2" y="11.2"/>
-      <point type="curve" x="163.2" y="40"/>
+      <point x="163.2" y="40" type="curve"/>
       <point x="163.2" y="70.4" name="hintSet0008"/>
       <point x="141.6" y="91.2"/>
-      <point type="curve" x="116" y="91.2"/>
+      <point x="116" y="91.2" type="curve"/>
       <point x="89.6" y="91.2"/>
       <point x="68" y="70.4"/>
-      <point type="curve" x="68" y="40"/>
+      <point x="68" y="40" type="curve"/>
       <point x="68" y="11.2" name="hintSet0010"/>
       <point x="89.6" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/f.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/f.glif
@@ -6,29 +6,29 @@
   <anchor x="109.60000000000001" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="76.8" y="0" name="hintSet0000"/>
-      <point type="line" x="142.4" y="0"/>
-      <point type="line" x="142.4" y="450.4"/>
+      <point x="76.8" y="0" type="line" name="hintSet0000"/>
+      <point x="142.4" y="0" type="line"/>
+      <point x="142.4" y="450.4" type="line"/>
       <point x="142.4" y="500"/>
       <point x="160" y="525.6"/>
-      <point type="curve" x="196.8" y="525.6"/>
+      <point x="196.8" y="525.6" type="curve"/>
       <point x="211.2" y="525.6"/>
       <point x="226.4" y="522.4"/>
-      <point type="curve" x="240.8" y="516"/>
-      <point type="line" x="255.2" y="566.4"/>
+      <point x="240.8" y="516" type="curve"/>
+      <point x="255.2" y="566.4" type="line"/>
       <point x="237.6" y="573.6"/>
       <point x="214.4" y="579.2"/>
-      <point type="curve" x="190.4" y="579.2"/>
+      <point x="190.4" y="579.2" type="curve"/>
       <point x="112.8" y="579.2"/>
       <point x="76.8" y="529.6"/>
-      <point type="curve" x="76.8" y="450.4"/>
+      <point x="76.8" y="450.4" type="curve"/>
     </contour>
     <contour>
-      <point type="line" x="24" y="335.2" name="hintSet0008"/>
-      <point type="line" x="224.8" y="335.2" name="hintSet0009"/>
-      <point type="line" x="224.8" y="388.8"/>
-      <point type="line" x="79.2" y="388.8" name="hintSet0011"/>
-      <point type="line" x="24" y="384.8"/>
+      <point x="24" y="335.2" type="line" name="hintSet0008"/>
+      <point x="224.8" y="335.2" type="line" name="hintSet0009"/>
+      <point x="224.8" y="388.8" type="line"/>
+      <point x="79.2" y="388.8" type="line" name="hintSet0011"/>
+      <point x="24" y="384.8" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/five.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/five.glif
@@ -4,35 +4,35 @@
   <unicode hex="0035"/>
   <outline>
     <contour>
-      <point type="curve" x="187.2" y="-9.6" name="hintSet0000"/>
+      <point x="187.2" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="276" y="-9.6"/>
       <point x="359.2" y="52.8"/>
-      <point type="curve" x="359.2" y="163.2"/>
+      <point x="359.2" y="163.2" type="curve"/>
       <point x="359.2" y="273.6"/>
       <point x="288" y="323.2"/>
-      <point type="curve" x="200.8" y="323.2"/>
+      <point x="200.8" y="323.2" type="curve"/>
       <point x="169.6" y="323.2"/>
       <point x="146.4" y="315.2"/>
-      <point type="curve" x="122.4" y="302.4"/>
-      <point type="line" x="136" y="453.6"/>
-      <point type="line" x="333.6" y="453.6"/>
-      <point type="line" x="333.6" y="510.4"/>
-      <point type="line" x="78.4" y="510.4"/>
-      <point type="line" x="61.6" y="264.8"/>
-      <point type="line" x="96.8" y="242.4"/>
+      <point x="122.4" y="302.4" type="curve"/>
+      <point x="136" y="453.6" type="line"/>
+      <point x="333.6" y="453.6" type="line"/>
+      <point x="333.6" y="510.4" type="line"/>
+      <point x="78.4" y="510.4" type="line"/>
+      <point x="61.6" y="264.8" type="line"/>
+      <point x="96.8" y="242.4" type="line"/>
       <point x="127.2" y="262.4"/>
       <point x="148.8" y="273.6"/>
-      <point type="curve" x="184" y="273.6"/>
+      <point x="184" y="273.6" type="curve"/>
       <point x="249.6" y="273.6"/>
       <point x="292.8" y="232"/>
-      <point type="curve" x="292.8" y="161.6"/>
+      <point x="292.8" y="161.6" type="curve"/>
       <point x="292.8" y="90.4"/>
       <point x="243.2" y="44.8"/>
-      <point type="curve" x="180.8" y="44.8"/>
+      <point x="180.8" y="44.8" type="curve"/>
       <point x="120.8" y="44.8"/>
       <point x="82.4" y="72.8"/>
-      <point type="curve" x="52" y="103.2"/>
-      <point type="line" x="20" y="60"/>
+      <point x="52" y="103.2" type="curve"/>
+      <point x="20" y="60" type="line"/>
       <point x="55.2" y="24.8"/>
       <point x="105.6" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/four.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/four.glif
@@ -4,23 +4,23 @@
   <unicode hex="0034"/>
   <outline>
     <contour>
-      <point type="line" x="243.2" y="0" name="hintSet0000"/>
-      <point type="line" x="305.6" y="0"/>
-      <point type="line" x="305.6" y="510.4"/>
-      <point type="line" x="232" y="510.4"/>
-      <point type="line" x="13.6" y="184" name="hintSet0004"/>
-      <point type="line" x="13.6" y="140.8"/>
-      <point type="line" x="375.2" y="140.8"/>
-      <point type="line" x="375.2" y="193.6"/>
-      <point type="line" x="83.2" y="193.6"/>
-      <point type="line" x="202.4" y="368" name="hintSet0009"/>
+      <point x="243.2" y="0" type="line" name="hintSet0000"/>
+      <point x="305.6" y="0" type="line"/>
+      <point x="305.6" y="510.4" type="line"/>
+      <point x="232" y="510.4" type="line"/>
+      <point x="13.6" y="184" type="line" name="hintSet0004"/>
+      <point x="13.6" y="140.8" type="line"/>
+      <point x="375.2" y="140.8" type="line"/>
+      <point x="375.2" y="193.6" type="line"/>
+      <point x="83.2" y="193.6" type="line"/>
+      <point x="202.4" y="368" type="line" name="hintSet0009"/>
       <point x="216.8" y="392.8"/>
       <point x="231.2" y="415.2"/>
-      <point type="curve" x="244" y="440"/>
-      <point type="line" x="247.2" y="440"/>
+      <point x="244" y="440" type="curve"/>
+      <point x="247.2" y="440" type="line"/>
       <point x="245.6" y="412.8"/>
       <point x="243.2" y="368.8"/>
-      <point type="curve" x="243.2" y="341.6"/>
+      <point x="243.2" y="341.6" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/g.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/g.glif
@@ -6,84 +6,84 @@
   <anchor x="200.0" y="-184.0" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="196.8" y="-179.2" name="hintSet0000"/>
+      <point x="196.8" y="-179.2" type="curve" name="hintSet0000"/>
       <point x="317.6" y="-179.2"/>
       <point x="393.6" y="-116.8"/>
-      <point type="curve" x="393.6" y="-44.8"/>
+      <point x="393.6" y="-44.8" type="curve"/>
       <point x="393.6" y="20"/>
       <point x="348" y="48"/>
-      <point type="curve" x="257.6" y="48"/>
-      <point type="line" x="182.4" y="48" name="hintSet0003"/>
+      <point x="257.6" y="48" type="curve"/>
+      <point x="182.4" y="48" type="line" name="hintSet0003"/>
       <point x="129.6" y="48"/>
       <point x="113.6" y="65.6"/>
-      <point type="curve" x="113.6" y="90.4"/>
+      <point x="113.6" y="90.4" type="curve"/>
       <point x="113.6" y="112"/>
       <point x="124.8" y="124.8"/>
-      <point type="curve" x="138.4" y="136.8"/>
+      <point x="138.4" y="136.8" type="curve"/>
       <point x="156" y="128"/>
       <point x="177.6" y="123.2"/>
-      <point type="curve" x="196.8" y="123.2"/>
+      <point x="196.8" y="123.2" type="curve"/>
       <point x="276" y="123.2"/>
       <point x="339.2" y="175.2"/>
-      <point type="curve" x="339.2" y="258.4"/>
+      <point x="339.2" y="258.4" type="curve"/>
       <point x="339.2" y="291.2"/>
       <point x="325.6" y="320.8"/>
-      <point type="curve" x="307.2" y="338.4"/>
-      <point type="line" x="387.2" y="338.4"/>
-      <point type="line" x="387.2" y="388.8"/>
-      <point type="line" x="252" y="388.8"/>
+      <point x="307.2" y="338.4" type="curve"/>
+      <point x="387.2" y="338.4" type="line"/>
+      <point x="387.2" y="388.8" type="line"/>
+      <point x="252" y="388.8" type="line"/>
       <point x="237.6" y="394.4"/>
       <point x="218.4" y="398.4"/>
-      <point type="curve" x="196.8" y="398.4"/>
+      <point x="196.8" y="398.4" type="curve"/>
       <point x="117.6" y="398.4" name="hintSet0013"/>
       <point x="50.4" y="344.8"/>
-      <point type="curve" x="50.4" y="260"/>
+      <point x="50.4" y="260" type="curve"/>
       <point x="50.4" y="213.6"/>
       <point x="75.2" y="176"/>
-      <point type="curve" x="100.8" y="155.2"/>
-      <point type="line" x="100.8" y="152"/>
+      <point x="100.8" y="155.2" type="curve"/>
+      <point x="100.8" y="152" type="line"/>
       <point x="80.8" y="138.4" name="hintSet0016"/>
       <point x="58.4" y="112.8"/>
-      <point type="curve" x="58.4" y="80"/>
+      <point x="58.4" y="80" type="curve"/>
       <point x="58.4" y="49.6"/>
       <point x="73.6" y="28.8"/>
-      <point type="curve" x="92.8" y="16.8"/>
-      <point type="line" x="92.8" y="13.6"/>
+      <point x="92.8" y="16.8" type="curve"/>
+      <point x="92.8" y="13.6" type="line"/>
       <point x="57.6" y="-10.4" name="hintSet0019"/>
       <point x="36" y="-41.6"/>
-      <point type="curve" x="36" y="-74.4"/>
+      <point x="36" y="-74.4" type="curve"/>
       <point x="36" y="-141.6" name="hintSet0020"/>
       <point x="101.6" y="-179.2"/>
     </contour>
     <contour>
-      <point type="curve" x="196.8" y="167.2" name="hintSet0021"/>
+      <point x="196.8" y="167.2" type="curve" name="hintSet0021"/>
       <point x="152" y="167.2"/>
       <point x="114.4" y="203.2"/>
-      <point type="curve" x="114.4" y="260"/>
+      <point x="114.4" y="260" type="curve"/>
       <point x="114.4" y="316.8"/>
       <point x="151.2" y="350.4"/>
-      <point type="curve" x="196.8" y="350.4"/>
+      <point x="196.8" y="350.4" type="curve"/>
       <point x="242.4" y="350.4"/>
       <point x="279.2" y="316.8"/>
-      <point type="curve" x="279.2" y="260"/>
+      <point x="279.2" y="260" type="curve"/>
       <point x="279.2" y="203.2"/>
       <point x="241.6" y="167.2"/>
     </contour>
     <contour>
-      <point type="curve" x="206.4" y="-133.6" name="hintSet0026"/>
+      <point x="206.4" y="-133.6" type="curve" name="hintSet0026"/>
       <point x="136" y="-133.6"/>
       <point x="93.6" y="-107.2"/>
-      <point type="curve" x="93.6" y="-65.6"/>
+      <point x="93.6" y="-65.6" type="curve"/>
       <point x="93.6" y="-43.2"/>
       <point x="105.6" y="-20"/>
-      <point type="curve" x="133.6" y="0"/>
+      <point x="133.6" y="0" type="curve"/>
       <point x="150.4" y="-4.8" name="hintSet0029"/>
       <point x="168.8" y="-6.4"/>
-      <point type="curve" x="184" y="-6.4"/>
-      <point type="line" x="251.2" y="-6.4"/>
+      <point x="184" y="-6.4" type="curve"/>
+      <point x="251.2" y="-6.4" type="line"/>
       <point x="301.6" y="-6.4"/>
       <point x="329.6" y="-18.4"/>
-      <point type="curve" x="329.6" y="-54.4"/>
+      <point x="329.6" y="-54.4" type="curve"/>
       <point x="329.6" y="-95.2" name="hintSet0032"/>
       <point x="280.8" y="-133.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/greater.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/greater.glif
@@ -4,16 +4,16 @@
   <unicode hex="003E"/>
   <outline>
     <contour>
-      <point type="line" x="27.2" y="104.8" name="hintSet0000"/>
-      <point type="line" x="370.4" y="239.2"/>
-      <point type="line" x="370.4" y="292"/>
-      <point type="line" x="27.2" y="426.4"/>
-      <point type="line" x="27.2" y="369.6"/>
-      <point type="line" x="196" y="307.2"/>
-      <point type="line" x="303.2" y="267.2"/>
-      <point type="line" x="303.2" y="264"/>
-      <point type="line" x="196" y="224"/>
-      <point type="line" x="27.2" y="161.6"/>
+      <point x="27.2" y="104.8" type="line" name="hintSet0000"/>
+      <point x="370.4" y="239.2" type="line"/>
+      <point x="370.4" y="292" type="line"/>
+      <point x="27.2" y="426.4" type="line"/>
+      <point x="27.2" y="369.6" type="line"/>
+      <point x="196" y="307.2" type="line"/>
+      <point x="303.2" y="267.2" type="line"/>
+      <point x="303.2" y="264" type="line"/>
+      <point x="196" y="224" type="line"/>
+      <point x="27.2" y="161.6" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/h.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/h.glif
@@ -6,27 +6,27 @@
   <anchor x="228.8" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="65.6" y="0" name="hintSet0000"/>
-      <point type="line" x="131.2" y="0"/>
-      <point type="line" x="131.2" y="281.6"/>
+      <point x="65.6" y="0" type="line" name="hintSet0000"/>
+      <point x="131.2" y="0" type="line"/>
+      <point x="131.2" y="281.6" type="line"/>
       <point x="170.4" y="320.8"/>
       <point x="197.6" y="341.6"/>
-      <point type="curve" x="237.6" y="341.6"/>
+      <point x="237.6" y="341.6" type="curve"/>
       <point x="288.8" y="341.6"/>
       <point x="311.2" y="310.4"/>
-      <point type="curve" x="311.2" y="237.6"/>
-      <point type="line" x="311.2" y="0"/>
-      <point type="line" x="376.8" y="0"/>
-      <point type="line" x="376.8" y="246.4"/>
+      <point x="311.2" y="237.6" type="curve"/>
+      <point x="311.2" y="0" type="line"/>
+      <point x="376.8" y="0" type="line"/>
+      <point x="376.8" y="246.4" type="line"/>
       <point x="376.8" y="345.6"/>
       <point x="340" y="398.4"/>
-      <point type="curve" x="258.4" y="398.4"/>
+      <point x="258.4" y="398.4" type="curve"/>
       <point x="204.8" y="398.4"/>
       <point x="165.6" y="369.6"/>
-      <point type="curve" x="128.8" y="334.4"/>
-      <point type="line" x="131.2" y="414.4"/>
-      <point type="line" x="131.2" y="569.6"/>
-      <point type="line" x="65.6" y="569.6"/>
+      <point x="128.8" y="334.4" type="curve"/>
+      <point x="131.2" y="414.4" type="line"/>
+      <point x="131.2" y="569.6" type="line"/>
+      <point x="65.6" y="569.6" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/hyphen.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/hyphen.glif
@@ -4,10 +4,10 @@
   <unicode hex="002D"/>
   <outline>
     <contour>
-      <point type="line" x="32.8" y="175.2" name="hintSet0000"/>
-      <point type="line" x="216.8" y="175.2"/>
-      <point type="line" x="216.8" y="225.6"/>
-      <point type="line" x="32.8" y="225.6"/>
+      <point x="32.8" y="175.2" type="line" name="hintSet0000"/>
+      <point x="216.8" y="175.2" type="line"/>
+      <point x="216.8" y="225.6" type="line"/>
+      <point x="32.8" y="225.6" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/i.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/i.glif
@@ -7,22 +7,22 @@
   <anchor x="98.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="65.6" y="0" name="hintSet0000"/>
-      <point type="line" x="131.2" y="0"/>
-      <point type="line" x="131.2" y="388.8"/>
-      <point type="line" x="65.6" y="388.8"/>
+      <point x="65.6" y="0" type="line" name="hintSet0000"/>
+      <point x="131.2" y="0" type="line"/>
+      <point x="131.2" y="388.8" type="line"/>
+      <point x="65.6" y="388.8" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="99.2" y="468.8" name="hintSet0004"/>
+      <point x="99.2" y="468.8" type="curve" name="hintSet0004"/>
       <point x="124.8" y="468.8"/>
       <point x="144.8" y="486.4"/>
-      <point type="curve" x="144.8" y="511.2"/>
+      <point x="144.8" y="511.2" type="curve"/>
       <point x="144.8" y="536.8"/>
       <point x="124.8" y="553.6"/>
-      <point type="curve" x="99.2" y="553.6"/>
+      <point x="99.2" y="553.6" type="curve"/>
       <point x="73.6" y="553.6"/>
       <point x="53.6" y="536.8"/>
-      <point type="curve" x="53.6" y="511.2"/>
+      <point x="53.6" y="511.2" type="curve"/>
       <point x="53.6" y="486.4"/>
       <point x="73.6" y="468.8"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/j.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/j.glif
@@ -6,34 +6,34 @@
   <anchor x="47.2" y="-184.8" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="25.6" y="-173.6" name="hintSet0000"/>
+      <point x="25.6" y="-173.6" type="curve" name="hintSet0000"/>
       <point x="103.2" y="-173.6"/>
       <point x="132" y="-123.2"/>
-      <point type="curve" x="132" y="-44"/>
-      <point type="line" x="132" y="388.8"/>
-      <point type="line" x="66.4" y="388.8"/>
-      <point type="line" x="66.4" y="-44"/>
+      <point x="132" y="-44" type="curve"/>
+      <point x="132" y="388.8" type="line"/>
+      <point x="66.4" y="388.8" type="line"/>
+      <point x="66.4" y="-44" type="line"/>
       <point x="66.4" y="-91.2"/>
       <point x="56.8" y="-120"/>
-      <point type="curve" x="18.4" y="-120"/>
+      <point x="18.4" y="-120" type="curve"/>
       <point x="4.8" y="-120"/>
       <point x="-8.8" y="-116.8"/>
-      <point type="curve" x="-18.4" y="-113.6"/>
-      <point type="line" x="-32" y="-163.2"/>
+      <point x="-18.4" y="-113.6" type="curve"/>
+      <point x="-32" y="-163.2" type="line"/>
       <point x="-18.4" y="-168.8"/>
       <point x="1.6" y="-173.6"/>
     </contour>
     <contour>
-      <point type="curve" x="100" y="468.8" name="hintSet0009"/>
+      <point x="100" y="468.8" type="curve" name="hintSet0009"/>
       <point x="124.8" y="468.8"/>
       <point x="144.8" y="486.4"/>
-      <point type="curve" x="144.8" y="511.2"/>
+      <point x="144.8" y="511.2" type="curve"/>
       <point x="144.8" y="536.8"/>
       <point x="124.8" y="553.6"/>
-      <point type="curve" x="100" y="553.6"/>
+      <point x="100" y="553.6" type="curve"/>
       <point x="74.4" y="553.6"/>
       <point x="54.4" y="536.8"/>
-      <point type="curve" x="54.4" y="511.2"/>
+      <point x="54.4" y="511.2" type="curve"/>
       <point x="54.4" y="486.4"/>
       <point x="74.4" y="468.8"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/k.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/k.glif
@@ -6,19 +6,19 @@
   <anchor x="216.8" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="65.6" y="0" name="hintSet0000"/>
-      <point type="line" x="130.4" y="0"/>
-      <point type="line" x="130.4" y="102.4"/>
-      <point type="line" x="203.2" y="187.2"/>
-      <point type="line" x="316.8" y="0"/>
-      <point type="line" x="388.8" y="0"/>
-      <point type="line" x="240.8" y="232.8"/>
-      <point type="line" x="371.2" y="388.8"/>
-      <point type="line" x="298.4" y="388.8"/>
-      <point type="line" x="132.8" y="184"/>
-      <point type="line" x="130.4" y="184"/>
-      <point type="line" x="130.4" y="569.6"/>
-      <point type="line" x="65.6" y="569.6"/>
+      <point x="65.6" y="0" type="line" name="hintSet0000"/>
+      <point x="130.4" y="0" type="line"/>
+      <point x="130.4" y="102.4" type="line"/>
+      <point x="203.2" y="187.2" type="line"/>
+      <point x="316.8" y="0" type="line"/>
+      <point x="388.8" y="0" type="line"/>
+      <point x="240.8" y="232.8" type="line"/>
+      <point x="371.2" y="388.8" type="line"/>
+      <point x="298.4" y="388.8" type="line"/>
+      <point x="132.8" y="184" type="line"/>
+      <point x="130.4" y="184" type="line"/>
+      <point x="130.4" y="569.6" type="line"/>
+      <point x="65.6" y="569.6" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/l.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/l.glif
@@ -6,20 +6,20 @@
   <anchor x="109.60000000000001" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="135.2" y="-9.6" name="hintSet0000"/>
+      <point x="135.2" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="152.8" y="-9.6"/>
       <point x="164" y="-7.2"/>
-      <point type="curve" x="172.8" y="-3.2"/>
-      <point type="line" x="164" y="46.4"/>
+      <point x="172.8" y="-3.2" type="curve"/>
+      <point x="164" y="46.4" type="line"/>
       <point x="156.8" y="44.8"/>
       <point x="153.6" y="44.8"/>
-      <point type="curve" x="149.6" y="44.8"/>
+      <point x="149.6" y="44.8" type="curve"/>
       <point x="140" y="44.8"/>
       <point x="131.2" y="52.8"/>
-      <point type="curve" x="131.2" y="73.6"/>
-      <point type="line" x="131.2" y="569.6"/>
-      <point type="line" x="65.6" y="569.6"/>
-      <point type="line" x="65.6" y="78.4"/>
+      <point x="131.2" y="73.6" type="curve"/>
+      <point x="131.2" y="569.6" type="line"/>
+      <point x="65.6" y="569.6" type="line"/>
+      <point x="65.6" y="78.4" type="line"/>
       <point x="65.6" y="21.6"/>
       <point x="85.6" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/less.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/less.glif
@@ -4,16 +4,16 @@
   <unicode hex="003C"/>
   <outline>
     <contour>
-      <point type="line" x="370.4" y="104.8" name="hintSet0000"/>
-      <point type="line" x="370.4" y="161.6"/>
-      <point type="line" x="201.6" y="224"/>
-      <point type="line" x="94.4" y="264"/>
-      <point type="line" x="94.4" y="267.2"/>
-      <point type="line" x="201.6" y="307.2"/>
-      <point type="line" x="370.4" y="369.6"/>
-      <point type="line" x="370.4" y="426.4"/>
-      <point type="line" x="27.2" y="292"/>
-      <point type="line" x="27.2" y="239.2"/>
+      <point x="370.4" y="104.8" type="line" name="hintSet0000"/>
+      <point x="370.4" y="161.6" type="line"/>
+      <point x="201.6" y="224" type="line"/>
+      <point x="94.4" y="264" type="line"/>
+      <point x="94.4" y="267.2" type="line"/>
+      <point x="201.6" y="307.2" type="line"/>
+      <point x="370.4" y="369.6" type="line"/>
+      <point x="370.4" y="426.4" type="line"/>
+      <point x="27.2" y="292" type="line"/>
+      <point x="27.2" y="239.2" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/m.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/m.glif
@@ -6,42 +6,42 @@
   <anchor x="340.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="65.6" y="0" name="hintSet0000"/>
-      <point type="line" x="131.2" y="0"/>
-      <point type="line" x="131.2" y="281.6"/>
+      <point x="65.6" y="0" type="line" name="hintSet0000"/>
+      <point x="131.2" y="0" type="line"/>
+      <point x="131.2" y="281.6" type="line"/>
       <point x="167.2" y="321.6"/>
       <point x="200" y="341.6"/>
-      <point type="curve" x="228.8" y="341.6"/>
+      <point x="228.8" y="341.6" type="curve"/>
       <point x="278.4" y="341.6"/>
       <point x="301.6" y="310.4"/>
-      <point type="curve" x="301.6" y="237.6"/>
-      <point type="line" x="301.6" y="0"/>
-      <point type="line" x="367.2" y="0"/>
-      <point type="line" x="367.2" y="281.6"/>
+      <point x="301.6" y="237.6" type="curve"/>
+      <point x="301.6" y="0" type="line"/>
+      <point x="367.2" y="0" type="line"/>
+      <point x="367.2" y="281.6" type="line"/>
       <point x="403.2" y="321.6"/>
       <point x="434.4" y="341.6"/>
-      <point type="curve" x="464.8" y="341.6"/>
+      <point x="464.8" y="341.6" type="curve"/>
       <point x="513.6" y="341.6"/>
       <point x="536.8" y="310.4"/>
-      <point type="curve" x="536.8" y="237.6"/>
-      <point type="line" x="536.8" y="0"/>
-      <point type="line" x="602.4" y="0"/>
-      <point type="line" x="602.4" y="246.4"/>
+      <point x="536.8" y="237.6" type="curve"/>
+      <point x="536.8" y="0" type="line"/>
+      <point x="602.4" y="0" type="line"/>
+      <point x="602.4" y="246.4" type="line"/>
       <point x="602.4" y="345.6"/>
       <point x="564" y="398.4"/>
-      <point type="curve" x="484" y="398.4"/>
+      <point x="484" y="398.4" type="curve"/>
       <point x="436.8" y="398.4"/>
       <point x="396.8" y="368"/>
-      <point type="curve" x="356" y="324"/>
+      <point x="356" y="324" type="curve"/>
       <point x="340" y="370.4"/>
       <point x="308" y="398.4"/>
-      <point type="curve" x="248.8" y="398.4"/>
+      <point x="248.8" y="398.4" type="curve"/>
       <point x="202.4" y="398.4" name="hintSet0016"/>
       <point x="161.6" y="369.6"/>
-      <point type="curve" x="128" y="332.8"/>
-      <point type="line" x="125.6" y="332.8"/>
-      <point type="line" x="120" y="388.8"/>
-      <point type="line" x="65.6" y="388.8" name="hintSet0019"/>
+      <point x="128" y="332.8" type="curve"/>
+      <point x="125.6" y="332.8" type="line"/>
+      <point x="120" y="388.8" type="line"/>
+      <point x="65.6" y="388.8" type="line" name="hintSet0019"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/n.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/n.glif
@@ -6,27 +6,27 @@
   <anchor x="222.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="65.6" y="0" name="hintSet0000"/>
-      <point type="line" x="131.2" y="0"/>
-      <point type="line" x="131.2" y="281.6"/>
+      <point x="65.6" y="0" type="line" name="hintSet0000"/>
+      <point x="131.2" y="0" type="line"/>
+      <point x="131.2" y="281.6" type="line"/>
       <point x="170.4" y="320.8"/>
       <point x="197.6" y="341.6"/>
-      <point type="curve" x="237.6" y="341.6"/>
+      <point x="237.6" y="341.6" type="curve"/>
       <point x="288.8" y="341.6"/>
       <point x="311.2" y="310.4"/>
-      <point type="curve" x="311.2" y="237.6"/>
-      <point type="line" x="311.2" y="0"/>
-      <point type="line" x="376.8" y="0"/>
-      <point type="line" x="376.8" y="246.4"/>
+      <point x="311.2" y="237.6" type="curve"/>
+      <point x="311.2" y="0" type="line"/>
+      <point x="376.8" y="0" type="line"/>
+      <point x="376.8" y="246.4" type="line"/>
       <point x="376.8" y="345.6"/>
       <point x="340" y="398.4"/>
-      <point type="curve" x="258.4" y="398.4"/>
+      <point x="258.4" y="398.4" type="curve"/>
       <point x="204.8" y="398.4" name="hintSet0009"/>
       <point x="164.8" y="369.6"/>
-      <point type="curve" x="128" y="332.8"/>
-      <point type="line" x="125.6" y="332.8"/>
-      <point type="line" x="120" y="388.8"/>
-      <point type="line" x="65.6" y="388.8" name="hintSet0012"/>
+      <point x="128" y="332.8" type="curve"/>
+      <point x="125.6" y="332.8" type="line"/>
+      <point x="120" y="388.8" type="line"/>
+      <point x="65.6" y="388.8" type="line" name="hintSet0012"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/nine.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/nine.glif
@@ -4,42 +4,42 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point type="curve" x="164" y="-9.6" name="hintSet0000"/>
+      <point x="164" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="265.6" y="-9.6"/>
       <point x="358.4" y="69.6"/>
-      <point type="curve" x="358.4" y="274.4"/>
+      <point x="358.4" y="274.4" type="curve"/>
       <point x="358.4" y="438.4"/>
       <point x="283.2" y="520"/>
-      <point type="curve" x="182.4" y="520"/>
+      <point x="182.4" y="520" type="curve"/>
       <point x="100.8" y="520"/>
       <point x="32" y="453.6"/>
-      <point type="curve" x="32" y="356"/>
+      <point x="32" y="356" type="curve"/>
       <point x="32" y="251.2"/>
       <point x="88.8" y="198.4"/>
-      <point type="curve" x="176.8" y="198.4"/>
+      <point x="176.8" y="198.4" type="curve"/>
       <point x="220.8" y="198.4"/>
       <point x="268" y="224.8"/>
-      <point type="curve" x="300" y="268"/>
-      <point type="line" x="297.6" y="320"/>
+      <point x="300" y="268" type="curve"/>
+      <point x="297.6" y="320" type="line"/>
       <point x="262.4" y="268"/>
       <point x="221.6" y="248"/>
-      <point type="curve" x="188" y="248"/>
+      <point x="188" y="248" type="curve"/>
       <point x="124.8" y="248"/>
       <point x="93.6" y="289.6"/>
-      <point type="curve" x="93.6" y="356"/>
+      <point x="93.6" y="356" type="curve"/>
       <point x="93.6" y="423.2"/>
       <point x="132.8" y="468"/>
-      <point type="curve" x="182.4" y="468"/>
+      <point x="182.4" y="468" type="curve"/>
       <point x="256" y="468"/>
       <point x="296.8" y="400"/>
-      <point type="curve" x="296.8" y="274.4"/>
+      <point x="296.8" y="274.4" type="curve"/>
       <point x="296.8" y="103.2"/>
       <point x="235.2" y="44.8"/>
-      <point type="curve" x="161.6" y="44.8"/>
+      <point x="161.6" y="44.8" type="curve"/>
       <point x="129.6" y="44.8"/>
       <point x="98.4" y="60.8"/>
-      <point type="curve" x="77.6" y="85.6"/>
-      <point type="line" x="40.8" y="44"/>
+      <point x="77.6" y="85.6" type="curve"/>
+      <point x="40.8" y="44" type="line"/>
       <point x="68.8" y="13.6"/>
       <point x="109.6" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/numbersign.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/numbersign.glif
@@ -4,40 +4,40 @@
   <unicode hex="0023"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="115.2" y="0"/>
-      <point type="line" x="135.2" y="163.2"/>
-      <point type="line" x="240.8" y="163.2"/>
-      <point type="line" x="221.6" y="0"/>
-      <point type="line" x="264" y="0"/>
-      <point type="line" x="284" y="163.2"/>
-      <point type="line" x="357.6" y="163.2"/>
-      <point type="line" x="357.6" y="208.8"/>
-      <point type="line" x="289.6" y="208.8"/>
-      <point type="line" x="304" y="327.2"/>
-      <point type="line" x="373.6" y="327.2"/>
-      <point type="line" x="373.6" y="373.6"/>
-      <point type="line" x="308.8" y="373.6"/>
-      <point type="line" x="328" y="520" name="hintSet0014"/>
-      <point type="line" x="285.6" y="520"/>
-      <point type="line" x="266.4" y="373.6" name="hintSet0016"/>
-      <point type="line" x="160" y="373.6"/>
-      <point type="line" x="178.4" y="520" name="hintSet0018"/>
-      <point type="line" x="136" y="520"/>
-      <point type="line" x="117.6" y="373.6" name="hintSet0020"/>
-      <point type="line" x="44" y="373.6"/>
-      <point type="line" x="44" y="327.2"/>
-      <point type="line" x="112" y="327.2"/>
-      <point type="line" x="97.6" y="208.8"/>
-      <point type="line" x="28" y="208.8"/>
-      <point type="line" x="28" y="163.2"/>
-      <point type="line" x="92" y="163.2"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="115.2" y="0" type="line"/>
+      <point x="135.2" y="163.2" type="line"/>
+      <point x="240.8" y="163.2" type="line"/>
+      <point x="221.6" y="0" type="line"/>
+      <point x="264" y="0" type="line"/>
+      <point x="284" y="163.2" type="line"/>
+      <point x="357.6" y="163.2" type="line"/>
+      <point x="357.6" y="208.8" type="line"/>
+      <point x="289.6" y="208.8" type="line"/>
+      <point x="304" y="327.2" type="line"/>
+      <point x="373.6" y="327.2" type="line"/>
+      <point x="373.6" y="373.6" type="line"/>
+      <point x="308.8" y="373.6" type="line"/>
+      <point x="328" y="520" type="line" name="hintSet0014"/>
+      <point x="285.6" y="520" type="line"/>
+      <point x="266.4" y="373.6" type="line" name="hintSet0016"/>
+      <point x="160" y="373.6" type="line"/>
+      <point x="178.4" y="520" type="line" name="hintSet0018"/>
+      <point x="136" y="520" type="line"/>
+      <point x="117.6" y="373.6" type="line" name="hintSet0020"/>
+      <point x="44" y="373.6" type="line"/>
+      <point x="44" y="327.2" type="line"/>
+      <point x="112" y="327.2" type="line"/>
+      <point x="97.6" y="208.8" type="line"/>
+      <point x="28" y="208.8" type="line"/>
+      <point x="28" y="163.2" type="line"/>
+      <point x="92" y="163.2" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="140.8" y="208.8"/>
-      <point type="line" x="155.2" y="327.2"/>
-      <point type="line" x="260.8" y="327.2"/>
-      <point type="line" x="246.4" y="208.8"/>
+      <point x="140.8" y="208.8" type="line"/>
+      <point x="155.2" y="327.2" type="line"/>
+      <point x="260.8" y="327.2" type="line"/>
+      <point x="246.4" y="208.8" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/o.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/o.glif
@@ -8,30 +8,30 @@
   <anchor x="216.8" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="216.8" y="-9.6" name="hintSet0000"/>
+      <point x="216.8" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="312" y="-9.6"/>
       <point x="396.8" y="64.8"/>
-      <point type="curve" x="396.8" y="193.6"/>
+      <point x="396.8" y="193.6" type="curve"/>
       <point x="396.8" y="324"/>
       <point x="312" y="398.4"/>
-      <point type="curve" x="216.8" y="398.4"/>
+      <point x="216.8" y="398.4" type="curve"/>
       <point x="121.6" y="398.4"/>
       <point x="36.8" y="324"/>
-      <point type="curve" x="36.8" y="193.6"/>
+      <point x="36.8" y="193.6" type="curve"/>
       <point x="36.8" y="64.8"/>
       <point x="121.6" y="-9.6"/>
     </contour>
     <contour>
-      <point type="curve" x="216.8" y="44.8"/>
+      <point x="216.8" y="44.8" type="curve"/>
       <point x="150.4" y="44.8"/>
       <point x="104.8" y="104.8"/>
-      <point type="curve" x="104.8" y="193.6"/>
+      <point x="104.8" y="193.6" type="curve"/>
       <point x="104.8" y="283.2"/>
       <point x="150.4" y="344"/>
-      <point type="curve" x="216.8" y="344"/>
+      <point x="216.8" y="344" type="curve"/>
       <point x="284" y="344"/>
       <point x="328.8" y="283.2"/>
-      <point type="curve" x="328.8" y="193.6"/>
+      <point x="328.8" y="193.6" type="curve"/>
       <point x="328.8" y="104.8"/>
       <point x="284" y="44.8"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/one.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/one.glif
@@ -4,19 +4,19 @@
   <unicode hex="0031"/>
   <outline>
     <contour>
-      <point type="line" x="63.2" y="0" name="hintSet0000"/>
-      <point type="line" x="351.2" y="0" name="hintSet0001"/>
-      <point type="line" x="351.2" y="54.4"/>
-      <point type="line" x="245.6" y="54.4" name="hintSet0003"/>
-      <point type="line" x="245.6" y="510.4"/>
-      <point type="line" x="195.2" y="510.4"/>
+      <point x="63.2" y="0" type="line" name="hintSet0000"/>
+      <point x="351.2" y="0" type="line" name="hintSet0001"/>
+      <point x="351.2" y="54.4" type="line"/>
+      <point x="245.6" y="54.4" type="line" name="hintSet0003"/>
+      <point x="245.6" y="510.4" type="line"/>
+      <point x="195.2" y="510.4" type="line"/>
       <point x="167.2" y="493.6"/>
       <point x="133.6" y="480.8"/>
-      <point type="curve" x="87.2" y="472.8"/>
-      <point type="line" x="87.2" y="430.4"/>
-      <point type="line" x="180" y="430.4"/>
-      <point type="line" x="180" y="54.4"/>
-      <point type="line" x="63.2" y="54.4" name="hintSet0010"/>
+      <point x="87.2" y="472.8" type="curve"/>
+      <point x="87.2" y="430.4" type="line"/>
+      <point x="180" y="430.4" type="line"/>
+      <point x="180" y="54.4" type="line"/>
+      <point x="63.2" y="54.4" type="line" name="hintSet0010"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/p.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/p.glif
@@ -6,38 +6,38 @@
   <anchor x="93.60000000000001" y="-174.4" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="65.6" y="-164" name="hintSet0000"/>
-      <point type="line" x="131.2" y="-164"/>
-      <point type="line" x="131.2" y="-32.8"/>
-      <point type="line" x="129.6" y="35.2"/>
+      <point x="65.6" y="-164" type="line" name="hintSet0000"/>
+      <point x="131.2" y="-164" type="line"/>
+      <point x="131.2" y="-32.8" type="line"/>
+      <point x="129.6" y="35.2" type="line"/>
       <point x="165.6" y="7.2"/>
       <point x="201.6" y="-9.6"/>
-      <point type="curve" x="237.6" y="-9.6"/>
+      <point x="237.6" y="-9.6" type="curve"/>
       <point x="326.4" y="-9.6"/>
       <point x="405.6" y="68"/>
-      <point type="curve" x="405.6" y="200"/>
+      <point x="405.6" y="200" type="curve"/>
       <point x="405.6" y="320.8"/>
       <point x="352" y="398.4"/>
-      <point type="curve" x="252" y="398.4"/>
+      <point x="252" y="398.4" type="curve"/>
       <point x="206.4" y="398.4" name="hintSet0007"/>
       <point x="163.2" y="373.6"/>
-      <point type="curve" x="128" y="344"/>
-      <point type="line" x="125.6" y="344"/>
-      <point type="line" x="120" y="388.8"/>
-      <point type="line" x="65.6" y="388.8" name="hintSet0010"/>
+      <point x="128" y="344" type="curve"/>
+      <point x="125.6" y="344" type="line"/>
+      <point x="120" y="388.8" type="line"/>
+      <point x="65.6" y="388.8" type="line" name="hintSet0010"/>
     </contour>
     <contour>
-      <point type="curve" x="226.4" y="45.6"/>
+      <point x="226.4" y="45.6" type="curve"/>
       <point x="200.8" y="45.6"/>
       <point x="166.4" y="56.8"/>
-      <point type="curve" x="131.2" y="86.4"/>
-      <point type="line" x="131.2" y="290.4"/>
+      <point x="131.2" y="86.4" type="curve"/>
+      <point x="131.2" y="290.4" type="line"/>
       <point x="169.6" y="324.8"/>
       <point x="202.4" y="343.2"/>
-      <point type="curve" x="235.2" y="343.2"/>
+      <point x="235.2" y="343.2" type="curve"/>
       <point x="308.8" y="343.2"/>
       <point x="337.6" y="285.6"/>
-      <point type="curve" x="337.6" y="200"/>
+      <point x="337.6" y="200" type="curve"/>
       <point x="337.6" y="104"/>
       <point x="290.4" y="45.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/parenleft.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/parenleft.glif
@@ -4,18 +4,18 @@
   <unicode hex="0028"/>
   <outline>
     <contour>
-      <point type="curve" x="171.2" y="-140.8" name="hintSet0000"/>
-      <point type="line" x="212" y="-121.6"/>
+      <point x="171.2" y="-140.8" type="curve" name="hintSet0000"/>
+      <point x="212" y="-121.6" type="line"/>
       <point x="150.4" y="-20"/>
       <point x="120" y="100.8"/>
-      <point type="curve" x="120" y="222.4"/>
+      <point x="120" y="222.4" type="curve"/>
       <point x="120" y="344"/>
       <point x="150.4" y="464.8"/>
-      <point type="curve" x="212" y="566.4"/>
-      <point type="line" x="171.2" y="585.6"/>
+      <point x="212" y="566.4" type="curve"/>
+      <point x="171.2" y="585.6" type="line"/>
       <point x="104.8" y="478.4"/>
       <point x="65.6" y="363.2"/>
-      <point type="curve" x="65.6" y="222.4"/>
+      <point x="65.6" y="222.4" type="curve"/>
       <point x="65.6" y="81.6"/>
       <point x="104.8" y="-33.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/parenright.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/parenright.glif
@@ -4,20 +4,20 @@
   <unicode hex="0029"/>
   <outline>
     <contour>
-      <point type="line" x="71.2" y="-140.8" name="hintSet0000"/>
+      <point x="71.2" y="-140.8" type="line" name="hintSet0000"/>
       <point x="137.6" y="-33.6"/>
       <point x="176.8" y="81.6"/>
-      <point type="curve" x="176.8" y="222.4"/>
+      <point x="176.8" y="222.4" type="curve"/>
       <point x="176.8" y="363.2"/>
       <point x="137.6" y="478.4"/>
-      <point type="curve" x="71.2" y="585.6"/>
-      <point type="line" x="30.4" y="566.4"/>
+      <point x="71.2" y="585.6" type="curve"/>
+      <point x="30.4" y="566.4" type="line"/>
       <point x="92" y="464.8"/>
       <point x="122.4" y="344"/>
-      <point type="curve" x="122.4" y="222.4"/>
+      <point x="122.4" y="222.4" type="curve"/>
       <point x="122.4" y="100.8"/>
       <point x="92" y="-20"/>
-      <point type="curve" x="30.4" y="-121.6"/>
+      <point x="30.4" y="-121.6" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/period.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/period.glif
@@ -4,16 +4,16 @@
   <unicode hex="002E"/>
   <outline>
     <contour>
-      <point type="curve" x="100" y="-9.6" name="hintSet0000"/>
+      <point x="100" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="125.6" y="-9.6"/>
       <point x="147.2" y="11.2"/>
-      <point type="curve" x="147.2" y="40"/>
+      <point x="147.2" y="40" type="curve"/>
       <point x="147.2" y="70.4" name="hintSet0002"/>
       <point x="125.6" y="91.2"/>
-      <point type="curve" x="100" y="91.2"/>
+      <point x="100" y="91.2" type="curve"/>
       <point x="73.6" y="91.2"/>
       <point x="52" y="70.4"/>
-      <point type="curve" x="52" y="40"/>
+      <point x="52" y="40" type="curve"/>
       <point x="52" y="11.2" name="hintSet0004"/>
       <point x="73.6" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/plus.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/plus.glif
@@ -4,18 +4,18 @@
   <unicode hex="002B"/>
   <outline>
     <contour>
-      <point type="line" x="172.8" y="83.2" name="hintSet0000"/>
-      <point type="line" x="224.8" y="83.2"/>
-      <point type="line" x="224.8" y="239.2"/>
-      <point type="line" x="370.4" y="239.2"/>
-      <point type="line" x="370.4" y="288.8"/>
-      <point type="line" x="224.8" y="288.8"/>
-      <point type="line" x="224.8" y="444.8"/>
-      <point type="line" x="172.8" y="444.8"/>
-      <point type="line" x="172.8" y="288.8"/>
-      <point type="line" x="27.2" y="288.8"/>
-      <point type="line" x="27.2" y="239.2"/>
-      <point type="line" x="172.8" y="239.2"/>
+      <point x="172.8" y="83.2" type="line" name="hintSet0000"/>
+      <point x="224.8" y="83.2" type="line"/>
+      <point x="224.8" y="239.2" type="line"/>
+      <point x="370.4" y="239.2" type="line"/>
+      <point x="370.4" y="288.8" type="line"/>
+      <point x="224.8" y="288.8" type="line"/>
+      <point x="224.8" y="444.8" type="line"/>
+      <point x="172.8" y="444.8" type="line"/>
+      <point x="172.8" y="288.8" type="line"/>
+      <point x="27.2" y="288.8" type="line"/>
+      <point x="27.2" y="239.2" type="line"/>
+      <point x="172.8" y="239.2" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/q.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/q.glif
@@ -6,38 +6,38 @@
   <anchor x="340.8" y="-174.4" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="312" y="-164" name="hintSet0000"/>
-      <point type="line" x="378.4" y="-164"/>
-      <point type="line" x="378.4" y="388.8"/>
-      <point type="line" x="325.6" y="388.8" name="hintSet0003"/>
-      <point type="line" x="319.2" y="352"/>
-      <point type="line" x="317.6" y="352"/>
+      <point x="312" y="-164" type="line" name="hintSet0000"/>
+      <point x="378.4" y="-164" type="line"/>
+      <point x="378.4" y="388.8" type="line"/>
+      <point x="325.6" y="388.8" type="line" name="hintSet0003"/>
+      <point x="319.2" y="352" type="line"/>
+      <point x="317.6" y="352" type="line"/>
       <point x="282.4" y="382.4"/>
       <point x="251.2" y="398.4"/>
-      <point type="curve" x="206.4" y="398.4"/>
+      <point x="206.4" y="398.4" type="curve"/>
       <point x="117.6" y="398.4"/>
       <point x="37.6" y="320"/>
-      <point type="curve" x="37.6" y="193.6"/>
+      <point x="37.6" y="193.6" type="curve"/>
       <point x="37.6" y="64"/>
       <point x="100.8" y="-9.6"/>
-      <point type="curve" x="198.4" y="-9.6"/>
+      <point x="198.4" y="-9.6" type="curve"/>
       <point x="243.2" y="-9.6" name="hintSet0009"/>
       <point x="284" y="14.4"/>
-      <point type="curve" x="315.2" y="44.8"/>
-      <point type="line" x="312" y="-25.6"/>
+      <point x="315.2" y="44.8" type="curve"/>
+      <point x="312" y="-25.6" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="212.8" y="45.6"/>
+      <point x="212.8" y="45.6" type="curve"/>
       <point x="144.8" y="45.6"/>
       <point x="105.6" y="101.6"/>
-      <point type="curve" x="105.6" y="194.4"/>
+      <point x="105.6" y="194.4" type="curve"/>
       <point x="105.6" y="283.2"/>
       <point x="155.2" y="343.2"/>
-      <point type="curve" x="217.6" y="343.2"/>
+      <point x="217.6" y="343.2" type="curve"/>
       <point x="249.6" y="343.2"/>
       <point x="279.2" y="332"/>
-      <point type="curve" x="312" y="302.4"/>
-      <point type="line" x="312" y="99.2"/>
+      <point x="312" y="302.4" type="curve"/>
+      <point x="312" y="99.2" type="line"/>
       <point x="280" y="63.2"/>
       <point x="248.8" y="45.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/question.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/question.glif
@@ -4,38 +4,38 @@
   <unicode hex="003F"/>
   <outline>
     <contour>
-      <point type="curve" x="128" y="158.4" name="hintSet0000"/>
-      <point type="line" x="185.6" y="158.4"/>
+      <point x="128" y="158.4" type="curve" name="hintSet0000"/>
+      <point x="185.6" y="158.4" type="line"/>
       <point x="172.8" y="270.4"/>
       <point x="301.6" y="312.8"/>
-      <point type="curve" x="301.6" y="417.6"/>
+      <point x="301.6" y="417.6" type="curve"/>
       <point x="301.6" y="496.8"/>
       <point x="248.8" y="545.6"/>
-      <point type="curve" x="168" y="545.6"/>
+      <point x="168" y="545.6" type="curve"/>
       <point x="109.6" y="545.6"/>
       <point x="64" y="517.6"/>
-      <point type="curve" x="30.4" y="479.2"/>
-      <point type="line" x="68" y="444.8"/>
+      <point x="30.4" y="479.2" type="curve"/>
+      <point x="68" y="444.8" type="line"/>
       <point x="92.8" y="473.6"/>
       <point x="124.8" y="491.2"/>
-      <point type="curve" x="160" y="491.2"/>
+      <point x="160" y="491.2" type="curve"/>
       <point x="211.2" y="491.2"/>
       <point x="237.6" y="456"/>
-      <point type="curve" x="237.6" y="413.6"/>
+      <point x="237.6" y="413.6" type="curve"/>
       <point x="237.6" y="328.8"/>
       <point x="110.4" y="283.2"/>
     </contour>
     <contour>
-      <point type="curve" x="158.4" y="-9.6"/>
+      <point x="158.4" y="-9.6" type="curve"/>
       <point x="184.8" y="-9.6"/>
       <point x="206.4" y="11.2"/>
-      <point type="curve" x="206.4" y="40"/>
+      <point x="206.4" y="40" type="curve"/>
       <point x="206.4" y="70.4" name="hintSet0011"/>
       <point x="184.8" y="91.2"/>
-      <point type="curve" x="158.4" y="91.2"/>
+      <point x="158.4" y="91.2" type="curve"/>
       <point x="132" y="91.2"/>
       <point x="111.2" y="70.4"/>
-      <point type="curve" x="111.2" y="40"/>
+      <point x="111.2" y="40" type="curve"/>
       <point x="111.2" y="11.2" name="hintSet0013"/>
       <point x="132" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/quotedbl.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/quotedbl.glif
@@ -4,20 +4,20 @@
   <unicode hex="0022"/>
   <outline>
     <contour>
-      <point type="line" x="63.36" y="275.84" name="hintSet0000"/>
-      <point type="line" x="95.36" y="275.84"/>
-      <point type="line" x="105.6" y="382.72"/>
-      <point type="line" x="107.52" y="441.6"/>
-      <point type="line" x="51.2" y="441.6"/>
-      <point type="line" x="53.12" y="382.72"/>
+      <point x="63.36" y="275.84" type="line" name="hintSet0000"/>
+      <point x="95.36" y="275.84" type="line"/>
+      <point x="105.6" y="382.72" type="line"/>
+      <point x="107.52" y="441.6" type="line"/>
+      <point x="51.2" y="441.6" type="line"/>
+      <point x="53.12" y="382.72" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="204.96" y="275.84"/>
-      <point type="line" x="236.96" y="275.84"/>
-      <point type="line" x="247.2" y="382.72"/>
-      <point type="line" x="249.12" y="441.6"/>
-      <point type="line" x="192.8" y="441.6"/>
-      <point type="line" x="194.72" y="382.72"/>
+      <point x="204.96" y="275.84" type="line"/>
+      <point x="236.96" y="275.84" type="line"/>
+      <point x="247.2" y="382.72" type="line"/>
+      <point x="249.12" y="441.6" type="line"/>
+      <point x="192.8" y="441.6" type="line"/>
+      <point x="194.72" y="382.72" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/quotesingle.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/quotesingle.glif
@@ -4,12 +4,12 @@
   <unicode hex="0027"/>
   <outline>
     <contour>
-      <point type="line" x="79.2" y="344.8" name="hintSet0000"/>
-      <point type="line" x="119.2" y="344.8"/>
-      <point type="line" x="132" y="478.4"/>
-      <point type="line" x="134.4" y="552"/>
-      <point type="line" x="64" y="552"/>
-      <point type="line" x="66.4" y="478.4"/>
+      <point x="79.2" y="344.8" type="line" name="hintSet0000"/>
+      <point x="119.2" y="344.8" type="line"/>
+      <point x="132" y="478.4" type="line"/>
+      <point x="134.4" y="552" type="line"/>
+      <point x="64" y="552" type="line"/>
+      <point x="66.4" y="478.4" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/r.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/r.glif
@@ -6,25 +6,25 @@
   <anchor x="98.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="65.6" y="0" name="hintSet0000"/>
-      <point type="line" x="131.2" y="0"/>
-      <point type="line" x="131.2" y="249.6"/>
+      <point x="65.6" y="0" type="line" name="hintSet0000"/>
+      <point x="131.2" y="0" type="line"/>
+      <point x="131.2" y="249.6" type="line"/>
       <point x="157.6" y="315.2"/>
       <point x="196.8" y="339.2"/>
-      <point type="curve" x="229.6" y="339.2"/>
+      <point x="229.6" y="339.2" type="curve"/>
       <point x="245.6" y="339.2"/>
       <point x="254.4" y="336.8"/>
-      <point type="curve" x="267.2" y="332.8"/>
-      <point type="line" x="280" y="390.4"/>
+      <point x="267.2" y="332.8" type="curve"/>
+      <point x="280" y="390.4" type="line"/>
       <point x="267.2" y="396"/>
       <point x="255.2" y="398.4"/>
-      <point type="curve" x="238.4" y="398.4"/>
+      <point x="238.4" y="398.4" type="curve"/>
       <point x="194.4" y="398.4" name="hintSet0007"/>
       <point x="154.4" y="367.2"/>
-      <point type="curve" x="128" y="318.4"/>
-      <point type="line" x="125.6" y="318.4"/>
-      <point type="line" x="120" y="388.8"/>
-      <point type="line" x="65.6" y="388.8" name="hintSet0010"/>
+      <point x="128" y="318.4" type="curve"/>
+      <point x="125.6" y="318.4" type="line"/>
+      <point x="120" y="388.8" type="line"/>
+      <point x="65.6" y="388.8" type="line" name="hintSet0010"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/s.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/s.glif
@@ -7,42 +7,42 @@
   <anchor x="178.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="167.2" y="-9.6" name="hintSet0000"/>
+      <point x="167.2" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="259.2" y="-9.6"/>
       <point x="309.6" y="43.2"/>
-      <point type="curve" x="309.6" y="106.4"/>
+      <point x="309.6" y="106.4" type="curve"/>
       <point x="309.6" y="180"/>
       <point x="247.2" y="203.2"/>
-      <point type="curve" x="191.2" y="224"/>
+      <point x="191.2" y="224" type="curve"/>
       <point x="147.2" y="240.8"/>
       <point x="104.8" y="254.4"/>
-      <point type="curve" x="104.8" y="291.2"/>
+      <point x="104.8" y="291.2" type="curve"/>
       <point x="104.8" y="320.8"/>
       <point x="127.2" y="347.2"/>
-      <point type="curve" x="176" y="347.2"/>
+      <point x="176" y="347.2" type="curve"/>
       <point x="210.4" y="347.2"/>
       <point x="238.4" y="332.8"/>
-      <point type="curve" x="264.8" y="312.8"/>
-      <point type="line" x="296" y="354.4"/>
+      <point x="264.8" y="312.8" type="curve"/>
+      <point x="296" y="354.4" type="line"/>
       <point x="266.4" y="378.4"/>
       <point x="224" y="398.4"/>
-      <point type="curve" x="175.2" y="398.4"/>
+      <point x="175.2" y="398.4" type="curve"/>
       <point x="91.2" y="398.4"/>
       <point x="41.6" y="350.4"/>
-      <point type="curve" x="41.6" y="288"/>
+      <point x="41.6" y="288" type="curve"/>
       <point x="41.6" y="222.4"/>
       <point x="102.4" y="196"/>
-      <point type="curve" x="157.6" y="176"/>
+      <point x="157.6" y="176" type="curve"/>
       <point x="200" y="160"/>
       <point x="246.4" y="142.4"/>
-      <point type="curve" x="246.4" y="102.4"/>
+      <point x="246.4" y="102.4" type="curve"/>
       <point x="246.4" y="68.8"/>
       <point x="220.8" y="41.6"/>
-      <point type="curve" x="169.6" y="41.6"/>
+      <point x="169.6" y="41.6" type="curve"/>
       <point x="123.2" y="41.6"/>
       <point x="88.8" y="60.8"/>
-      <point type="curve" x="55.2" y="88"/>
-      <point type="line" x="22.4" y="44"/>
+      <point x="55.2" y="88" type="curve"/>
+      <point x="22.4" y="44" type="line"/>
       <point x="59.2" y="13.6"/>
       <point x="112" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/semicolon.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/semicolon.glif
@@ -4,41 +4,41 @@
   <unicode hex="003B"/>
   <outline>
     <contour>
-      <point type="curve" x="80" y="281.12" name="hintSet0000"/>
+      <point x="80" y="281.12" type="curve" name="hintSet0000"/>
       <point x="100.48" y="281.12"/>
       <point x="117.76" y="297.76"/>
-      <point type="curve" x="117.76" y="320.8"/>
+      <point x="117.76" y="320.8" type="curve"/>
       <point x="117.76" y="345.12"/>
       <point x="100.48" y="361.76"/>
-      <point type="curve" x="80" y="361.76"/>
+      <point x="80" y="361.76" type="curve"/>
       <point x="58.88" y="361.76"/>
       <point x="41.6" y="345.12"/>
-      <point type="curve" x="41.6" y="320.8"/>
+      <point x="41.6" y="320.8" type="curve"/>
       <point x="41.6" y="297.76"/>
       <point x="58.88" y="281.12"/>
     </contour>
     <contour>
-      <point type="line" x="42.88" y="-108.8" name="hintSet0005"/>
+      <point x="42.88" y="-108.8" type="line" name="hintSet0005"/>
       <point x="94.72" y="-87.04"/>
       <point x="126.72" y="-44.16"/>
-      <point type="curve" x="126.72" y="10.88"/>
+      <point x="126.72" y="10.88" type="curve"/>
       <point x="126.72" y="49.28"/>
       <point x="110.08" y="72.96"/>
-      <point type="curve" x="82.56" y="72.96"/>
+      <point x="82.56" y="72.96" type="curve"/>
       <point x="61.44" y="72.96" name="hintSet0008"/>
       <point x="43.52" y="58.88"/>
-      <point type="curve" x="43.52" y="35.84"/>
+      <point x="43.52" y="35.84" type="curve"/>
       <point x="43.52" y="12.16" name="hintSet0009"/>
       <point x="60.8" y="-0.64"/>
-      <point type="curve" x="81.28" y="-0.64"/>
+      <point x="81.28" y="-0.64" type="curve"/>
       <point x="91.52" y="-0.64" name="hintSet0010"/>
       <point x="101.12" y="1.92"/>
-      <point type="curve" x="108.16" y="10.24"/>
-      <point type="line" x="81.92" y="48.64"/>
-      <point type="line" x="87.68" y="1.28"/>
+      <point x="108.16" y="10.24" type="curve"/>
+      <point x="81.92" y="48.64" type="line"/>
+      <point x="87.68" y="1.28" type="line"/>
       <point x="88.32" y="-33.92"/>
       <point x="66.56" y="-62.08"/>
-      <point type="curve" x="30.08" y="-78.08"/>
+      <point x="30.08" y="-78.08" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/seven.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/seven.glif
@@ -4,15 +4,15 @@
   <unicode hex="0037"/>
   <outline>
     <contour>
-      <point type="curve" x="141.6" y="0" name="hintSet0000"/>
-      <point type="line" x="209.6" y="0"/>
+      <point x="141.6" y="0" type="curve" name="hintSet0000"/>
+      <point x="209.6" y="0" type="line"/>
       <point x="218.4" y="199.2"/>
       <point x="243.2" y="315.2"/>
-      <point type="curve" x="364" y="469.6"/>
-      <point type="line" x="364" y="510.4"/>
-      <point type="line" x="35.2" y="510.4"/>
-      <point type="line" x="35.2" y="453.6"/>
-      <point type="line" x="289.6" y="453.6"/>
+      <point x="364" y="469.6" type="curve"/>
+      <point x="364" y="510.4" type="line"/>
+      <point x="35.2" y="510.4" type="line"/>
+      <point x="35.2" y="453.6" type="line"/>
+      <point x="289.6" y="453.6" type="line"/>
       <point x="188.8" y="313.6"/>
       <point x="150.4" y="192"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/six.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/six.glif
@@ -4,42 +4,42 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point type="curve" x="214.4" y="-9.6" name="hintSet0000"/>
+      <point x="214.4" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="296.8" y="-9.6"/>
       <point x="365.6" y="56.8"/>
-      <point type="curve" x="365.6" y="154.4"/>
+      <point x="365.6" y="154.4" type="curve"/>
       <point x="365.6" y="259.2"/>
       <point x="308" y="312"/>
-      <point type="curve" x="220" y="312"/>
+      <point x="220" y="312" type="curve"/>
       <point x="176.8" y="312"/>
       <point x="128.8" y="284.8"/>
-      <point type="curve" x="96.8" y="242.4"/>
-      <point type="line" x="99.2" y="190.4"/>
+      <point x="96.8" y="242.4" type="curve"/>
+      <point x="99.2" y="190.4" type="line"/>
       <point x="134.4" y="242.4"/>
       <point x="176" y="262.4"/>
-      <point type="curve" x="208.8" y="262.4"/>
+      <point x="208.8" y="262.4" type="curve"/>
       <point x="272" y="262.4"/>
       <point x="303.2" y="220.8"/>
-      <point type="curve" x="303.2" y="154.4"/>
+      <point x="303.2" y="154.4" type="curve"/>
       <point x="303.2" y="87.2"/>
       <point x="264.8" y="42.4"/>
-      <point type="curve" x="214.4" y="42.4"/>
+      <point x="214.4" y="42.4" type="curve"/>
       <point x="141.6" y="42.4"/>
       <point x="100.8" y="110.4"/>
-      <point type="curve" x="100.8" y="236"/>
+      <point x="100.8" y="236" type="curve"/>
       <point x="100.8" y="407.2"/>
       <point x="162.4" y="464.8"/>
-      <point type="curve" x="235.2" y="464.8"/>
+      <point x="235.2" y="464.8" type="curve"/>
       <point x="267.2" y="464.8"/>
       <point x="298.4" y="449.6"/>
-      <point type="curve" x="319.2" y="424.8"/>
-      <point type="line" x="356" y="465.6"/>
+      <point x="319.2" y="424.8" type="curve"/>
+      <point x="356" y="465.6" type="line"/>
       <point x="327.2" y="496.8"/>
       <point x="288" y="520"/>
-      <point type="curve" x="232.8" y="520"/>
+      <point x="232.8" y="520" type="curve"/>
       <point x="131.2" y="520"/>
       <point x="38.4" y="440.8"/>
-      <point type="curve" x="38.4" y="236"/>
+      <point x="38.4" y="236" type="curve"/>
       <point x="38.4" y="72"/>
       <point x="114.4" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/slash.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/slash.glif
@@ -4,10 +4,10 @@
   <unicode hex="002F"/>
   <outline>
     <contour>
-      <point type="line" x="8" y="-128" name="hintSet0000"/>
-      <point type="line" x="56" y="-128"/>
-      <point type="line" x="269.6" y="568"/>
-      <point type="line" x="221.6" y="568"/>
+      <point x="8" y="-128" type="line" name="hintSet0000"/>
+      <point x="56" y="-128" type="line"/>
+      <point x="269.6" y="568" type="line"/>
+      <point x="221.6" y="568" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/t.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/t.glif
@@ -7,28 +7,28 @@
   <anchor x="169.60000000000002" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="188" y="-9.6" name="hintSet0000"/>
+      <point x="188" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="212" y="-9.6"/>
       <point x="238.4" y="-2.4"/>
-      <point type="curve" x="260" y="4.8"/>
-      <point type="line" x="247.2" y="54.4"/>
+      <point x="260" y="4.8" type="curve"/>
+      <point x="247.2" y="54.4" type="line"/>
       <point x="234.4" y="49.6"/>
       <point x="216.8" y="44"/>
-      <point type="curve" x="203.2" y="44"/>
+      <point x="203.2" y="44" type="curve"/>
       <point x="158.4" y="44"/>
       <point x="143.2" y="71.2"/>
-      <point type="curve" x="143.2" y="119.2"/>
-      <point type="line" x="143.2" y="335.2"/>
-      <point type="line" x="248" y="335.2"/>
-      <point type="line" x="248" y="388.8" name="hintSet0007"/>
-      <point type="line" x="143.2" y="388.8"/>
-      <point type="line" x="143.2" y="497.6" name="hintSet0009"/>
-      <point type="line" x="88" y="497.6" name="hintSet0010"/>
-      <point type="line" x="80" y="388.8" name="hintSet0011"/>
-      <point type="line" x="19.2" y="384.8" name="hintSet0012"/>
-      <point type="line" x="19.2" y="335.2" name="hintSet0013"/>
-      <point type="line" x="76.8" y="335.2"/>
-      <point type="line" x="76.8" y="120"/>
+      <point x="143.2" y="119.2" type="curve"/>
+      <point x="143.2" y="335.2" type="line"/>
+      <point x="248" y="335.2" type="line"/>
+      <point x="248" y="388.8" type="line" name="hintSet0007"/>
+      <point x="143.2" y="388.8" type="line"/>
+      <point x="143.2" y="497.6" type="line" name="hintSet0009"/>
+      <point x="88" y="497.6" type="line" name="hintSet0010"/>
+      <point x="80" y="388.8" type="line" name="hintSet0011"/>
+      <point x="19.2" y="384.8" type="line" name="hintSet0012"/>
+      <point x="19.2" y="335.2" type="line" name="hintSet0013"/>
+      <point x="76.8" y="335.2" type="line"/>
+      <point x="76.8" y="120" type="line"/>
       <point x="76.8" y="43.2"/>
       <point x="104.8" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/three.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/three.glif
@@ -4,44 +4,44 @@
   <unicode hex="0033"/>
   <outline>
     <contour>
-      <point type="curve" x="188.8" y="-9.6" name="hintSet0000"/>
+      <point x="188.8" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="282.4" y="-9.6"/>
       <point x="356.8" y="45.6"/>
-      <point type="curve" x="356.8" y="136"/>
+      <point x="356.8" y="136" type="curve"/>
       <point x="356.8" y="206.4"/>
       <point x="308" y="251.2"/>
-      <point type="curve" x="246.4" y="265.6"/>
-      <point type="line" x="246.4" y="268.8"/>
+      <point x="246.4" y="265.6" type="curve"/>
+      <point x="246.4" y="268.8" type="line"/>
       <point x="301.6" y="289.6" name="hintSet0004"/>
       <point x="339.2" y="328.8"/>
-      <point type="curve" x="339.2" y="390.4"/>
+      <point x="339.2" y="390.4" type="curve"/>
       <point x="339.2" y="472.8"/>
       <point x="275.2" y="520"/>
-      <point type="curve" x="186.4" y="520"/>
+      <point x="186.4" y="520" type="curve"/>
       <point x="126.4" y="520"/>
       <point x="79.2" y="492.8"/>
-      <point type="curve" x="40" y="456"/>
-      <point type="line" x="75.2" y="414.4"/>
+      <point x="40" y="456" type="curve"/>
+      <point x="75.2" y="414.4" type="line"/>
       <point x="105.6" y="444.8"/>
       <point x="141.6" y="466.4"/>
-      <point type="curve" x="184" y="466.4"/>
+      <point x="184" y="466.4" type="curve"/>
       <point x="238.4" y="466.4"/>
       <point x="272" y="435.2"/>
-      <point type="curve" x="272" y="385.6"/>
+      <point x="272" y="385.6" type="curve"/>
       <point x="272" y="332"/>
       <point x="236" y="290.4"/>
-      <point type="curve" x="127.2" y="290.4"/>
-      <point type="line" x="127.2" y="240" name="hintSet0011"/>
+      <point x="127.2" y="290.4" type="curve"/>
+      <point x="127.2" y="240" type="line" name="hintSet0011"/>
       <point x="248.8" y="240"/>
       <point x="290.4" y="199.2"/>
-      <point type="curve" x="290.4" y="138.4"/>
+      <point x="290.4" y="138.4" type="curve"/>
       <point x="290.4" y="81.6"/>
       <point x="246.4" y="44.8"/>
-      <point type="curve" x="184.8" y="44.8"/>
+      <point x="184.8" y="44.8" type="curve"/>
       <point x="124.8" y="44.8"/>
       <point x="84.8" y="73.6"/>
-      <point type="curve" x="54.4" y="105.6"/>
-      <point type="line" x="20.8" y="62.4"/>
+      <point x="54.4" y="105.6" type="curve"/>
+      <point x="20.8" y="62.4" type="line"/>
       <point x="55.2" y="24.8"/>
       <point x="107.2" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/two.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/two.glif
@@ -4,32 +4,32 @@
   <unicode hex="0032"/>
   <outline>
     <contour>
-      <point type="line" x="32" y="0" name="hintSet0000"/>
-      <point type="line" x="361.6" y="0"/>
-      <point type="line" x="361.6" y="56.8"/>
-      <point type="line" x="213.6" y="56.8"/>
+      <point x="32" y="0" type="line" name="hintSet0000"/>
+      <point x="361.6" y="0" type="line"/>
+      <point x="361.6" y="56.8" type="line"/>
+      <point x="213.6" y="56.8" type="line"/>
       <point x="187.2" y="56.8"/>
       <point x="156" y="54.4"/>
-      <point type="curve" x="128" y="52"/>
+      <point x="128" y="52" type="curve"/>
       <point x="248.8" y="178.4"/>
       <point x="336" y="273.6"/>
-      <point type="curve" x="336" y="369.6"/>
+      <point x="336" y="369.6" type="curve"/>
       <point x="336" y="460"/>
       <point x="277.6" y="520"/>
-      <point type="curve" x="183.2" y="520"/>
+      <point x="183.2" y="520" type="curve"/>
       <point x="116.8" y="520"/>
       <point x="71.2" y="488.8"/>
-      <point type="curve" x="28.8" y="442.4"/>
-      <point type="line" x="66.4" y="404.8"/>
+      <point x="28.8" y="442.4" type="curve"/>
+      <point x="66.4" y="404.8" type="line"/>
       <point x="96" y="439.2"/>
       <point x="132.8" y="466.4"/>
-      <point type="curve" x="175.2" y="466.4"/>
+      <point x="175.2" y="466.4" type="curve"/>
       <point x="240" y="466.4"/>
       <point x="272" y="424.8"/>
-      <point type="curve" x="272" y="366.4"/>
+      <point x="272" y="366.4" type="curve"/>
       <point x="272" y="284"/>
       <point x="185.6" y="192"/>
-      <point type="curve" x="32" y="39.2"/>
+      <point x="32" y="39.2" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/u.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/u.glif
@@ -8,25 +8,25 @@
   <anchor x="232.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="179.2" y="-9.6" name="hintSet0000"/>
+      <point x="179.2" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="232.8" y="-9.6" name="hintSet0001"/>
       <point x="271.2" y="18.4"/>
-      <point type="curve" x="307.2" y="60.8"/>
-      <point type="line" x="309.6" y="60.8"/>
-      <point type="line" x="315.2" y="0" name="hintSet0003"/>
-      <point type="line" x="369.6" y="0" name="hintSet0004"/>
-      <point type="line" x="369.6" y="388.8"/>
-      <point type="line" x="304" y="388.8"/>
-      <point type="line" x="304" y="112.8" name="hintSet0007"/>
+      <point x="307.2" y="60.8" type="curve"/>
+      <point x="309.6" y="60.8" type="line"/>
+      <point x="315.2" y="0" type="line" name="hintSet0003"/>
+      <point x="369.6" y="0" type="line" name="hintSet0004"/>
+      <point x="369.6" y="388.8" type="line"/>
+      <point x="304" y="388.8" type="line"/>
+      <point x="304" y="112.8" type="line" name="hintSet0007"/>
       <point x="267.2" y="67.2"/>
       <point x="239.2" y="47.2"/>
-      <point type="curve" x="199.2" y="47.2"/>
+      <point x="199.2" y="47.2" type="curve"/>
       <point x="148" y="47.2"/>
       <point x="126.4" y="78.4"/>
-      <point type="curve" x="126.4" y="151.2"/>
-      <point type="line" x="126.4" y="388.8"/>
-      <point type="line" x="60" y="388.8"/>
-      <point type="line" x="60" y="142.4"/>
+      <point x="126.4" y="151.2" type="curve"/>
+      <point x="126.4" y="388.8" type="line"/>
+      <point x="60" y="388.8" type="line"/>
+      <point x="60" y="142.4" type="line"/>
       <point x="60" y="43.2"/>
       <point x="96.8" y="-9.6"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/underscore.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/underscore.glif
@@ -4,10 +4,10 @@
   <unicode hex="005F"/>
   <outline>
     <contour>
-      <point type="line" x="9.6" y="-100.8" name="hintSet0000"/>
-      <point type="line" x="390.4" y="-100.8"/>
-      <point type="line" x="390.4" y="-56.8"/>
-      <point type="line" x="9.6" y="-56.8"/>
+      <point x="9.6" y="-100.8" type="line" name="hintSet0000"/>
+      <point x="390.4" y="-100.8" type="line"/>
+      <point x="390.4" y="-56.8" type="line"/>
+      <point x="9.6" y="-56.8" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/v.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/v.glif
@@ -6,20 +6,20 @@
   <anchor x="188.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="149.6" y="0" name="hintSet0000"/>
-      <point type="line" x="226.4" y="0"/>
-      <point type="line" x="364" y="388.8"/>
-      <point type="line" x="299.2" y="388.8"/>
-      <point type="line" x="225.6" y="168"/>
+      <point x="149.6" y="0" type="line" name="hintSet0000"/>
+      <point x="226.4" y="0" type="line"/>
+      <point x="364" y="388.8" type="line"/>
+      <point x="299.2" y="388.8" type="line"/>
+      <point x="225.6" y="168" type="line"/>
       <point x="214.4" y="129.6"/>
       <point x="201.6" y="90.4"/>
-      <point type="curve" x="190.4" y="53.6"/>
-      <point type="line" x="187.2" y="53.6"/>
+      <point x="190.4" y="53.6" type="curve"/>
+      <point x="187.2" y="53.6" type="line"/>
       <point x="175.2" y="90.4"/>
       <point x="162.4" y="129.6"/>
-      <point type="curve" x="151.2" y="168"/>
-      <point type="line" x="77.6" y="388.8"/>
-      <point type="line" x="9.6" y="388.8"/>
+      <point x="151.2" y="168" type="curve"/>
+      <point x="77.6" y="388.8" type="line"/>
+      <point x="9.6" y="388.8" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/w.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/w.glif
@@ -6,40 +6,40 @@
   <anchor x="288.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="127.2" y="0" name="hintSet0000"/>
-      <point type="line" x="204" y="0"/>
-      <point type="line" x="258.4" y="208"/>
+      <point x="127.2" y="0" type="line" name="hintSet0000"/>
+      <point x="204" y="0" type="line"/>
+      <point x="258.4" y="208" type="line"/>
       <point x="268.8" y="244.8"/>
       <point x="276.8" y="281.6"/>
-      <point type="curve" x="285.6" y="320.8"/>
-      <point type="line" x="288.8" y="320.8"/>
+      <point x="285.6" y="320.8" type="curve"/>
+      <point x="288.8" y="320.8" type="line"/>
       <point x="298.4" y="281.6"/>
       <point x="305.6" y="245.6"/>
-      <point type="curve" x="315.2" y="208.8"/>
-      <point type="line" x="371.2" y="0"/>
-      <point type="line" x="451.2" y="0"/>
-      <point type="line" x="555.2" y="388.8"/>
-      <point type="line" x="492.8" y="388.8"/>
-      <point type="line" x="436" y="164"/>
+      <point x="315.2" y="208.8" type="curve"/>
+      <point x="371.2" y="0" type="line"/>
+      <point x="451.2" y="0" type="line"/>
+      <point x="555.2" y="388.8" type="line"/>
+      <point x="492.8" y="388.8" type="line"/>
+      <point x="436" y="164" type="line"/>
       <point x="428" y="127.2"/>
       <point x="420.8" y="92"/>
-      <point type="curve" x="412" y="56"/>
-      <point type="line" x="408.8" y="56"/>
+      <point x="412" y="56" type="curve"/>
+      <point x="408.8" y="56" type="line"/>
       <point x="400" y="92"/>
       <point x="391.2" y="127.2"/>
-      <point type="curve" x="381.6" y="164"/>
-      <point type="line" x="320.8" y="388.8"/>
-      <point type="line" x="256.8" y="388.8"/>
-      <point type="line" x="196.8" y="164"/>
+      <point x="381.6" y="164" type="curve"/>
+      <point x="320.8" y="388.8" type="line"/>
+      <point x="256.8" y="388.8" type="line"/>
+      <point x="196.8" y="164" type="line"/>
       <point x="187.2" y="128"/>
       <point x="179.2" y="92"/>
-      <point type="curve" x="170.4" y="56"/>
-      <point type="line" x="167.2" y="56"/>
+      <point x="170.4" y="56" type="curve"/>
+      <point x="167.2" y="56" type="line"/>
       <point x="160" y="92"/>
       <point x="152.8" y="127.2"/>
-      <point type="curve" x="144" y="164"/>
-      <point type="line" x="86.4" y="388.8"/>
-      <point type="line" x="19.2" y="388.8"/>
+      <point x="144" y="164" type="curve"/>
+      <point x="86.4" y="388.8" type="line"/>
+      <point x="19.2" y="388.8" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/x.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/x.glif
@@ -6,32 +6,32 @@
   <anchor x="178.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="11.2" y="0" name="hintSet0000"/>
-      <point type="line" x="80" y="0"/>
-      <point type="line" x="132.8" y="90.4"/>
+      <point x="11.2" y="0" type="line" name="hintSet0000"/>
+      <point x="80" y="0" type="line"/>
+      <point x="132.8" y="90.4" type="line"/>
       <point x="145.6" y="114.4"/>
       <point x="158.4" y="137.6"/>
-      <point type="curve" x="172" y="160"/>
-      <point type="line" x="175.2" y="160"/>
+      <point x="172" y="160" type="curve"/>
+      <point x="175.2" y="160" type="line"/>
       <point x="189.6" y="137.6"/>
       <point x="204" y="113.6"/>
-      <point type="curve" x="217.6" y="90.4"/>
-      <point type="line" x="274.4" y="0"/>
-      <point type="line" x="345.6" y="0"/>
-      <point type="line" x="219.2" y="196"/>
-      <point type="line" x="336.8" y="388.8"/>
-      <point type="line" x="268" y="388.8"/>
-      <point type="line" x="220.8" y="303.2"/>
+      <point x="217.6" y="90.4" type="curve"/>
+      <point x="274.4" y="0" type="line"/>
+      <point x="345.6" y="0" type="line"/>
+      <point x="219.2" y="196" type="line"/>
+      <point x="336.8" y="388.8" type="line"/>
+      <point x="268" y="388.8" type="line"/>
+      <point x="220.8" y="303.2" type="line"/>
       <point x="208.8" y="282.4"/>
       <point x="196.8" y="260"/>
-      <point type="curve" x="185.6" y="238.4"/>
-      <point type="line" x="182.4" y="238.4"/>
+      <point x="185.6" y="238.4" type="curve"/>
+      <point x="182.4" y="238.4" type="line"/>
       <point x="168.8" y="260"/>
       <point x="156" y="282.4"/>
-      <point type="curve" x="144" y="303.2"/>
-      <point type="line" x="92" y="388.8"/>
-      <point type="line" x="20.8" y="388.8"/>
-      <point type="line" x="138.4" y="203.2"/>
+      <point x="144" y="303.2" type="curve"/>
+      <point x="92" y="388.8" type="line"/>
+      <point x="20.8" y="388.8" type="line"/>
+      <point x="138.4" y="203.2" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/y.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/y.glif
@@ -6,31 +6,31 @@
   <anchor x="160.0" y="-193.60000000000002" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="72" y="-167.2" name="hintSet0000"/>
+      <point x="72" y="-167.2" type="curve" name="hintSet0000"/>
       <point x="150.4" y="-167.2"/>
       <point x="190.4" y="-108.8"/>
-      <point type="curve" x="217.6" y="-32"/>
-      <point type="line" x="364" y="388.8"/>
-      <point type="line" x="300" y="388.8"/>
-      <point type="line" x="230.4" y="173.6"/>
+      <point x="217.6" y="-32" type="curve"/>
+      <point x="364" y="388.8" type="line"/>
+      <point x="300" y="388.8" type="line"/>
+      <point x="230.4" y="173.6" type="line"/>
       <point x="220" y="139.2"/>
       <point x="208.8" y="99.2"/>
-      <point type="curve" x="197.6" y="64"/>
-      <point type="line" x="194.4" y="64"/>
+      <point x="197.6" y="64" type="curve"/>
+      <point x="194.4" y="64" type="line"/>
       <point x="182.4" y="100"/>
       <point x="168.8" y="140"/>
-      <point type="curve" x="156.8" y="173.6"/>
-      <point type="line" x="77.6" y="388.8"/>
-      <point type="line" x="9.6" y="388.8"/>
-      <point type="line" x="165.6" y="-0.8"/>
-      <point type="line" x="156.8" y="-29.6"/>
+      <point x="156.8" y="173.6" type="curve"/>
+      <point x="77.6" y="388.8" type="line"/>
+      <point x="9.6" y="388.8" type="line"/>
+      <point x="165.6" y="-0.8" type="line"/>
+      <point x="156.8" y="-29.6" type="line"/>
       <point x="140.8" y="-77.6"/>
       <point x="112.8" y="-112.8"/>
-      <point type="curve" x="68.8" y="-112.8"/>
+      <point x="68.8" y="-112.8" type="curve"/>
       <point x="59.2" y="-112.8"/>
       <point x="47.2" y="-109.6"/>
-      <point type="curve" x="39.2" y="-107.2"/>
-      <point type="line" x="26.4" y="-159.2"/>
+      <point x="39.2" y="-107.2" type="curve"/>
+      <point x="26.4" y="-159.2" type="line"/>
       <point x="39.2" y="-164"/>
       <point x="54.4" y="-167.2"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/z.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/z.glif
@@ -6,16 +6,16 @@
   <anchor x="182.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="24.8" y="0" name="hintSet0000"/>
-      <point type="line" x="319.2" y="0"/>
-      <point type="line" x="319.2" y="53.6"/>
-      <point type="line" x="108" y="53.6"/>
-      <point type="line" x="312.8" y="353.6"/>
-      <point type="line" x="312.8" y="388.8"/>
-      <point type="line" x="47.2" y="388.8"/>
-      <point type="line" x="47.2" y="335.2"/>
-      <point type="line" x="229.6" y="335.2"/>
-      <point type="line" x="24.8" y="35.2"/>
+      <point x="24.8" y="0" type="line" name="hintSet0000"/>
+      <point x="319.2" y="0" type="line"/>
+      <point x="319.2" y="53.6" type="line"/>
+      <point x="108" y="53.6" type="line"/>
+      <point x="312.8" y="353.6" type="line"/>
+      <point x="312.8" y="388.8" type="line"/>
+      <point x="47.2" y="388.8" type="line"/>
+      <point x="47.2" y="335.2" type="line"/>
+      <point x="229.6" y="335.2" type="line"/>
+      <point x="24.8" y="35.2" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/zero.glif
+++ b/tests/autohint_data/expected_output/decimals-decimal.ufo/glyphs.com.adobe.type.processedglyphs/zero.glif
@@ -4,30 +4,30 @@
   <unicode hex="0030"/>
   <outline>
     <contour>
-      <point type="curve" x="199.2" y="-9.6" name="hintSet0000"/>
+      <point x="199.2" y="-9.6" type="curve" name="hintSet0000"/>
       <point x="300.8" y="-9.6"/>
       <point x="362.4" y="85.6"/>
-      <point type="curve" x="362.4" y="256.8"/>
+      <point x="362.4" y="256.8" type="curve"/>
       <point x="362.4" y="428"/>
       <point x="300.8" y="520"/>
-      <point type="curve" x="199.2" y="520"/>
+      <point x="199.2" y="520" type="curve"/>
       <point x="96.8" y="520"/>
       <point x="35.2" y="428"/>
-      <point type="curve" x="35.2" y="256.8"/>
+      <point x="35.2" y="256.8" type="curve"/>
       <point x="35.2" y="85.6"/>
       <point x="96.8" y="-9.6"/>
     </contour>
     <contour>
-      <point type="curve" x="199.2" y="43.2"/>
+      <point x="199.2" y="43.2" type="curve"/>
       <point x="139.2" y="43.2"/>
       <point x="99.2" y="107.2"/>
-      <point type="curve" x="99.2" y="256.8"/>
+      <point x="99.2" y="256.8" type="curve"/>
       <point x="99.2" y="406.4"/>
       <point x="139.2" y="467.2"/>
-      <point type="curve" x="199.2" y="467.2"/>
+      <point x="199.2" y="467.2" type="curve"/>
       <point x="258.4" y="467.2"/>
       <point x="298.4" y="406.4"/>
-      <point type="curve" x="298.4" y="256.8"/>
+      <point x="298.4" y="256.8" type="curve"/>
       <point x="298.4" y="107.2"/>
       <point x="258.4" y="43.2"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/A_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/A_.glif
@@ -7,26 +7,26 @@
   <anchor x="270.04" y="-14.999999999999996" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="8" y="7" name="hintSet0000"/>
-      <point type="line" x="92" y="7"/>
-      <point type="line" x="204" y="366"/>
+      <point x="8" y="7" type="line" name="hintSet0000"/>
+      <point x="92" y="7" type="line"/>
+      <point x="204" y="366" type="line"/>
       <point x="228" y="438"/>
       <point x="248" y="508"/>
-      <point type="curve" x="268" y="583"/>
-      <point type="line" x="272" y="583"/>
+      <point x="268" y="583" type="curve"/>
+      <point x="272" y="583" type="line"/>
       <point x="293" y="508"/>
       <point x="313" y="438"/>
-      <point type="curve" x="337" y="366"/>
-      <point type="line" x="448" y="7"/>
-      <point type="line" x="536" y="7"/>
-      <point type="line" x="318" y="649"/>
-      <point type="line" x="226" y="649"/>
+      <point x="337" y="366" type="curve"/>
+      <point x="448" y="7" type="line"/>
+      <point x="536" y="7" type="line"/>
+      <point x="318" y="649" type="line"/>
+      <point x="226" y="649" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="122" y="203"/>
-      <point type="line" x="419" y="203"/>
-      <point type="line" x="419" y="268"/>
-      <point type="line" x="122" y="268"/>
+      <point x="122" y="203" type="line"/>
+      <point x="419" y="203" type="line"/>
+      <point x="419" y="268" type="line"/>
+      <point x="122" y="268" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/B_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/B_.glif
@@ -6,44 +6,44 @@
   <anchor x="302.34" y="-14.999999999999996" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="95" y="7" name="hintSet0000"/>
-      <point type="line" x="299" y="7"/>
+      <point x="95" y="7" type="line" name="hintSet0000"/>
+      <point x="299" y="7" type="line"/>
       <point x="443" y="7"/>
       <point x="543" y="68"/>
-      <point type="curve" x="543" y="195"/>
+      <point x="543" y="195" type="curve"/>
       <point x="543" y="283"/>
       <point x="490" y="334"/>
-      <point type="curve" x="412" y="349"/>
-      <point type="line" x="412" y="352"/>
+      <point x="412" y="349" type="curve"/>
+      <point x="412" y="352" type="line"/>
       <point x="473" y="372" name="hintSet0005"/>
       <point x="506" y="429"/>
-      <point type="curve" x="506" y="493"/>
+      <point x="506" y="493" type="curve"/>
       <point x="506" y="605"/>
       <point x="416" y="649"/>
-      <point type="curve" x="286" y="649"/>
-      <point type="line" x="95" y="649"/>
+      <point x="286" y="649" type="curve"/>
+      <point x="95" y="649" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="176" y="376"/>
-      <point type="line" x="176" y="585"/>
-      <point type="line" x="275" y="585"/>
+      <point x="176" y="376" type="line"/>
+      <point x="176" y="585" type="line"/>
+      <point x="275" y="585" type="line"/>
       <point x="375" y="585"/>
       <point x="426" y="556"/>
-      <point type="curve" x="426" y="482"/>
+      <point x="426" y="482" type="curve"/>
       <point x="426" y="416"/>
       <point x="381" y="376"/>
-      <point type="curve" x="271" y="376"/>
+      <point x="271" y="376" type="curve"/>
     </contour>
     <contour>
-      <point type="line" x="176" y="71"/>
-      <point type="line" x="176" y="313"/>
-      <point type="line" x="288" y="313"/>
+      <point x="176" y="71" type="line"/>
+      <point x="176" y="313" type="line"/>
+      <point x="288" y="313" type="line"/>
       <point x="400" y="313" name="hintSet0016"/>
       <point x="463" y="277"/>
-      <point type="curve" x="463" y="198"/>
+      <point x="463" y="198" type="curve"/>
       <point x="463" y="111"/>
       <point x="398" y="71"/>
-      <point type="curve" x="288" y="71"/>
+      <point x="288" y="71" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/C_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/C_.glif
@@ -7,30 +7,30 @@
   <anchor x="274.40000000000003" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="270" y="-10" name="hintSet0000"/>
+      <point x="270" y="-10" type="curve" name="hintSet0000"/>
       <point x="338" y="-10"/>
       <point x="390" y="18"/>
-      <point type="curve" x="431" y="66"/>
-      <point type="line" x="394" y="108"/>
+      <point x="431" y="66" type="curve"/>
+      <point x="394" y="108" type="line"/>
       <point x="361" y="71"/>
       <point x="323" y="49"/>
-      <point type="curve" x="273" y="49"/>
+      <point x="273" y="49" type="curve"/>
       <point x="174" y="49"/>
       <point x="110" y="132"/>
-      <point type="curve" x="110" y="264"/>
+      <point x="110" y="264" type="curve"/>
       <point x="110" y="394"/>
       <point x="176" y="476"/>
-      <point type="curve" x="275" y="476"/>
+      <point x="275" y="476" type="curve"/>
       <point x="320" y="476"/>
       <point x="354" y="456"/>
-      <point type="curve" x="382" y="426"/>
-      <point type="line" x="418" y="470"/>
+      <point x="382" y="426" type="curve"/>
+      <point x="418" y="470" type="line"/>
       <point x="388" y="504"/>
       <point x="338" y="534"/>
-      <point type="curve" x="274" y="534"/>
+      <point x="274" y="534" type="curve"/>
       <point x="141" y="534"/>
       <point x="42" y="431"/>
-      <point type="curve" x="42" y="262"/>
+      <point x="42" y="262" type="curve"/>
       <point x="42" y="91"/>
       <point x="139" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/D_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/D_.glif
@@ -6,26 +6,26 @@
   <anchor x="244.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="206" y="0"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="206" y="0" type="line"/>
       <point x="365" y="0"/>
       <point x="451" y="98"/>
-      <point type="curve" x="451" y="265"/>
+      <point x="451" y="265" type="curve"/>
       <point x="451" y="431"/>
       <point x="365" y="525"/>
-      <point type="curve" x="203" y="525"/>
-      <point type="line" x="72" y="525"/>
+      <point x="203" y="525" type="curve"/>
+      <point x="72" y="525" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="138" y="54"/>
-      <point type="line" x="138" y="470"/>
-      <point type="line" x="198" y="470"/>
+      <point x="138" y="54" type="line"/>
+      <point x="138" y="470" type="line"/>
+      <point x="198" y="470" type="line"/>
       <point x="321" y="470"/>
       <point x="382" y="397"/>
-      <point type="curve" x="382" y="265"/>
+      <point x="382" y="265" type="curve"/>
       <point x="382" y="132"/>
       <point x="321" y="54"/>
-      <point type="curve" x="198" y="54"/>
+      <point x="198" y="54" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/E_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/E_.glif
@@ -7,18 +7,18 @@
   <anchor x="238.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="382" y="0"/>
-      <point type="line" x="382" y="57"/>
-      <point type="line" x="138" y="57"/>
-      <point type="line" x="138" y="247"/>
-      <point type="line" x="338" y="247"/>
-      <point type="line" x="338" y="304"/>
-      <point type="line" x="138" y="304"/>
-      <point type="line" x="138" y="469"/>
-      <point type="line" x="374" y="469"/>
-      <point type="line" x="374" y="525"/>
-      <point type="line" x="72" y="525"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="382" y="0" type="line"/>
+      <point x="382" y="57" type="line"/>
+      <point x="138" y="57" type="line"/>
+      <point x="138" y="247" type="line"/>
+      <point x="338" y="247" type="line"/>
+      <point x="338" y="304" type="line"/>
+      <point x="138" y="304" type="line"/>
+      <point x="138" y="469" type="line"/>
+      <point x="374" y="469" type="line"/>
+      <point x="374" y="525" type="line"/>
+      <point x="72" y="525" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/F_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/F_.glif
@@ -6,16 +6,16 @@
   <anchor x="108.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="138" y="0"/>
-      <point type="line" x="138" y="235"/>
-      <point type="line" x="338" y="235"/>
-      <point type="line" x="338" y="291"/>
-      <point type="line" x="138" y="291"/>
-      <point type="line" x="138" y="469"/>
-      <point type="line" x="374" y="469"/>
-      <point type="line" x="374" y="525"/>
-      <point type="line" x="72" y="525"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="138" y="0" type="line"/>
+      <point x="138" y="235" type="line"/>
+      <point x="338" y="235" type="line"/>
+      <point x="338" y="291" type="line"/>
+      <point x="138" y="291" type="line"/>
+      <point x="138" y="469" type="line"/>
+      <point x="374" y="469" type="line"/>
+      <point x="374" y="525" type="line"/>
+      <point x="72" y="525" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/G_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/G_.glif
@@ -6,34 +6,34 @@
   <anchor x="278.40000000000003" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="278" y="-10" name="hintSet0000"/>
+      <point x="278" y="-10" type="curve" name="hintSet0000"/>
       <point x="349" y="-10"/>
       <point x="406" y="16"/>
-      <point type="curve" x="440" y="51"/>
-      <point type="line" x="440" y="272"/>
-      <point type="line" x="268" y="272" name="hintSet0003"/>
-      <point type="line" x="268" y="217"/>
-      <point type="line" x="379" y="217" name="hintSet0005"/>
-      <point type="line" x="379" y="80"/>
+      <point x="440" y="51" type="curve"/>
+      <point x="440" y="272" type="line"/>
+      <point x="268" y="272" type="line" name="hintSet0003"/>
+      <point x="268" y="217" type="line"/>
+      <point x="379" y="217" type="line" name="hintSet0005"/>
+      <point x="379" y="80" type="line"/>
       <point x="358" y="61"/>
       <point x="322" y="49"/>
-      <point type="curve" x="285" y="49"/>
+      <point x="285" y="49" type="curve"/>
       <point x="173" y="49"/>
       <point x="110" y="132"/>
-      <point type="curve" x="110" y="264"/>
+      <point x="110" y="264" type="curve"/>
       <point x="110" y="394"/>
       <point x="178" y="476"/>
-      <point type="curve" x="284" y="476"/>
+      <point x="284" y="476" type="curve"/>
       <point x="337" y="476"/>
       <point x="370" y="454"/>
-      <point type="curve" x="397" y="426"/>
-      <point type="line" x="434" y="470"/>
+      <point x="397" y="426" type="curve"/>
+      <point x="434" y="470" type="line"/>
       <point x="403" y="502"/>
       <point x="355" y="534"/>
-      <point type="curve" x="282" y="534"/>
+      <point x="282" y="534" type="curve"/>
       <point x="143" y="534"/>
       <point x="42" y="431"/>
-      <point type="curve" x="42" y="262"/>
+      <point x="42" y="262" type="curve"/>
       <point x="42" y="91"/>
       <point x="140" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/H_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/H_.glif
@@ -6,18 +6,18 @@
   <anchor x="260.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="138" y="0"/>
-      <point type="line" x="138" y="247"/>
-      <point type="line" x="382" y="247"/>
-      <point type="line" x="382" y="0"/>
-      <point type="line" x="450" y="0"/>
-      <point type="line" x="450" y="525"/>
-      <point type="line" x="382" y="525"/>
-      <point type="line" x="382" y="305"/>
-      <point type="line" x="138" y="305"/>
-      <point type="line" x="138" y="525"/>
-      <point type="line" x="72" y="525"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="138" y="0" type="line"/>
+      <point x="138" y="247" type="line"/>
+      <point x="382" y="247" type="line"/>
+      <point x="382" y="0" type="line"/>
+      <point x="450" y="0" type="line"/>
+      <point x="450" y="525" type="line"/>
+      <point x="382" y="525" type="line"/>
+      <point x="382" y="305" type="line"/>
+      <point x="138" y="305" type="line"/>
+      <point x="138" y="525" type="line"/>
+      <point x="72" y="525" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/I_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/I_.glif
@@ -7,10 +7,10 @@
   <anchor x="104.80000000000001" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="138" y="0"/>
-      <point type="line" x="138" y="525"/>
-      <point type="line" x="72" y="525"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="138" y="0" type="line"/>
+      <point x="138" y="525" type="line"/>
+      <point x="72" y="525" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/J_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/J_.glif
@@ -6,20 +6,20 @@
   <anchor x="202.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="170" y="-10" name="hintSet0000"/>
+      <point x="170" y="-10" type="curve" name="hintSet0000"/>
       <point x="272" y="-10"/>
       <point x="314" y="64"/>
-      <point type="curve" x="314" y="154"/>
-      <point type="line" x="314" y="525"/>
-      <point type="line" x="247" y="525"/>
-      <point type="line" x="247" y="161"/>
+      <point x="314" y="154" type="curve"/>
+      <point x="314" y="525" type="line"/>
+      <point x="247" y="525" type="line"/>
+      <point x="247" y="161" type="line"/>
       <point x="247" y="81"/>
       <point x="219" y="49"/>
-      <point type="curve" x="163" y="49"/>
+      <point x="163" y="49" type="curve"/>
       <point x="126" y="49"/>
       <point x="96" y="66"/>
-      <point type="curve" x="73" y="108"/>
-      <point type="line" x="25" y="74"/>
+      <point x="73" y="108" type="curve"/>
+      <point x="25" y="74" type="line"/>
       <point x="55" y="19"/>
       <point x="103" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/K_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/K_.glif
@@ -6,19 +6,19 @@
   <anchor x="262.40000000000003" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="138" y="0"/>
-      <point type="line" x="138" y="166"/>
-      <point type="line" x="229" y="273"/>
-      <point type="line" x="386" y="0"/>
-      <point type="line" x="460" y="0"/>
-      <point type="line" x="270" y="325"/>
-      <point type="line" x="434" y="525"/>
-      <point type="line" x="359" y="525"/>
-      <point type="line" x="141" y="262"/>
-      <point type="line" x="138" y="262"/>
-      <point type="line" x="138" y="525"/>
-      <point type="line" x="72" y="525"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="138" y="0" type="line"/>
+      <point x="138" y="166" type="line"/>
+      <point x="229" y="273" type="line"/>
+      <point x="386" y="0" type="line"/>
+      <point x="460" y="0" type="line"/>
+      <point x="270" y="325" type="line"/>
+      <point x="434" y="525" type="line"/>
+      <point x="359" y="525" type="line"/>
+      <point x="141" y="262" type="line"/>
+      <point x="138" y="262" type="line"/>
+      <point x="138" y="525" type="line"/>
+      <point x="72" y="525" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/L_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/L_.glif
@@ -6,12 +6,12 @@
   <anchor x="231.20000000000002" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="368" y="0"/>
-      <point type="line" x="368" y="57"/>
-      <point type="line" x="138" y="57"/>
-      <point type="line" x="138" y="525"/>
-      <point type="line" x="72" y="525"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="368" y="0" type="line"/>
+      <point x="368" y="57" type="line"/>
+      <point x="138" y="57" type="line"/>
+      <point x="138" y="525" type="line"/>
+      <point x="72" y="525" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/M_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/M_.glif
@@ -6,36 +6,36 @@
   <anchor x="292.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="132" y="0"/>
-      <point type="line" x="132" y="289"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="132" y="0" type="line"/>
+      <point x="132" y="289" type="line"/>
       <point x="132" y="335"/>
       <point x="127" y="398"/>
-      <point type="curve" x="124" y="444"/>
-      <point type="line" x="127" y="444"/>
-      <point type="line" x="169" y="325"/>
-      <point type="line" x="268" y="53"/>
-      <point type="line" x="312" y="53"/>
-      <point type="line" x="411" y="325"/>
-      <point type="line" x="453" y="444"/>
-      <point type="line" x="456" y="444"/>
+      <point x="124" y="444" type="curve"/>
+      <point x="127" y="444" type="line"/>
+      <point x="169" y="325" type="line"/>
+      <point x="268" y="53" type="line"/>
+      <point x="312" y="53" type="line"/>
+      <point x="411" y="325" type="line"/>
+      <point x="453" y="444" type="line"/>
+      <point x="456" y="444" type="line"/>
       <point x="453" y="398"/>
       <point x="447" y="335"/>
-      <point type="curve" x="447" y="289"/>
-      <point type="line" x="447" y="0"/>
-      <point type="line" x="510" y="0"/>
-      <point type="line" x="510" y="525"/>
-      <point type="line" x="429" y="525"/>
-      <point type="line" x="330" y="245"/>
+      <point x="447" y="289" type="curve"/>
+      <point x="447" y="0" type="line"/>
+      <point x="510" y="0" type="line"/>
+      <point x="510" y="525" type="line"/>
+      <point x="429" y="525" type="line"/>
+      <point x="330" y="245" type="line"/>
       <point x="317" y="209"/>
       <point x="306" y="171"/>
-      <point type="curve" x="294" y="135"/>
-      <point type="line" x="290" y="135"/>
+      <point x="294" y="135" type="curve"/>
+      <point x="290" y="135" type="line"/>
       <point x="278" y="171"/>
       <point x="266" y="209"/>
-      <point type="curve" x="253" y="245"/>
-      <point type="line" x="152" y="525"/>
-      <point type="line" x="72" y="525"/>
+      <point x="253" y="245" type="curve"/>
+      <point x="152" y="525" type="line"/>
+      <point x="72" y="525" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/N_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/N_.glif
@@ -6,26 +6,26 @@
   <anchor x="261.6" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="135" y="0"/>
-      <point type="line" x="135" y="274"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="135" y="0" type="line"/>
+      <point x="135" y="274" type="line"/>
       <point x="135" y="330"/>
       <point x="130" y="386"/>
-      <point type="curve" x="126" y="438"/>
-      <point type="line" x="130" y="438"/>
-      <point type="line" x="186" y="330"/>
-      <point type="line" x="377" y="0"/>
-      <point type="line" x="446" y="0"/>
-      <point type="line" x="446" y="525"/>
-      <point type="line" x="382" y="525"/>
-      <point type="line" x="382" y="254"/>
+      <point x="126" y="438" type="curve"/>
+      <point x="130" y="438" type="line"/>
+      <point x="186" y="330" type="line"/>
+      <point x="377" y="0" type="line"/>
+      <point x="446" y="0" type="line"/>
+      <point x="446" y="525" type="line"/>
+      <point x="382" y="525" type="line"/>
+      <point x="382" y="254" type="line"/>
       <point x="382" y="198" name="hintSet0011"/>
       <point x="387" y="139"/>
-      <point type="curve" x="390" y="86"/>
-      <point type="line" x="387" y="86"/>
-      <point type="line" x="330" y="195"/>
-      <point type="line" x="141" y="525"/>
-      <point type="line" x="72" y="525"/>
+      <point x="390" y="86" type="curve"/>
+      <point x="387" y="86" type="line"/>
+      <point x="330" y="195" type="line"/>
+      <point x="141" y="525" type="line"/>
+      <point x="72" y="525" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/O_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/O_.glif
@@ -8,30 +8,30 @@
   <anchor x="265.6" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="266" y="-10" name="hintSet0000"/>
+      <point x="266" y="-10" type="curve" name="hintSet0000"/>
       <point x="398" y="-10"/>
       <point x="490" y="96"/>
-      <point type="curve" x="490" y="265"/>
+      <point x="490" y="265" type="curve"/>
       <point x="490" y="432"/>
       <point x="398" y="534"/>
-      <point type="curve" x="266" y="534"/>
+      <point x="266" y="534" type="curve"/>
       <point x="134" y="534"/>
       <point x="42" y="433"/>
-      <point type="curve" x="42" y="265"/>
+      <point x="42" y="265" type="curve"/>
       <point x="42" y="96"/>
       <point x="134" y="-10"/>
     </contour>
     <contour>
-      <point type="curve" x="266" y="49"/>
+      <point x="266" y="49" type="curve"/>
       <point x="172" y="49"/>
       <point x="110" y="134"/>
-      <point type="curve" x="110" y="265"/>
+      <point x="110" y="265" type="curve"/>
       <point x="110" y="395"/>
       <point x="172" y="476"/>
-      <point type="curve" x="266" y="476"/>
+      <point x="266" y="476" type="curve"/>
       <point x="359" y="476"/>
       <point x="421" y="395"/>
-      <point type="curve" x="421" y="265"/>
+      <point x="421" y="265" type="curve"/>
       <point x="421" y="134"/>
       <point x="359" y="49"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/P_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/P_.glif
@@ -6,28 +6,28 @@
   <anchor x="109.60000000000001" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="138" y="0"/>
-      <point type="line" x="138" y="208"/>
-      <point type="line" x="225" y="208"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="138" y="0" type="line"/>
+      <point x="138" y="208" type="line"/>
+      <point x="225" y="208" type="line"/>
       <point x="340" y="208"/>
       <point x="418" y="260"/>
-      <point type="curve" x="418" y="370"/>
+      <point x="418" y="370" type="curve"/>
       <point x="418" y="486"/>
       <point x="339" y="525"/>
-      <point type="curve" x="222" y="525"/>
-      <point type="line" x="72" y="525"/>
+      <point x="222" y="525" type="curve"/>
+      <point x="72" y="525" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="138" y="262"/>
-      <point type="line" x="138" y="471"/>
-      <point type="line" x="214" y="471"/>
+      <point x="138" y="262" type="line"/>
+      <point x="138" y="471" type="line"/>
+      <point x="214" y="471" type="line"/>
       <point x="306" y="471"/>
       <point x="352" y="446"/>
-      <point type="curve" x="352" y="370"/>
+      <point x="352" y="370" type="curve"/>
       <point x="352" y="296"/>
       <point x="308" y="262"/>
-      <point type="curve" x="217" y="262"/>
+      <point x="217" y="262" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/Q_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/Q_.glif
@@ -5,46 +5,46 @@
   <anchor x="265.6" y="542.4" name="aboveUC"/>
   <outline>
     <contour>
-      <point type="curve" x="266" y="-10" name="hintSet0000"/>
+      <point x="266" y="-10" type="curve" name="hintSet0000"/>
       <point x="398" y="-10"/>
       <point x="490" y="96"/>
-      <point type="curve" x="490" y="265"/>
+      <point x="490" y="265" type="curve"/>
       <point x="490" y="432"/>
       <point x="398" y="534"/>
-      <point type="curve" x="266" y="534"/>
+      <point x="266" y="534" type="curve"/>
       <point x="134" y="534"/>
       <point x="42" y="433"/>
-      <point type="curve" x="42" y="265"/>
+      <point x="42" y="265" type="curve"/>
       <point x="42" y="96"/>
       <point x="134" y="-10"/>
     </contour>
     <contour>
-      <point type="curve" x="266" y="46" name="hintSet0005"/>
+      <point x="266" y="46" type="curve" name="hintSet0005"/>
       <point x="172" y="46"/>
       <point x="110" y="130"/>
-      <point type="curve" x="110" y="265"/>
+      <point x="110" y="265" type="curve"/>
       <point x="110" y="395"/>
       <point x="172" y="476"/>
-      <point type="curve" x="266" y="476"/>
+      <point x="266" y="476" type="curve"/>
       <point x="359" y="476"/>
       <point x="421" y="395"/>
-      <point type="curve" x="421" y="265"/>
+      <point x="421" y="265" type="curve"/>
       <point x="421" y="130"/>
       <point x="359" y="46"/>
     </contour>
     <contour>
-      <point type="curve" x="426" y="-132"/>
+      <point x="426" y="-132" type="curve"/>
       <point x="458" y="-132"/>
       <point x="486" y="-126"/>
-      <point type="curve" x="502" y="-120"/>
-      <point type="line" x="489" y="-69"/>
+      <point x="502" y="-120" type="curve"/>
+      <point x="489" y="-69" type="line"/>
       <point x="474" y="-73"/>
       <point x="457" y="-76"/>
-      <point type="curve" x="434" y="-76"/>
+      <point x="434" y="-76" type="curve"/>
       <point x="371" y="-76" name="hintSet0014"/>
       <point x="320" y="-49"/>
-      <point type="curve" x="299" y="7"/>
-      <point type="line" x="230" y="2"/>
+      <point x="299" y="7" type="curve"/>
+      <point x="230" y="2" type="line"/>
       <point x="258" y="-74" name="hintSet0016"/>
       <point x="326" y="-132"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/R_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/R_.glif
@@ -6,34 +6,34 @@
   <anchor x="248.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="138" y="0"/>
-      <point type="line" x="138" y="222"/>
-      <point type="line" x="236" y="222"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="138" y="0" type="line"/>
+      <point x="138" y="222" type="line"/>
+      <point x="236" y="222" type="line"/>
       <point x="343" y="222"/>
       <point x="420" y="273"/>
-      <point type="curve" x="420" y="378"/>
+      <point x="420" y="378" type="curve"/>
       <point x="420" y="486"/>
       <point x="343" y="525"/>
-      <point type="curve" x="236" y="525"/>
-      <point type="line" x="72" y="525"/>
+      <point x="236" y="525" type="curve"/>
+      <point x="72" y="525" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="138" y="276"/>
-      <point type="line" x="138" y="471"/>
-      <point type="line" x="226" y="471"/>
+      <point x="138" y="276" type="line"/>
+      <point x="138" y="471" type="line"/>
+      <point x="226" y="471" type="line"/>
       <point x="308" y="471"/>
       <point x="354" y="446"/>
-      <point type="curve" x="354" y="378"/>
+      <point x="354" y="378" type="curve"/>
       <point x="354" y="310"/>
       <point x="308" y="276"/>
-      <point type="curve" x="226" y="276"/>
+      <point x="226" y="276" type="curve"/>
     </contour>
     <contour>
-      <point type="line" x="360" y="0"/>
-      <point type="line" x="435" y="0"/>
-      <point type="line" x="275" y="275" name="hintSet0014"/>
-      <point type="line" x="223" y="240"/>
+      <point x="360" y="0" type="line"/>
+      <point x="435" y="0" type="line"/>
+      <point x="275" y="275" type="line" name="hintSet0014"/>
+      <point x="223" y="240" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/S_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/S_.glif
@@ -7,44 +7,44 @@
   <anchor x="218.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="218" y="-10" name="hintSet0000"/>
+      <point x="218" y="-10" type="curve" name="hintSet0000"/>
       <point x="328" y="-10"/>
       <point x="396" y="57"/>
-      <point type="curve" x="396" y="140"/>
+      <point x="396" y="140" type="curve"/>
       <point x="396" y="218"/>
       <point x="349" y="254"/>
-      <point type="curve" x="288" y="280"/>
-      <point type="line" x="214" y="312"/>
+      <point x="288" y="280" type="curve"/>
+      <point x="214" y="312" type="line"/>
       <point x="172" y="330"/>
       <point x="126" y="349"/>
-      <point type="curve" x="126" y="399"/>
+      <point x="126" y="399" type="curve"/>
       <point x="126" y="446"/>
       <point x="166" y="476"/>
-      <point type="curve" x="224" y="476"/>
+      <point x="224" y="476" type="curve"/>
       <point x="273" y="476"/>
       <point x="311" y="457"/>
-      <point type="curve" x="343" y="426"/>
-      <point type="line" x="379" y="470"/>
+      <point x="343" y="426" type="curve"/>
+      <point x="379" y="470" type="line"/>
       <point x="342" y="508"/>
       <point x="286" y="534"/>
-      <point type="curve" x="224" y="534"/>
+      <point x="224" y="534" type="curve"/>
       <point x="129" y="534"/>
       <point x="59" y="475"/>
-      <point type="curve" x="59" y="395"/>
+      <point x="59" y="395" type="curve"/>
       <point x="59" y="318"/>
       <point x="116" y="281"/>
-      <point type="curve" x="166" y="260"/>
-      <point type="line" x="241" y="227"/>
+      <point x="166" y="260" type="curve"/>
+      <point x="241" y="227" type="line"/>
       <point x="290" y="205"/>
       <point x="328" y="188"/>
-      <point type="curve" x="328" y="134"/>
+      <point x="328" y="134" type="curve"/>
       <point x="328" y="83"/>
       <point x="287" y="49"/>
-      <point type="curve" x="218" y="49"/>
+      <point x="218" y="49" type="curve"/>
       <point x="164" y="49"/>
       <point x="111" y="75"/>
-      <point type="curve" x="74" y="114"/>
-      <point type="line" x="34" y="68"/>
+      <point x="74" y="114" type="curve"/>
+      <point x="34" y="68" type="line"/>
       <point x="79" y="21"/>
       <point x="144" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/T_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/T_.glif
@@ -7,14 +7,14 @@
   <anchor x="214.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="181" y="0" name="hintSet0000"/>
-      <point type="line" x="248" y="0"/>
-      <point type="line" x="248" y="469"/>
-      <point type="line" x="406" y="469"/>
-      <point type="line" x="406" y="525"/>
-      <point type="line" x="22" y="525"/>
-      <point type="line" x="22" y="469"/>
-      <point type="line" x="181" y="469"/>
+      <point x="181" y="0" type="line" name="hintSet0000"/>
+      <point x="248" y="0" type="line"/>
+      <point x="248" y="469" type="line"/>
+      <point x="406" y="469" type="line"/>
+      <point x="406" y="525" type="line"/>
+      <point x="22" y="525" type="line"/>
+      <point x="22" y="469" type="line"/>
+      <point x="181" y="469" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/U_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/U_.glif
@@ -8,22 +8,22 @@
   <anchor x="257.6" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="258" y="-10" name="hintSet0000"/>
+      <point x="258" y="-10" type="curve" name="hintSet0000"/>
       <point x="366" y="-10"/>
       <point x="446" y="48"/>
-      <point type="curve" x="446" y="217"/>
-      <point type="line" x="446" y="525"/>
-      <point type="line" x="382" y="525"/>
-      <point type="line" x="382" y="215"/>
+      <point x="446" y="217" type="curve"/>
+      <point x="446" y="525" type="line"/>
+      <point x="382" y="525" type="line"/>
+      <point x="382" y="215" type="line"/>
       <point x="382" y="89"/>
       <point x="328" y="49"/>
-      <point type="curve" x="258" y="49"/>
+      <point x="258" y="49" type="curve"/>
       <point x="190" y="49"/>
       <point x="136" y="89"/>
-      <point type="curve" x="136" y="215"/>
-      <point type="line" x="136" y="525"/>
-      <point type="line" x="70" y="525"/>
-      <point type="line" x="70" y="217"/>
+      <point x="136" y="215" type="curve"/>
+      <point x="136" y="525" type="line"/>
+      <point x="70" y="525" type="line"/>
+      <point x="70" y="217" type="line"/>
       <point x="70" y="48"/>
       <point x="151" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/V_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/V_.glif
@@ -6,20 +6,20 @@
   <anchor x="206.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="168" y="0" name="hintSet0000"/>
-      <point type="line" x="246" y="0"/>
-      <point type="line" x="412" y="525"/>
-      <point type="line" x="344" y="525"/>
-      <point type="line" x="260" y="242"/>
+      <point x="168" y="0" type="line" name="hintSet0000"/>
+      <point x="246" y="0" type="line"/>
+      <point x="412" y="525" type="line"/>
+      <point x="344" y="525" type="line"/>
+      <point x="260" y="242" type="line"/>
       <point x="242" y="179"/>
       <point x="229" y="130"/>
-      <point type="curve" x="210" y="68"/>
-      <point type="line" x="206" y="68"/>
+      <point x="210" y="68" type="curve"/>
+      <point x="206" y="68" type="line"/>
       <point x="186" y="130"/>
       <point x="174" y="179"/>
-      <point type="curve" x="155" y="242"/>
-      <point type="line" x="71" y="525"/>
-      <point type="line" x="0" y="525"/>
+      <point x="155" y="242" type="curve"/>
+      <point x="71" y="525" type="line"/>
+      <point x="0" y="525" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/W_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/W_.glif
@@ -6,40 +6,40 @@
   <anchor x="316.8" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="130" y="0" name="hintSet0000"/>
-      <point type="line" x="209" y="0"/>
-      <point type="line" x="286" y="316"/>
+      <point x="130" y="0" type="line" name="hintSet0000"/>
+      <point x="209" y="0" type="line"/>
+      <point x="286" y="316" type="line"/>
       <point x="295" y="357" name="hintSet0003"/>
       <point x="305" y="394"/>
-      <point type="curve" x="313" y="435"/>
-      <point type="line" x="316" y="435"/>
+      <point x="313" y="435" type="curve"/>
+      <point x="316" y="435" type="line"/>
       <point x="324" y="394"/>
       <point x="332" y="357"/>
-      <point type="curve" x="342" y="316"/>
-      <point type="line" x="421" y="0"/>
-      <point type="line" x="501" y="0"/>
-      <point type="line" x="610" y="525"/>
-      <point type="line" x="546" y="525"/>
-      <point type="line" x="490" y="239"/>
+      <point x="342" y="316" type="curve"/>
+      <point x="421" y="0" type="line"/>
+      <point x="501" y="0" type="line"/>
+      <point x="610" y="525" type="line"/>
+      <point x="546" y="525" type="line"/>
+      <point x="490" y="239" type="line"/>
       <point x="480" y="183"/>
       <point x="470" y="126"/>
-      <point type="curve" x="461" y="70"/>
-      <point type="line" x="458" y="70"/>
+      <point x="461" y="70" type="curve"/>
+      <point x="458" y="70" type="line"/>
       <point x="445" y="126"/>
       <point x="432" y="184"/>
-      <point type="curve" x="419" y="239"/>
-      <point type="line" x="346" y="525"/>
-      <point type="line" x="286" y="525"/>
-      <point type="line" x="213" y="239"/>
+      <point x="419" y="239" type="curve"/>
+      <point x="346" y="525" type="line"/>
+      <point x="286" y="525" type="line"/>
+      <point x="213" y="239" type="line"/>
       <point x="201" y="183"/>
       <point x="188" y="126"/>
-      <point type="curve" x="176" y="70"/>
-      <point type="line" x="173" y="70"/>
+      <point x="176" y="70" type="curve"/>
+      <point x="173" y="70" type="line"/>
       <point x="163" y="126"/>
       <point x="152" y="182"/>
-      <point type="curve" x="142" y="239"/>
-      <point type="line" x="87" y="525"/>
-      <point type="line" x="18" y="525"/>
+      <point x="142" y="239" type="curve"/>
+      <point x="87" y="525" type="line"/>
+      <point x="18" y="525" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/X_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/X_.glif
@@ -6,32 +6,32 @@
   <anchor x="201.60000000000002" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="12" y="0" name="hintSet0000"/>
-      <point type="line" x="82" y="0"/>
-      <point type="line" x="158" y="142"/>
+      <point x="12" y="0" type="line" name="hintSet0000"/>
+      <point x="82" y="0" type="line"/>
+      <point x="158" y="142" type="line"/>
       <point x="171" y="167"/>
       <point x="185" y="194"/>
-      <point type="curve" x="200" y="226"/>
-      <point type="line" x="203" y="226"/>
+      <point x="200" y="226" type="curve"/>
+      <point x="203" y="226" type="line"/>
       <point x="220" y="194"/>
       <point x="234" y="167"/>
-      <point type="curve" x="248" y="142"/>
-      <point type="line" x="325" y="0"/>
-      <point type="line" x="398" y="0"/>
-      <point type="line" x="246" y="268"/>
-      <point type="line" x="389" y="525"/>
-      <point type="line" x="318" y="525"/>
-      <point type="line" x="249" y="390"/>
+      <point x="248" y="142" type="curve"/>
+      <point x="325" y="0" type="line"/>
+      <point x="398" y="0" type="line"/>
+      <point x="246" y="268" type="line"/>
+      <point x="389" y="525" type="line"/>
+      <point x="318" y="525" type="line"/>
+      <point x="249" y="390" type="line"/>
       <point x="236" y="366"/>
       <point x="226" y="345"/>
-      <point type="curve" x="211" y="314"/>
-      <point type="line" x="208" y="314"/>
+      <point x="211" y="314" type="curve"/>
+      <point x="208" y="314" type="line"/>
       <point x="192" y="345"/>
       <point x="181" y="366"/>
-      <point type="curve" x="167" y="390"/>
-      <point type="line" x="96" y="525"/>
-      <point type="line" x="22" y="525"/>
-      <point type="line" x="165" y="271"/>
+      <point x="167" y="390" type="curve"/>
+      <point x="96" y="525" type="line"/>
+      <point x="22" y="525" type="line"/>
+      <point x="165" y="271" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/Y_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/Y_.glif
@@ -6,22 +6,22 @@
   <anchor x="192.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="157" y="0" name="hintSet0000"/>
-      <point type="line" x="224" y="0"/>
-      <point type="line" x="224" y="203"/>
-      <point type="line" x="382" y="525"/>
-      <point type="line" x="312" y="525"/>
-      <point type="line" x="245" y="377"/>
+      <point x="157" y="0" type="line" name="hintSet0000"/>
+      <point x="224" y="0" type="line"/>
+      <point x="224" y="203" type="line"/>
+      <point x="382" y="525" type="line"/>
+      <point x="312" y="525" type="line"/>
+      <point x="245" y="377" type="line"/>
       <point x="229" y="338"/>
       <point x="210" y="302"/>
-      <point type="curve" x="192" y="262"/>
-      <point type="line" x="189" y="262"/>
+      <point x="192" y="262" type="curve"/>
+      <point x="189" y="262" type="line"/>
       <point x="171" y="302"/>
       <point x="155" y="338"/>
-      <point type="curve" x="138" y="377"/>
-      <point type="line" x="70" y="525"/>
-      <point type="line" x="-1" y="525"/>
-      <point type="line" x="157" y="203"/>
+      <point x="138" y="377" type="curve"/>
+      <point x="70" y="525" type="line"/>
+      <point x="-1" y="525" type="line"/>
+      <point x="157" y="203" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/Z_.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/Z_.glif
@@ -6,16 +6,16 @@
   <anchor x="225.60000000000002" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="36" y="0" name="hintSet0000"/>
-      <point type="line" x="398" y="0"/>
-      <point type="line" x="398" y="57"/>
-      <point type="line" x="118" y="57"/>
-      <point type="line" x="395" y="486"/>
-      <point type="line" x="395" y="525"/>
-      <point type="line" x="61" y="525"/>
-      <point type="line" x="61" y="469"/>
-      <point type="line" x="312" y="469"/>
-      <point type="line" x="36" y="40"/>
+      <point x="36" y="0" type="line" name="hintSet0000"/>
+      <point x="398" y="0" type="line"/>
+      <point x="398" y="57" type="line"/>
+      <point x="118" y="57" type="line"/>
+      <point x="395" y="486" type="line"/>
+      <point x="395" y="525" type="line"/>
+      <point x="61" y="525" type="line"/>
+      <point x="61" y="469" type="line"/>
+      <point x="312" y="469" type="line"/>
+      <point x="36" y="40" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/a.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/a.glif
@@ -7,42 +7,42 @@
   <anchor x="201.60000000000002" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="155" y="-10" name="hintSet0000"/>
+      <point x="155" y="-10" type="curve" name="hintSet0000"/>
       <point x="204" y="-10" name="hintSet0001"/>
       <point x="247" y="16"/>
-      <point type="curve" x="284" y="46"/>
-      <point type="line" x="286" y="46"/>
-      <point type="line" x="292" y="0" name="hintSet0003"/>
-      <point type="line" x="346" y="0" name="hintSet0004"/>
-      <point type="line" x="346" y="238"/>
+      <point x="284" y="46" type="curve"/>
+      <point x="286" y="46" type="line"/>
+      <point x="292" y="0" type="line" name="hintSet0003"/>
+      <point x="346" y="0" type="line" name="hintSet0004"/>
+      <point x="346" y="238" type="line"/>
       <point x="346" y="335"/>
       <point x="306" y="398"/>
-      <point type="curve" x="211" y="398"/>
+      <point x="211" y="398" type="curve"/>
       <point x="149" y="398"/>
       <point x="94" y="371"/>
-      <point type="curve" x="58" y="348"/>
-      <point type="line" x="84" y="302"/>
+      <point x="58" y="348" type="curve"/>
+      <point x="84" y="302" type="line"/>
       <point x="114" y="323"/>
       <point x="155" y="344"/>
-      <point type="curve" x="200" y="344"/>
+      <point x="200" y="344" type="curve"/>
       <point x="264" y="344"/>
       <point x="280" y="296"/>
-      <point type="curve" x="280" y="246"/>
+      <point x="280" y="246" type="curve"/>
       <point x="114" y="228"/>
       <point x="42" y="186"/>
-      <point type="curve" x="42" y="101"/>
+      <point x="42" y="101" type="curve"/>
       <point x="42" y="31" name="hintSet0012"/>
       <point x="90" y="-10"/>
     </contour>
     <contour>
-      <point type="curve" x="174" y="43"/>
+      <point x="174" y="43" type="curve"/>
       <point x="136" y="43"/>
       <point x="106" y="62"/>
-      <point type="curve" x="106" y="106"/>
+      <point x="106" y="106" type="curve"/>
       <point x="106" y="155"/>
       <point x="150" y="187"/>
-      <point type="curve" x="280" y="203"/>
-      <point type="line" x="280" y="95"/>
+      <point x="280" y="203" type="curve"/>
+      <point x="280" y="95" type="line"/>
       <point x="242" y="62"/>
       <point x="212" y="43"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/ampersand.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/ampersand.glif
@@ -4,54 +4,54 @@
   <unicode hex="0026"/>
   <outline>
     <contour>
-      <point type="curve" x="186" y="-10" name="hintSet0000"/>
+      <point x="186" y="-10" type="curve" name="hintSet0000"/>
       <point x="259" y="-10"/>
       <point x="315" y="24"/>
-      <point type="curve" x="359" y="73"/>
+      <point x="359" y="73" type="curve"/>
       <point x="410" y="133"/>
       <point x="446" y="205"/>
-      <point type="curve" x="469" y="283"/>
-      <point type="line" x="407" y="283"/>
+      <point x="469" y="283" type="curve"/>
+      <point x="407" y="283" type="line"/>
       <point x="388" y="211"/>
       <point x="356" y="151"/>
-      <point type="curve" x="314" y="105"/>
+      <point x="314" y="105" type="curve"/>
       <point x="278" y="68"/>
       <point x="237" y="43"/>
-      <point type="curve" x="193" y="43"/>
+      <point x="193" y="43" type="curve"/>
       <point x="135" y="43"/>
       <point x="90" y="82"/>
-      <point type="curve" x="90" y="140"/>
+      <point x="90" y="140" type="curve"/>
       <point x="90" y="255"/>
       <point x="319" y="296"/>
-      <point type="curve" x="319" y="430"/>
+      <point x="319" y="430" type="curve"/>
       <point x="319" y="492"/>
       <point x="281" y="534"/>
-      <point type="curve" x="216" y="534"/>
+      <point x="216" y="534" type="curve"/>
       <point x="143" y="534" name="hintSet0009"/>
       <point x="94" y="480"/>
-      <point type="curve" x="94" y="410"/>
+      <point x="94" y="410" type="curve"/>
       <point x="94" y="299"/>
       <point x="206" y="153"/>
-      <point type="curve" x="320" y="63"/>
+      <point x="320" y="63" type="curve"/>
       <point x="368" y="26"/>
       <point x="416" y="2"/>
-      <point type="curve" x="458" y="-10"/>
-      <point type="line" x="475" y="45"/>
+      <point x="458" y="-10" type="curve"/>
+      <point x="475" y="45" type="line"/>
       <point x="442" y="54"/>
       <point x="402" y="76"/>
-      <point type="curve" x="360" y="107"/>
+      <point x="360" y="107" type="curve"/>
       <point x="259" y="182"/>
       <point x="151" y="313"/>
-      <point type="curve" x="151" y="411"/>
+      <point x="151" y="411" type="curve"/>
       <point x="151" y="454"/>
       <point x="177" y="487"/>
-      <point type="curve" x="216" y="487"/>
+      <point x="216" y="487" type="curve"/>
       <point x="251" y="487"/>
       <point x="266" y="460"/>
-      <point type="curve" x="266" y="430"/>
+      <point x="266" y="430" type="curve"/>
       <point x="266" y="317" name="hintSet0017"/>
       <point x="26" y="291"/>
-      <point type="curve" x="26" y="136"/>
+      <point x="26" y="136" type="curve"/>
       <point x="26" y="51"/>
       <point x="90" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/asciicircum.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/asciicircum.glif
@@ -4,16 +4,16 @@
   <unicode hex="005E"/>
   <outline>
     <contour>
-      <point type="line" x="48" y="227" name="hintSet0000"/>
-      <point type="line" x="106" y="227"/>
-      <point type="line" x="158" y="368"/>
-      <point type="line" x="198" y="474"/>
-      <point type="line" x="201" y="474"/>
-      <point type="line" x="240" y="368"/>
-      <point type="line" x="292" y="227"/>
-      <point type="line" x="350" y="227"/>
-      <point type="line" x="228" y="536"/>
-      <point type="line" x="170" y="536"/>
+      <point x="48" y="227" type="line" name="hintSet0000"/>
+      <point x="106" y="227" type="line"/>
+      <point x="158" y="368" type="line"/>
+      <point x="198" y="474" type="line"/>
+      <point x="201" y="474" type="line"/>
+      <point x="240" y="368" type="line"/>
+      <point x="292" y="227" type="line"/>
+      <point x="350" y="227" type="line"/>
+      <point x="228" y="536" type="line"/>
+      <point x="170" y="536" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/asciitilde.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/asciitilde.glif
@@ -4,24 +4,24 @@
   <unicode hex="007E"/>
   <outline>
     <contour>
-      <point type="curve" x="269" y="206" name="hintSet0000"/>
+      <point x="269" y="206" type="curve" name="hintSet0000"/>
       <point x="303" y="206"/>
       <point x="340" y="226"/>
-      <point type="curve" x="369" y="277"/>
-      <point type="line" x="332" y="304"/>
+      <point x="369" y="277" type="curve"/>
+      <point x="332" y="304" type="line"/>
       <point x="314" y="270"/>
       <point x="294" y="255"/>
-      <point type="curve" x="270" y="255"/>
+      <point x="270" y="255" type="curve"/>
       <point x="226" y="255" name="hintSet0004"/>
       <point x="192" y="322"/>
-      <point type="curve" x="129" y="322"/>
+      <point x="129" y="322" type="curve"/>
       <point x="94" y="322"/>
       <point x="58" y="302"/>
-      <point type="curve" x="29" y="250"/>
-      <point type="line" x="66" y="224"/>
+      <point x="29" y="250" type="curve"/>
+      <point x="66" y="224" type="line"/>
       <point x="84" y="258"/>
       <point x="104" y="273"/>
-      <point type="curve" x="127" y="273"/>
+      <point x="127" y="273" type="curve"/>
       <point x="172" y="273" name="hintSet0008"/>
       <point x="206" y="206"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/asterisk.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/asterisk.glif
@@ -4,21 +4,21 @@
   <unicode hex="002A"/>
   <outline>
     <contour>
-      <point type="line" x="110" y="336" name="hintSet0000"/>
-      <point type="line" x="167" y="405"/>
-      <point type="line" x="224" y="336"/>
-      <point type="line" x="255" y="359"/>
-      <point type="line" x="210" y="434"/>
-      <point type="line" x="288" y="466"/>
-      <point type="line" x="276" y="503"/>
-      <point type="line" x="194" y="484"/>
-      <point type="line" x="186" y="570"/>
-      <point type="line" x="147" y="570"/>
-      <point type="line" x="140" y="483"/>
-      <point type="line" x="58" y="503"/>
-      <point type="line" x="46" y="466"/>
-      <point type="line" x="124" y="434"/>
-      <point type="line" x="78" y="359"/>
+      <point x="110" y="336" type="line" name="hintSet0000"/>
+      <point x="167" y="405" type="line"/>
+      <point x="224" y="336" type="line"/>
+      <point x="255" y="359" type="line"/>
+      <point x="210" y="434" type="line"/>
+      <point x="288" y="466" type="line"/>
+      <point x="276" y="503" type="line"/>
+      <point x="194" y="484" type="line"/>
+      <point x="186" y="570" type="line"/>
+      <point x="147" y="570" type="line"/>
+      <point x="140" y="483" type="line"/>
+      <point x="58" y="503" type="line"/>
+      <point x="46" y="466" type="line"/>
+      <point x="124" y="434" type="line"/>
+      <point x="78" y="359" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/at.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/at.glif
@@ -4,73 +4,73 @@
   <unicode hex="0040"/>
   <outline>
     <contour>
-      <point type="curve" x="322" y="-124" name="hintSet0000"/>
+      <point x="322" y="-124" type="curve" name="hintSet0000"/>
       <point x="378" y="-124"/>
       <point x="428" y="-111"/>
-      <point type="curve" x="474" y="-83"/>
-      <point type="line" x="457" y="-44"/>
+      <point x="474" y="-83" type="curve"/>
+      <point x="457" y="-44" type="line"/>
       <point x="421" y="-65"/>
       <point x="376" y="-80"/>
-      <point type="curve" x="327" y="-80"/>
+      <point x="327" y="-80" type="curve"/>
       <point x="191" y="-80"/>
       <point x="89" y="9"/>
-      <point type="curve" x="89" y="165"/>
+      <point x="89" y="165" type="curve"/>
       <point x="89" y="352"/>
       <point x="226" y="473"/>
-      <point type="curve" x="369" y="473"/>
+      <point x="369" y="473" type="curve"/>
       <point x="514" y="473"/>
       <point x="590" y="378"/>
-      <point type="curve" x="590" y="250"/>
+      <point x="590" y="250" type="curve"/>
       <point x="590" y="146"/>
       <point x="534" y="84"/>
-      <point type="curve" x="483" y="84"/>
+      <point x="483" y="84" type="curve"/>
       <point x="439" y="84"/>
       <point x="424" y="114"/>
-      <point type="curve" x="440" y="178"/>
-      <point type="line" x="471" y="338"/>
-      <point type="line" x="427" y="338"/>
-      <point type="line" x="418" y="306"/>
-      <point type="line" x="417" y="306"/>
+      <point x="440" y="178" type="curve"/>
+      <point x="471" y="338" type="line"/>
+      <point x="427" y="338" type="line"/>
+      <point x="418" y="306" type="line"/>
+      <point x="417" y="306" type="line"/>
       <point x="402" y="332"/>
       <point x="380" y="344"/>
-      <point type="curve" x="353" y="344"/>
+      <point x="353" y="344" type="curve"/>
       <point x="259" y="344"/>
       <point x="199" y="244"/>
-      <point type="curve" x="199" y="158"/>
+      <point x="199" y="158" type="curve"/>
       <point x="199" y="86" name="hintSet0015"/>
       <point x="241" y="46"/>
-      <point type="curve" x="295" y="46"/>
+      <point x="295" y="46" type="curve"/>
       <point x="330" y="46"/>
       <point x="366" y="69"/>
-      <point type="curve" x="393" y="100"/>
-      <point type="line" x="394" y="100"/>
+      <point x="393" y="100" type="curve"/>
+      <point x="394" y="100" type="line"/>
       <point x="400" y="60" name="hintSet0018"/>
       <point x="434" y="39"/>
-      <point type="curve" x="477" y="39"/>
+      <point x="477" y="39" type="curve"/>
       <point x="550" y="39"/>
       <point x="637" y="112"/>
-      <point type="curve" x="637" y="252"/>
+      <point x="637" y="252" type="curve"/>
       <point x="637" y="410"/>
       <point x="536" y="517"/>
-      <point type="curve" x="374" y="517"/>
+      <point x="374" y="517" type="curve"/>
       <point x="195" y="517"/>
       <point x="41" y="377"/>
-      <point type="curve" x="41" y="162"/>
+      <point x="41" y="162" type="curve"/>
       <point x="41" y="-24"/>
       <point x="166" y="-124"/>
     </contour>
     <contour>
-      <point type="curve" x="308" y="90" name="hintSet0023"/>
+      <point x="308" y="90" type="curve" name="hintSet0023"/>
       <point x="276" y="90"/>
       <point x="252" y="111"/>
-      <point type="curve" x="252" y="162"/>
+      <point x="252" y="162" type="curve"/>
       <point x="252" y="222"/>
       <point x="290" y="298"/>
-      <point type="curve" x="354" y="298"/>
+      <point x="354" y="298" type="curve"/>
       <point x="375" y="298"/>
       <point x="390" y="290"/>
-      <point type="curve" x="405" y="265"/>
-      <point type="line" x="382" y="138"/>
+      <point x="405" y="265" type="curve"/>
+      <point x="382" y="138" type="line"/>
       <point x="354" y="105"/>
       <point x="330" y="90"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/b.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/b.glif
@@ -6,38 +6,38 @@
   <anchor x="227.20000000000002" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="238" y="-10" name="hintSet0000"/>
+      <point x="238" y="-10" type="curve" name="hintSet0000"/>
       <point x="326" y="-10"/>
       <point x="406" y="68"/>
-      <point type="curve" x="406" y="201"/>
+      <point x="406" y="201" type="curve"/>
       <point x="406" y="321"/>
       <point x="352" y="398"/>
-      <point type="curve" x="251" y="398"/>
+      <point x="251" y="398" type="curve"/>
       <point x="208" y="398"/>
       <point x="165" y="375"/>
-      <point type="curve" x="130" y="344"/>
-      <point type="line" x="131" y="414"/>
-      <point type="line" x="131" y="570"/>
-      <point type="line" x="66" y="570"/>
-      <point type="line" x="66" y="0" name="hintSet0007"/>
-      <point type="line" x="118" y="0" name="hintSet0008"/>
-      <point type="line" x="124" y="40" name="hintSet0009"/>
-      <point type="line" x="126" y="40"/>
+      <point x="130" y="344" type="curve"/>
+      <point x="131" y="414" type="line"/>
+      <point x="131" y="570" type="line"/>
+      <point x="66" y="570" type="line"/>
+      <point x="66" y="0" type="line" name="hintSet0007"/>
+      <point x="118" y="0" type="line" name="hintSet0008"/>
+      <point x="124" y="40" type="line" name="hintSet0009"/>
+      <point x="126" y="40" type="line"/>
       <point x="161" y="9" name="hintSet0011"/>
       <point x="202" y="-10"/>
     </contour>
     <contour>
-      <point type="curve" x="226" y="46"/>
+      <point x="226" y="46" type="curve"/>
       <point x="201" y="46"/>
       <point x="166" y="57"/>
-      <point type="curve" x="131" y="86"/>
-      <point type="line" x="131" y="290"/>
+      <point x="131" y="86" type="curve"/>
+      <point x="131" y="290" type="line"/>
       <point x="168" y="325"/>
       <point x="202" y="343"/>
-      <point type="curve" x="235" y="343"/>
+      <point x="235" y="343" type="curve"/>
       <point x="309" y="343"/>
       <point x="338" y="286"/>
-      <point type="curve" x="338" y="200"/>
+      <point x="338" y="200" type="curve"/>
       <point x="338" y="104"/>
       <point x="290" y="46"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/backslash.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/backslash.glif
@@ -4,10 +4,10 @@
   <unicode hex="005C"/>
   <outline>
     <contour>
-      <point type="line" x="225" y="-128" name="hintSet0000"/>
-      <point type="line" x="272" y="-128"/>
-      <point type="line" x="58" y="568"/>
-      <point type="line" x="11" y="568"/>
+      <point x="225" y="-128" type="line" name="hintSet0000"/>
+      <point x="272" y="-128" type="line"/>
+      <point x="58" y="568" type="line"/>
+      <point x="11" y="568" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/bar.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/bar.glif
@@ -4,10 +4,10 @@
   <unicode hex="007C"/>
   <outline>
     <contour>
-      <point type="line" x="74" y="-200" name="hintSet0000"/>
-      <point type="line" x="120" y="-200"/>
-      <point type="line" x="120" y="600"/>
-      <point type="line" x="74" y="600"/>
+      <point x="74" y="-200" type="line" name="hintSet0000"/>
+      <point x="120" y="-200" type="line"/>
+      <point x="120" y="600" type="line"/>
+      <point x="74" y="600" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/braceleft.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/braceleft.glif
@@ -4,48 +4,48 @@
   <unicode hex="007B"/>
   <outline>
     <contour>
-      <point type="curve" x="182" y="-122" name="hintSet0000"/>
-      <point type="line" x="218" y="-122"/>
-      <point type="line" x="218" y="-84"/>
-      <point type="line" x="197" y="-84"/>
+      <point x="182" y="-122" type="curve" name="hintSet0000"/>
+      <point x="218" y="-122" type="line"/>
+      <point x="218" y="-84" type="line"/>
+      <point x="197" y="-84" type="line"/>
       <point x="154" y="-84"/>
       <point x="142" y="-63"/>
-      <point type="curve" x="142" y="-11"/>
+      <point x="142" y="-11" type="curve"/>
       <point x="142" y="38"/>
       <point x="147" y="79"/>
-      <point type="curve" x="147" y="134"/>
+      <point x="147" y="134" type="curve"/>
       <point x="147" y="185"/>
       <point x="134" y="211"/>
-      <point type="curve" x="99" y="221"/>
-      <point type="line" x="99" y="224"/>
+      <point x="99" y="221" type="curve"/>
+      <point x="99" y="224" type="line"/>
       <point x="134" y="234"/>
       <point x="147" y="259"/>
-      <point type="curve" x="147" y="311"/>
+      <point x="147" y="311" type="curve"/>
       <point x="147" y="366"/>
       <point x="142" y="407"/>
-      <point type="curve" x="142" y="456"/>
+      <point x="142" y="456" type="curve"/>
       <point x="142" y="508"/>
       <point x="154" y="529"/>
-      <point type="curve" x="197" y="529"/>
-      <point type="line" x="218" y="529"/>
-      <point type="line" x="218" y="566"/>
-      <point type="line" x="182" y="566"/>
+      <point x="197" y="529" type="curve"/>
+      <point x="218" y="529" type="line"/>
+      <point x="218" y="566" type="line"/>
+      <point x="182" y="566" type="line"/>
       <point x="119" y="566"/>
       <point x="89" y="542"/>
-      <point type="curve" x="89" y="460"/>
+      <point x="89" y="460" type="curve"/>
       <point x="89" y="402"/>
       <point x="96" y="359"/>
-      <point type="curve" x="96" y="305"/>
+      <point x="96" y="305" type="curve"/>
       <point x="96" y="274" name="hintSet0016"/>
       <point x="82" y="244"/>
-      <point type="curve" x="27" y="243"/>
-      <point type="line" x="27" y="202"/>
+      <point x="27" y="243" type="curve"/>
+      <point x="27" y="202" type="line"/>
       <point x="82" y="201" name="hintSet0018"/>
       <point x="96" y="170"/>
-      <point type="curve" x="96" y="139"/>
+      <point x="96" y="139" type="curve"/>
       <point x="96" y="86" name="hintSet0019"/>
       <point x="89" y="43"/>
-      <point type="curve" x="89" y="-15"/>
+      <point x="89" y="-15" type="curve"/>
       <point x="89" y="-98"/>
       <point x="119" y="-122"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/braceright.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/braceright.glif
@@ -4,50 +4,50 @@
   <unicode hex="007D"/>
   <outline>
     <contour>
-      <point type="line" x="25" y="-122" name="hintSet0000"/>
-      <point type="line" x="60" y="-122"/>
+      <point x="25" y="-122" type="line" name="hintSet0000"/>
+      <point x="60" y="-122" type="line"/>
       <point x="124" y="-122"/>
       <point x="154" y="-98"/>
-      <point type="curve" x="154" y="-15"/>
+      <point x="154" y="-15" type="curve"/>
       <point x="154" y="43"/>
       <point x="146" y="86"/>
-      <point type="curve" x="146" y="139"/>
+      <point x="146" y="139" type="curve"/>
       <point x="146" y="170" name="hintSet0004"/>
       <point x="162" y="201"/>
-      <point type="curve" x="215" y="202"/>
-      <point type="line" x="215" y="243"/>
+      <point x="215" y="202" type="curve"/>
+      <point x="215" y="243" type="line"/>
       <point x="162" y="244" name="hintSet0006"/>
       <point x="146" y="274"/>
-      <point type="curve" x="146" y="305"/>
+      <point x="146" y="305" type="curve"/>
       <point x="146" y="359" name="hintSet0007"/>
       <point x="154" y="402"/>
-      <point type="curve" x="154" y="460"/>
+      <point x="154" y="460" type="curve"/>
       <point x="154" y="542"/>
       <point x="124" y="566"/>
-      <point type="curve" x="60" y="566"/>
-      <point type="line" x="25" y="566"/>
-      <point type="line" x="25" y="529"/>
-      <point type="line" x="46" y="529"/>
+      <point x="60" y="566" type="curve"/>
+      <point x="25" y="566" type="line"/>
+      <point x="25" y="529" type="line"/>
+      <point x="46" y="529" type="line"/>
       <point x="89" y="529"/>
       <point x="100" y="508"/>
-      <point type="curve" x="100" y="456"/>
+      <point x="100" y="456" type="curve"/>
       <point x="100" y="407"/>
       <point x="96" y="366"/>
-      <point type="curve" x="96" y="311"/>
+      <point x="96" y="311" type="curve"/>
       <point x="96" y="259"/>
       <point x="109" y="234"/>
-      <point type="curve" x="143" y="224"/>
-      <point type="line" x="143" y="221"/>
+      <point x="143" y="224" type="curve"/>
+      <point x="143" y="221" type="line"/>
       <point x="109" y="211"/>
       <point x="96" y="185"/>
-      <point type="curve" x="96" y="134"/>
+      <point x="96" y="134" type="curve"/>
       <point x="96" y="79"/>
       <point x="100" y="38"/>
-      <point type="curve" x="100" y="-11"/>
+      <point x="100" y="-11" type="curve"/>
       <point x="100" y="-63"/>
       <point x="89" y="-84"/>
-      <point type="curve" x="46" y="-84"/>
-      <point type="line" x="25" y="-84"/>
+      <point x="46" y="-84" type="curve"/>
+      <point x="25" y="-84" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/bracketleft.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/bracketleft.glif
@@ -4,14 +4,14 @@
   <unicode hex="005B"/>
   <outline>
     <contour>
-      <point type="line" x="75" y="-122" name="hintSet0000"/>
-      <point type="line" x="218" y="-122"/>
-      <point type="line" x="218" y="-84"/>
-      <point type="line" x="125" y="-84"/>
-      <point type="line" x="125" y="529"/>
-      <point type="line" x="218" y="529"/>
-      <point type="line" x="218" y="566"/>
-      <point type="line" x="75" y="566"/>
+      <point x="75" y="-122" type="line" name="hintSet0000"/>
+      <point x="218" y="-122" type="line"/>
+      <point x="218" y="-84" type="line"/>
+      <point x="125" y="-84" type="line"/>
+      <point x="125" y="529" type="line"/>
+      <point x="218" y="529" type="line"/>
+      <point x="218" y="566" type="line"/>
+      <point x="75" y="566" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/bracketright.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/bracketright.glif
@@ -4,14 +4,14 @@
   <unicode hex="005D"/>
   <outline>
     <contour>
-      <point type="line" x="25" y="-122" name="hintSet0000"/>
-      <point type="line" x="167" y="-122"/>
-      <point type="line" x="167" y="566"/>
-      <point type="line" x="25" y="566"/>
-      <point type="line" x="25" y="529"/>
-      <point type="line" x="118" y="529"/>
-      <point type="line" x="118" y="-84"/>
-      <point type="line" x="25" y="-84"/>
+      <point x="25" y="-122" type="line" name="hintSet0000"/>
+      <point x="167" y="-122" type="line"/>
+      <point x="167" y="566" type="line"/>
+      <point x="25" y="566" type="line"/>
+      <point x="25" y="529" type="line"/>
+      <point x="118" y="529" type="line"/>
+      <point x="118" y="-84" type="line"/>
+      <point x="25" y="-84" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/c.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/c.glif
@@ -7,30 +7,30 @@
   <anchor x="216.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="219" y="-10" name="hintSet0000"/>
+      <point x="219" y="-10" type="curve" name="hintSet0000"/>
       <point x="266" y="-10"/>
       <point x="310" y="9"/>
-      <point type="curve" x="345" y="40"/>
-      <point type="line" x="316" y="84"/>
+      <point x="345" y="40" type="curve"/>
+      <point x="316" y="84" type="line"/>
       <point x="292" y="62"/>
       <point x="261" y="45"/>
-      <point type="curve" x="225" y="45"/>
+      <point x="225" y="45" type="curve"/>
       <point x="154" y="45"/>
       <point x="105" y="105"/>
-      <point type="curve" x="105" y="194"/>
+      <point x="105" y="194" type="curve"/>
       <point x="105" y="283"/>
       <point x="156" y="344"/>
-      <point type="curve" x="226" y="344"/>
+      <point x="226" y="344" type="curve"/>
       <point x="258" y="344"/>
       <point x="282" y="330"/>
-      <point type="curve" x="304" y="310"/>
-      <point type="line" x="338" y="353"/>
+      <point x="304" y="310" type="curve"/>
+      <point x="338" y="353" type="line"/>
       <point x="310" y="378"/>
       <point x="275" y="398"/>
-      <point type="curve" x="224" y="398"/>
+      <point x="224" y="398" type="curve"/>
       <point x="124" y="398"/>
       <point x="37" y="324"/>
-      <point type="curve" x="37" y="194"/>
+      <point x="37" y="194" type="curve"/>
       <point x="37" y="65"/>
       <point x="116" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/colon.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/colon.glif
@@ -4,30 +4,30 @@
   <unicode hex="003A"/>
   <outline>
     <contour>
-      <point type="curve" x="80" y="281" name="hintSet0000"/>
+      <point x="80" y="281" type="curve" name="hintSet0000"/>
       <point x="100" y="281"/>
       <point x="118" y="298"/>
-      <point type="curve" x="118" y="321"/>
+      <point x="118" y="321" type="curve"/>
       <point x="118" y="345"/>
       <point x="100" y="362"/>
-      <point type="curve" x="80" y="362"/>
+      <point x="80" y="362" type="curve"/>
       <point x="59" y="362"/>
       <point x="42" y="345"/>
-      <point type="curve" x="42" y="321"/>
+      <point x="42" y="321" type="curve"/>
       <point x="42" y="298"/>
       <point x="59" y="281"/>
     </contour>
     <contour>
-      <point type="curve" x="80" y="-8"/>
+      <point x="80" y="-8" type="curve"/>
       <point x="100" y="-8"/>
       <point x="118" y="9"/>
-      <point type="curve" x="118" y="32"/>
+      <point x="118" y="32" type="curve"/>
       <point x="118" y="56" name="hintSet0007"/>
       <point x="100" y="73"/>
-      <point type="curve" x="80" y="73"/>
+      <point x="80" y="73" type="curve"/>
       <point x="59" y="73"/>
       <point x="42" y="56"/>
-      <point type="curve" x="42" y="32"/>
+      <point x="42" y="32" type="curve"/>
       <point x="42" y="9" name="hintSet0009"/>
       <point x="59" y="-8"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/comma.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/comma.glif
@@ -4,27 +4,27 @@
   <unicode hex="002C"/>
   <outline>
     <contour>
-      <point type="line" x="54" y="-136" name="hintSet0000"/>
+      <point x="54" y="-136" type="line" name="hintSet0000"/>
       <point x="118" y="-109"/>
       <point x="158" y="-55"/>
-      <point type="curve" x="158" y="14"/>
+      <point x="158" y="14" type="curve"/>
       <point x="158" y="62"/>
       <point x="138" y="91"/>
-      <point type="curve" x="103" y="91"/>
+      <point x="103" y="91" type="curve"/>
       <point x="77" y="91"/>
       <point x="54" y="74"/>
-      <point type="curve" x="54" y="45"/>
+      <point x="54" y="45" type="curve"/>
       <point x="54" y="15"/>
       <point x="76" y="-1"/>
-      <point type="curve" x="102" y="-1"/>
+      <point x="102" y="-1" type="curve"/>
       <point x="114" y="-1"/>
       <point x="126" y="2"/>
-      <point type="curve" x="135" y="13"/>
-      <point type="line" x="102" y="61"/>
-      <point type="line" x="110" y="2"/>
+      <point x="135" y="13" type="curve"/>
+      <point x="102" y="61" type="line"/>
+      <point x="110" y="2" type="line"/>
       <point x="110" y="-42"/>
       <point x="83" y="-78"/>
-      <point type="curve" x="38" y="-98"/>
+      <point x="38" y="-98" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/d.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/d.glif
@@ -6,38 +6,38 @@
   <anchor x="240.8" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="198" y="-10" name="hintSet0000"/>
+      <point x="198" y="-10" type="curve" name="hintSet0000"/>
       <point x="244" y="-10" name="hintSet0001"/>
       <point x="286" y="16"/>
-      <point type="curve" x="316" y="46"/>
-      <point type="line" x="318" y="46"/>
-      <point type="line" x="324" y="0" name="hintSet0003"/>
-      <point type="line" x="378" y="0" name="hintSet0004"/>
-      <point type="line" x="378" y="570"/>
-      <point type="line" x="312" y="570"/>
-      <point type="line" x="312" y="420"/>
-      <point type="line" x="315" y="354"/>
+      <point x="316" y="46" type="curve"/>
+      <point x="318" y="46" type="line"/>
+      <point x="324" y="0" type="line" name="hintSet0003"/>
+      <point x="378" y="0" type="line" name="hintSet0004"/>
+      <point x="378" y="570" type="line"/>
+      <point x="312" y="570" type="line"/>
+      <point x="312" y="420" type="line"/>
+      <point x="315" y="354" type="line"/>
       <point x="281" y="382"/>
       <point x="251" y="398"/>
-      <point type="curve" x="206" y="398"/>
+      <point x="206" y="398" type="curve"/>
       <point x="118" y="398"/>
       <point x="38" y="320"/>
-      <point type="curve" x="38" y="194"/>
+      <point x="38" y="194" type="curve"/>
       <point x="38" y="64" name="hintSet0011"/>
       <point x="101" y="-10"/>
     </contour>
     <contour>
-      <point type="curve" x="213" y="46"/>
+      <point x="213" y="46" type="curve"/>
       <point x="145" y="46"/>
       <point x="106" y="102"/>
-      <point type="curve" x="106" y="194"/>
+      <point x="106" y="194" type="curve"/>
       <point x="106" y="283"/>
       <point x="155" y="343"/>
-      <point type="curve" x="218" y="343"/>
+      <point x="218" y="343" type="curve"/>
       <point x="250" y="343"/>
       <point x="279" y="332"/>
-      <point type="curve" x="312" y="302"/>
-      <point type="line" x="312" y="99"/>
+      <point x="312" y="302" type="curve"/>
+      <point x="312" y="99" type="line"/>
       <point x="280" y="63"/>
       <point x="249" y="46"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/dollar.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/dollar.glif
@@ -4,50 +4,50 @@
   <unicode hex="0024"/>
   <outline>
     <contour>
-      <point type="curve" x="196" y="-10" name="hintSet0000"/>
+      <point x="196" y="-10" type="curve" name="hintSet0000"/>
       <point x="289" y="-10"/>
       <point x="350" y="46"/>
-      <point type="curve" x="350" y="132"/>
+      <point x="350" y="132" type="curve"/>
       <point x="350" y="304" name="hintSet0002"/>
       <point x="126" y="272"/>
-      <point type="curve" x="126" y="388"/>
+      <point x="126" y="388" type="curve"/>
       <point x="126" y="434"/>
       <point x="158" y="465"/>
-      <point type="curve" x="206" y="465"/>
+      <point x="206" y="465" type="curve"/>
       <point x="250" y="465"/>
       <point x="274" y="448"/>
-      <point type="curve" x="304" y="419"/>
-      <point type="line" x="339" y="458" name="hintSet0005"/>
+      <point x="304" y="419" type="curve"/>
+      <point x="339" y="458" type="line" name="hintSet0005"/>
       <point x="306" y="493"/>
       <point x="268" y="520"/>
-      <point type="curve" x="205" y="520"/>
+      <point x="205" y="520" type="curve"/>
       <point x="120" y="520"/>
       <point x="62" y="465"/>
-      <point type="curve" x="62" y="385"/>
+      <point x="62" y="385" type="curve"/>
       <point x="62" y="229"/>
       <point x="285" y="257"/>
-      <point type="curve" x="285" y="127"/>
+      <point x="285" y="127" type="curve"/>
       <point x="285" y="78"/>
       <point x="255" y="45"/>
-      <point type="curve" x="196" y="45"/>
+      <point x="196" y="45" type="curve"/>
       <point x="147" y="45"/>
       <point x="106" y="69"/>
-      <point type="curve" x="72" y="98"/>
-      <point type="line" x="42" y="53" name="hintSet0011"/>
+      <point x="72" y="98" type="curve"/>
+      <point x="42" y="53" type="line" name="hintSet0011"/>
       <point x="79" y="18"/>
       <point x="138" y="-10"/>
     </contour>
     <contour>
-      <point type="line" x="178" y="-88"/>
-      <point type="line" x="226" y="-88"/>
-      <point type="line" x="226" y="14"/>
-      <point type="line" x="178" y="14"/>
+      <point x="178" y="-88" type="line"/>
+      <point x="226" y="-88" type="line"/>
+      <point x="226" y="14" type="line"/>
+      <point x="178" y="14" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="178" y="495"/>
-      <point type="line" x="226" y="495"/>
-      <point type="line" x="226" y="598" name="hintSet0019"/>
-      <point type="line" x="178" y="598"/>
+      <point x="178" y="495" type="line"/>
+      <point x="226" y="495" type="line"/>
+      <point x="226" y="598" type="line" name="hintSet0019"/>
+      <point x="178" y="598" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/e.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/e.glif
@@ -7,38 +7,38 @@
   <anchor x="209.60000000000002" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="223" y="-10" name="hintSet0000"/>
+      <point x="223" y="-10" type="curve" name="hintSet0000"/>
       <point x="276" y="-10"/>
       <point x="318" y="9"/>
-      <point type="curve" x="351" y="30"/>
-      <point type="line" x="328" y="74"/>
+      <point x="351" y="30" type="curve"/>
+      <point x="328" y="74" type="line"/>
       <point x="299" y="55"/>
       <point x="268" y="43"/>
-      <point type="curve" x="231" y="43"/>
+      <point x="231" y="43" type="curve"/>
       <point x="157" y="43" name="hintSet0004"/>
       <point x="106" y="96"/>
-      <point type="curve" x="102" y="178"/>
-      <point type="line" x="364" y="178"/>
+      <point x="102" y="178" type="curve"/>
+      <point x="364" y="178" type="line"/>
       <point x="366" y="188"/>
       <point x="366" y="202"/>
-      <point type="curve" x="366" y="216"/>
+      <point x="366" y="216" type="curve"/>
       <point x="366" y="327"/>
       <point x="310" y="398"/>
-      <point type="curve" x="211" y="398"/>
+      <point x="211" y="398" type="curve"/>
       <point x="122" y="398" name="hintSet0008"/>
       <point x="37" y="321"/>
-      <point type="curve" x="37" y="194"/>
+      <point x="37" y="194" type="curve"/>
       <point x="37" y="66"/>
       <point x="119" y="-10"/>
     </contour>
     <contour>
-      <point type="line" x="101" y="226"/>
+      <point x="101" y="226" type="line"/>
       <point x="109" y="302"/>
       <point x="158" y="346"/>
-      <point type="curve" x="213" y="346"/>
+      <point x="213" y="346" type="curve"/>
       <point x="274" y="346"/>
       <point x="309" y="304"/>
-      <point type="curve" x="309" y="226"/>
+      <point x="309" y="226" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/eight.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/eight.glif
@@ -4,58 +4,58 @@
   <unicode hex="0038"/>
   <outline>
     <contour>
-      <point type="curve" x="200" y="-10" name="hintSet0000"/>
+      <point x="200" y="-10" type="curve" name="hintSet0000"/>
       <point x="299" y="-10"/>
       <point x="365" y="50"/>
-      <point type="curve" x="365" y="126"/>
+      <point x="365" y="126" type="curve"/>
       <point x="365" y="195"/>
       <point x="322" y="231"/>
-      <point type="curve" x="276" y="258"/>
-      <point type="line" x="276" y="261"/>
+      <point x="276" y="258" type="curve"/>
+      <point x="276" y="261" type="line"/>
       <point x="307" y="285" name="hintSet0004"/>
       <point x="346" y="330"/>
-      <point type="curve" x="346" y="384"/>
+      <point x="346" y="384" type="curve"/>
       <point x="346" y="463"/>
       <point x="291" y="520"/>
-      <point type="curve" x="202" y="520"/>
+      <point x="202" y="520" type="curve"/>
       <point x="120" y="520"/>
       <point x="58" y="467"/>
-      <point type="curve" x="58" y="389"/>
+      <point x="58" y="389" type="curve"/>
       <point x="58" y="335"/>
       <point x="91" y="298"/>
-      <point type="curve" x="129" y="271"/>
-      <point type="line" x="129" y="268"/>
+      <point x="129" y="271" type="curve"/>
+      <point x="129" y="268" type="line"/>
       <point x="81" y="242" name="hintSet0009"/>
       <point x="33" y="197"/>
-      <point type="curve" x="33" y="130"/>
+      <point x="33" y="130" type="curve"/>
       <point x="33" y="50"/>
       <point x="104" y="-10"/>
     </contour>
     <contour>
-      <point type="curve" x="236" y="278" name="hintSet0011"/>
+      <point x="236" y="278" type="curve" name="hintSet0011"/>
       <point x="174" y="302"/>
       <point x="118" y="328"/>
-      <point type="curve" x="118" y="389"/>
+      <point x="118" y="389" type="curve"/>
       <point x="118" y="438"/>
       <point x="154" y="471"/>
-      <point type="curve" x="201" y="471"/>
+      <point x="201" y="471" type="curve"/>
       <point x="257" y="471"/>
       <point x="290" y="431"/>
-      <point type="curve" x="290" y="381"/>
+      <point x="290" y="381" type="curve"/>
       <point x="290" y="343"/>
       <point x="270" y="309"/>
     </contour>
     <contour>
-      <point type="curve" x="202" y="39" name="hintSet0016"/>
+      <point x="202" y="39" type="curve" name="hintSet0016"/>
       <point x="139" y="39"/>
       <point x="92" y="80"/>
-      <point type="curve" x="92" y="137"/>
+      <point x="92" y="137" type="curve"/>
       <point x="92" y="183"/>
       <point x="122" y="221"/>
-      <point type="curve" x="163" y="248"/>
+      <point x="163" y="248" type="curve"/>
       <point x="237" y="218"/>
       <point x="302" y="194"/>
-      <point type="curve" x="302" y="129"/>
+      <point x="302" y="129" type="curve"/>
       <point x="302" y="76"/>
       <point x="261" y="39"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/exclam.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/exclam.glif
@@ -4,24 +4,24 @@
   <unicode hex="0021"/>
   <outline>
     <contour>
-      <point type="line" x="93" y="158" name="hintSet0000"/>
-      <point type="line" x="138" y="158"/>
-      <point type="line" x="147" y="461"/>
-      <point type="line" x="149" y="536"/>
-      <point type="line" x="82" y="536"/>
-      <point type="line" x="84" y="461"/>
+      <point x="93" y="158" type="line" name="hintSet0000"/>
+      <point x="138" y="158" type="line"/>
+      <point x="147" y="461" type="line"/>
+      <point x="149" y="536" type="line"/>
+      <point x="82" y="536" type="line"/>
+      <point x="84" y="461" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="116" y="-10" name="hintSet0006"/>
+      <point x="116" y="-10" type="curve" name="hintSet0006"/>
       <point x="142" y="-10"/>
       <point x="163" y="11"/>
-      <point type="curve" x="163" y="40"/>
+      <point x="163" y="40" type="curve"/>
       <point x="163" y="70" name="hintSet0008"/>
       <point x="142" y="91"/>
-      <point type="curve" x="116" y="91"/>
+      <point x="116" y="91" type="curve"/>
       <point x="90" y="91"/>
       <point x="68" y="70"/>
-      <point type="curve" x="68" y="40"/>
+      <point x="68" y="40" type="curve"/>
       <point x="68" y="11" name="hintSet0010"/>
       <point x="90" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/f.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/f.glif
@@ -6,29 +6,29 @@
   <anchor x="109.60000000000001" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="77" y="0" name="hintSet0000"/>
-      <point type="line" x="142" y="0"/>
-      <point type="line" x="142" y="450"/>
+      <point x="77" y="0" type="line" name="hintSet0000"/>
+      <point x="142" y="0" type="line"/>
+      <point x="142" y="450" type="line"/>
       <point x="142" y="500"/>
       <point x="160" y="526"/>
-      <point type="curve" x="197" y="526"/>
+      <point x="197" y="526" type="curve"/>
       <point x="211" y="526"/>
       <point x="226" y="522"/>
-      <point type="curve" x="241" y="516"/>
-      <point type="line" x="255" y="566"/>
+      <point x="241" y="516" type="curve"/>
+      <point x="255" y="566" type="line"/>
       <point x="238" y="574"/>
       <point x="214" y="579"/>
-      <point type="curve" x="190" y="579"/>
+      <point x="190" y="579" type="curve"/>
       <point x="113" y="579"/>
       <point x="77" y="530"/>
-      <point type="curve" x="77" y="450"/>
+      <point x="77" y="450" type="curve"/>
     </contour>
     <contour>
-      <point type="line" x="24" y="335" name="hintSet0008"/>
-      <point type="line" x="225" y="335" name="hintSet0009"/>
-      <point type="line" x="225" y="389"/>
-      <point type="line" x="79" y="389" name="hintSet0011"/>
-      <point type="line" x="24" y="385"/>
+      <point x="24" y="335" type="line" name="hintSet0008"/>
+      <point x="225" y="335" type="line" name="hintSet0009"/>
+      <point x="225" y="389" type="line"/>
+      <point x="79" y="389" type="line" name="hintSet0011"/>
+      <point x="24" y="385" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/five.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/five.glif
@@ -4,35 +4,35 @@
   <unicode hex="0035"/>
   <outline>
     <contour>
-      <point type="curve" x="187" y="-10" name="hintSet0000"/>
+      <point x="187" y="-10" type="curve" name="hintSet0000"/>
       <point x="276" y="-10"/>
       <point x="359" y="53"/>
-      <point type="curve" x="359" y="163"/>
+      <point x="359" y="163" type="curve"/>
       <point x="359" y="274"/>
       <point x="288" y="323"/>
-      <point type="curve" x="201" y="323"/>
+      <point x="201" y="323" type="curve"/>
       <point x="170" y="323"/>
       <point x="146" y="315"/>
-      <point type="curve" x="122" y="302"/>
-      <point type="line" x="136" y="454"/>
-      <point type="line" x="334" y="454"/>
-      <point type="line" x="334" y="510"/>
-      <point type="line" x="78" y="510"/>
-      <point type="line" x="62" y="265"/>
-      <point type="line" x="97" y="242"/>
+      <point x="122" y="302" type="curve"/>
+      <point x="136" y="454" type="line"/>
+      <point x="334" y="454" type="line"/>
+      <point x="334" y="510" type="line"/>
+      <point x="78" y="510" type="line"/>
+      <point x="62" y="265" type="line"/>
+      <point x="97" y="242" type="line"/>
       <point x="127" y="262"/>
       <point x="149" y="274"/>
-      <point type="curve" x="184" y="274"/>
+      <point x="184" y="274" type="curve"/>
       <point x="250" y="274"/>
       <point x="293" y="232"/>
-      <point type="curve" x="293" y="162"/>
+      <point x="293" y="162" type="curve"/>
       <point x="293" y="90"/>
       <point x="243" y="45"/>
-      <point type="curve" x="181" y="45"/>
+      <point x="181" y="45" type="curve"/>
       <point x="121" y="45"/>
       <point x="82" y="73"/>
-      <point type="curve" x="52" y="103"/>
-      <point type="line" x="20" y="60"/>
+      <point x="52" y="103" type="curve"/>
+      <point x="20" y="60" type="line"/>
       <point x="55" y="25"/>
       <point x="106" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/four.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/four.glif
@@ -4,23 +4,23 @@
   <unicode hex="0034"/>
   <outline>
     <contour>
-      <point type="line" x="243" y="0" name="hintSet0000"/>
-      <point type="line" x="306" y="0"/>
-      <point type="line" x="306" y="510"/>
-      <point type="line" x="232" y="510"/>
-      <point type="line" x="14" y="184" name="hintSet0004"/>
-      <point type="line" x="14" y="141"/>
-      <point type="line" x="375" y="141"/>
-      <point type="line" x="375" y="194"/>
-      <point type="line" x="83" y="194"/>
-      <point type="line" x="202" y="368" name="hintSet0009"/>
+      <point x="243" y="0" type="line" name="hintSet0000"/>
+      <point x="306" y="0" type="line"/>
+      <point x="306" y="510" type="line"/>
+      <point x="232" y="510" type="line"/>
+      <point x="14" y="184" type="line" name="hintSet0004"/>
+      <point x="14" y="141" type="line"/>
+      <point x="375" y="141" type="line"/>
+      <point x="375" y="194" type="line"/>
+      <point x="83" y="194" type="line"/>
+      <point x="202" y="368" type="line" name="hintSet0009"/>
       <point x="217" y="393"/>
       <point x="231" y="415"/>
-      <point type="curve" x="244" y="440"/>
-      <point type="line" x="247" y="440"/>
+      <point x="244" y="440" type="curve"/>
+      <point x="247" y="440" type="line"/>
       <point x="246" y="413"/>
       <point x="243" y="369"/>
-      <point type="curve" x="243" y="342"/>
+      <point x="243" y="342" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/g.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/g.glif
@@ -6,84 +6,84 @@
   <anchor x="200.0" y="-184.0" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="197" y="-179" name="hintSet0000"/>
+      <point x="197" y="-179" type="curve" name="hintSet0000"/>
       <point x="318" y="-179"/>
       <point x="394" y="-117"/>
-      <point type="curve" x="394" y="-45"/>
+      <point x="394" y="-45" type="curve"/>
       <point x="394" y="20"/>
       <point x="348" y="48"/>
-      <point type="curve" x="258" y="48"/>
-      <point type="line" x="182" y="48" name="hintSet0003"/>
+      <point x="258" y="48" type="curve"/>
+      <point x="182" y="48" type="line" name="hintSet0003"/>
       <point x="130" y="48"/>
       <point x="114" y="66"/>
-      <point type="curve" x="114" y="90"/>
+      <point x="114" y="90" type="curve"/>
       <point x="114" y="112"/>
       <point x="125" y="125"/>
-      <point type="curve" x="138" y="137"/>
+      <point x="138" y="137" type="curve"/>
       <point x="156" y="128"/>
       <point x="178" y="123"/>
-      <point type="curve" x="197" y="123"/>
+      <point x="197" y="123" type="curve"/>
       <point x="276" y="123"/>
       <point x="339" y="175"/>
-      <point type="curve" x="339" y="258"/>
+      <point x="339" y="258" type="curve"/>
       <point x="339" y="291"/>
       <point x="326" y="321"/>
-      <point type="curve" x="307" y="338"/>
-      <point type="line" x="387" y="338"/>
-      <point type="line" x="387" y="389"/>
-      <point type="line" x="252" y="389"/>
+      <point x="307" y="338" type="curve"/>
+      <point x="387" y="338" type="line"/>
+      <point x="387" y="389" type="line"/>
+      <point x="252" y="389" type="line"/>
       <point x="238" y="394"/>
       <point x="218" y="398"/>
-      <point type="curve" x="197" y="398"/>
+      <point x="197" y="398" type="curve"/>
       <point x="118" y="398" name="hintSet0013"/>
       <point x="50" y="345"/>
-      <point type="curve" x="50" y="260"/>
+      <point x="50" y="260" type="curve"/>
       <point x="50" y="214"/>
       <point x="75" y="176"/>
-      <point type="curve" x="101" y="155"/>
-      <point type="line" x="101" y="152"/>
+      <point x="101" y="155" type="curve"/>
+      <point x="101" y="152" type="line"/>
       <point x="81" y="138" name="hintSet0016"/>
       <point x="58" y="113"/>
-      <point type="curve" x="58" y="80"/>
+      <point x="58" y="80" type="curve"/>
       <point x="58" y="50"/>
       <point x="74" y="29"/>
-      <point type="curve" x="93" y="17"/>
-      <point type="line" x="93" y="14"/>
+      <point x="93" y="17" type="curve"/>
+      <point x="93" y="14" type="line"/>
       <point x="58" y="-10" name="hintSet0019"/>
       <point x="36" y="-42"/>
-      <point type="curve" x="36" y="-74"/>
+      <point x="36" y="-74" type="curve"/>
       <point x="36" y="-142" name="hintSet0020"/>
       <point x="102" y="-179"/>
     </contour>
     <contour>
-      <point type="curve" x="197" y="167" name="hintSet0021"/>
+      <point x="197" y="167" type="curve" name="hintSet0021"/>
       <point x="152" y="167"/>
       <point x="114" y="203"/>
-      <point type="curve" x="114" y="260"/>
+      <point x="114" y="260" type="curve"/>
       <point x="114" y="317"/>
       <point x="151" y="350"/>
-      <point type="curve" x="197" y="350"/>
+      <point x="197" y="350" type="curve"/>
       <point x="242" y="350"/>
       <point x="279" y="317"/>
-      <point type="curve" x="279" y="260"/>
+      <point x="279" y="260" type="curve"/>
       <point x="279" y="203"/>
       <point x="242" y="167"/>
     </contour>
     <contour>
-      <point type="curve" x="206" y="-134" name="hintSet0026"/>
+      <point x="206" y="-134" type="curve" name="hintSet0026"/>
       <point x="136" y="-134"/>
       <point x="94" y="-107"/>
-      <point type="curve" x="94" y="-66"/>
+      <point x="94" y="-66" type="curve"/>
       <point x="94" y="-43"/>
       <point x="106" y="-20"/>
-      <point type="curve" x="134" y="0"/>
+      <point x="134" y="0" type="curve"/>
       <point x="150" y="-5" name="hintSet0029"/>
       <point x="169" y="-6"/>
-      <point type="curve" x="184" y="-6"/>
-      <point type="line" x="251" y="-6"/>
+      <point x="184" y="-6" type="curve"/>
+      <point x="251" y="-6" type="line"/>
       <point x="302" y="-6"/>
       <point x="330" y="-18"/>
-      <point type="curve" x="330" y="-54"/>
+      <point x="330" y="-54" type="curve"/>
       <point x="330" y="-95" name="hintSet0032"/>
       <point x="281" y="-134"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/greater.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/greater.glif
@@ -4,16 +4,16 @@
   <unicode hex="003E"/>
   <outline>
     <contour>
-      <point type="line" x="27" y="105" name="hintSet0000"/>
-      <point type="line" x="370" y="239"/>
-      <point type="line" x="370" y="292"/>
-      <point type="line" x="27" y="426"/>
-      <point type="line" x="27" y="370"/>
-      <point type="line" x="196" y="307"/>
-      <point type="line" x="303" y="267"/>
-      <point type="line" x="303" y="264"/>
-      <point type="line" x="196" y="224"/>
-      <point type="line" x="27" y="162"/>
+      <point x="27" y="105" type="line" name="hintSet0000"/>
+      <point x="370" y="239" type="line"/>
+      <point x="370" y="292" type="line"/>
+      <point x="27" y="426" type="line"/>
+      <point x="27" y="370" type="line"/>
+      <point x="196" y="307" type="line"/>
+      <point x="303" y="267" type="line"/>
+      <point x="303" y="264" type="line"/>
+      <point x="196" y="224" type="line"/>
+      <point x="27" y="162" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/h.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/h.glif
@@ -6,27 +6,27 @@
   <anchor x="228.8" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="66" y="0" name="hintSet0000"/>
-      <point type="line" x="131" y="0"/>
-      <point type="line" x="131" y="282"/>
+      <point x="66" y="0" type="line" name="hintSet0000"/>
+      <point x="131" y="0" type="line"/>
+      <point x="131" y="282" type="line"/>
       <point x="170" y="321"/>
       <point x="198" y="342"/>
-      <point type="curve" x="238" y="342"/>
+      <point x="238" y="342" type="curve"/>
       <point x="289" y="342"/>
       <point x="311" y="310"/>
-      <point type="curve" x="311" y="238"/>
-      <point type="line" x="311" y="0"/>
-      <point type="line" x="377" y="0"/>
-      <point type="line" x="377" y="246"/>
+      <point x="311" y="238" type="curve"/>
+      <point x="311" y="0" type="line"/>
+      <point x="377" y="0" type="line"/>
+      <point x="377" y="246" type="line"/>
       <point x="377" y="346"/>
       <point x="340" y="398"/>
-      <point type="curve" x="258" y="398"/>
+      <point x="258" y="398" type="curve"/>
       <point x="205" y="398"/>
       <point x="166" y="370"/>
-      <point type="curve" x="129" y="334"/>
-      <point type="line" x="131" y="414"/>
-      <point type="line" x="131" y="570"/>
-      <point type="line" x="66" y="570"/>
+      <point x="129" y="334" type="curve"/>
+      <point x="131" y="414" type="line"/>
+      <point x="131" y="570" type="line"/>
+      <point x="66" y="570" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/hyphen.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/hyphen.glif
@@ -4,10 +4,10 @@
   <unicode hex="002D"/>
   <outline>
     <contour>
-      <point type="line" x="33" y="175" name="hintSet0000"/>
-      <point type="line" x="217" y="175"/>
-      <point type="line" x="217" y="226"/>
-      <point type="line" x="33" y="226"/>
+      <point x="33" y="175" type="line" name="hintSet0000"/>
+      <point x="217" y="175" type="line"/>
+      <point x="217" y="226" type="line"/>
+      <point x="33" y="226" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/i.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/i.glif
@@ -7,22 +7,22 @@
   <anchor x="98.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="66" y="0" name="hintSet0000"/>
-      <point type="line" x="131" y="0"/>
-      <point type="line" x="131" y="389"/>
-      <point type="line" x="66" y="389"/>
+      <point x="66" y="0" type="line" name="hintSet0000"/>
+      <point x="131" y="0" type="line"/>
+      <point x="131" y="389" type="line"/>
+      <point x="66" y="389" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="99" y="469" name="hintSet0004"/>
+      <point x="99" y="469" type="curve" name="hintSet0004"/>
       <point x="125" y="469"/>
       <point x="145" y="486"/>
-      <point type="curve" x="145" y="511"/>
+      <point x="145" y="511" type="curve"/>
       <point x="145" y="537"/>
       <point x="125" y="554"/>
-      <point type="curve" x="99" y="554"/>
+      <point x="99" y="554" type="curve"/>
       <point x="74" y="554"/>
       <point x="54" y="537"/>
-      <point type="curve" x="54" y="511"/>
+      <point x="54" y="511" type="curve"/>
       <point x="54" y="486"/>
       <point x="74" y="469"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/j.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/j.glif
@@ -6,34 +6,34 @@
   <anchor x="47.2" y="-184.8" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="26" y="-174" name="hintSet0000"/>
+      <point x="26" y="-174" type="curve" name="hintSet0000"/>
       <point x="103" y="-174"/>
       <point x="132" y="-123"/>
-      <point type="curve" x="132" y="-44"/>
-      <point type="line" x="132" y="389"/>
-      <point type="line" x="66" y="389"/>
-      <point type="line" x="66" y="-44"/>
+      <point x="132" y="-44" type="curve"/>
+      <point x="132" y="389" type="line"/>
+      <point x="66" y="389" type="line"/>
+      <point x="66" y="-44" type="line"/>
       <point x="66" y="-91"/>
       <point x="57" y="-120"/>
-      <point type="curve" x="18" y="-120"/>
+      <point x="18" y="-120" type="curve"/>
       <point x="5" y="-120"/>
       <point x="-9" y="-117"/>
-      <point type="curve" x="-18" y="-114"/>
-      <point type="line" x="-32" y="-163"/>
+      <point x="-18" y="-114" type="curve"/>
+      <point x="-32" y="-163" type="line"/>
       <point x="-18" y="-169"/>
       <point x="2" y="-174"/>
     </contour>
     <contour>
-      <point type="curve" x="100" y="469" name="hintSet0009"/>
+      <point x="100" y="469" type="curve" name="hintSet0009"/>
       <point x="125" y="469"/>
       <point x="145" y="486"/>
-      <point type="curve" x="145" y="511"/>
+      <point x="145" y="511" type="curve"/>
       <point x="145" y="537"/>
       <point x="125" y="554"/>
-      <point type="curve" x="100" y="554"/>
+      <point x="100" y="554" type="curve"/>
       <point x="74" y="554"/>
       <point x="54" y="537"/>
-      <point type="curve" x="54" y="511"/>
+      <point x="54" y="511" type="curve"/>
       <point x="54" y="486"/>
       <point x="74" y="469"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/k.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/k.glif
@@ -6,19 +6,19 @@
   <anchor x="216.8" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="66" y="0" name="hintSet0000"/>
-      <point type="line" x="130" y="0"/>
-      <point type="line" x="130" y="102"/>
-      <point type="line" x="203" y="187"/>
-      <point type="line" x="317" y="0"/>
-      <point type="line" x="389" y="0"/>
-      <point type="line" x="241" y="233"/>
-      <point type="line" x="371" y="389"/>
-      <point type="line" x="298" y="389"/>
-      <point type="line" x="133" y="184"/>
-      <point type="line" x="130" y="184"/>
-      <point type="line" x="130" y="570"/>
-      <point type="line" x="66" y="570"/>
+      <point x="66" y="0" type="line" name="hintSet0000"/>
+      <point x="130" y="0" type="line"/>
+      <point x="130" y="102" type="line"/>
+      <point x="203" y="187" type="line"/>
+      <point x="317" y="0" type="line"/>
+      <point x="389" y="0" type="line"/>
+      <point x="241" y="233" type="line"/>
+      <point x="371" y="389" type="line"/>
+      <point x="298" y="389" type="line"/>
+      <point x="133" y="184" type="line"/>
+      <point x="130" y="184" type="line"/>
+      <point x="130" y="570" type="line"/>
+      <point x="66" y="570" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/l.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/l.glif
@@ -6,20 +6,20 @@
   <anchor x="109.60000000000001" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="135" y="-10" name="hintSet0000"/>
+      <point x="135" y="-10" type="curve" name="hintSet0000"/>
       <point x="153" y="-10"/>
       <point x="164" y="-7"/>
-      <point type="curve" x="173" y="-3"/>
-      <point type="line" x="164" y="46"/>
+      <point x="173" y="-3" type="curve"/>
+      <point x="164" y="46" type="line"/>
       <point x="157" y="45"/>
       <point x="154" y="45"/>
-      <point type="curve" x="150" y="45"/>
+      <point x="150" y="45" type="curve"/>
       <point x="140" y="45"/>
       <point x="131" y="53"/>
-      <point type="curve" x="131" y="74"/>
-      <point type="line" x="131" y="570"/>
-      <point type="line" x="66" y="570"/>
-      <point type="line" x="66" y="78"/>
+      <point x="131" y="74" type="curve"/>
+      <point x="131" y="570" type="line"/>
+      <point x="66" y="570" type="line"/>
+      <point x="66" y="78" type="line"/>
       <point x="66" y="22"/>
       <point x="86" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/less.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/less.glif
@@ -4,16 +4,16 @@
   <unicode hex="003C"/>
   <outline>
     <contour>
-      <point type="line" x="370" y="105" name="hintSet0000"/>
-      <point type="line" x="370" y="162"/>
-      <point type="line" x="202" y="224"/>
-      <point type="line" x="94" y="264"/>
-      <point type="line" x="94" y="267"/>
-      <point type="line" x="202" y="307"/>
-      <point type="line" x="370" y="370"/>
-      <point type="line" x="370" y="426"/>
-      <point type="line" x="27" y="292"/>
-      <point type="line" x="27" y="239"/>
+      <point x="370" y="105" type="line" name="hintSet0000"/>
+      <point x="370" y="162" type="line"/>
+      <point x="202" y="224" type="line"/>
+      <point x="94" y="264" type="line"/>
+      <point x="94" y="267" type="line"/>
+      <point x="202" y="307" type="line"/>
+      <point x="370" y="370" type="line"/>
+      <point x="370" y="426" type="line"/>
+      <point x="27" y="292" type="line"/>
+      <point x="27" y="239" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/m.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/m.glif
@@ -6,42 +6,42 @@
   <anchor x="340.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="66" y="0" name="hintSet0000"/>
-      <point type="line" x="131" y="0"/>
-      <point type="line" x="131" y="282"/>
+      <point x="66" y="0" type="line" name="hintSet0000"/>
+      <point x="131" y="0" type="line"/>
+      <point x="131" y="282" type="line"/>
       <point x="167" y="322"/>
       <point x="200" y="342"/>
-      <point type="curve" x="229" y="342"/>
+      <point x="229" y="342" type="curve"/>
       <point x="278" y="342"/>
       <point x="302" y="310"/>
-      <point type="curve" x="302" y="238"/>
-      <point type="line" x="302" y="0"/>
-      <point type="line" x="367" y="0"/>
-      <point type="line" x="367" y="282"/>
+      <point x="302" y="238" type="curve"/>
+      <point x="302" y="0" type="line"/>
+      <point x="367" y="0" type="line"/>
+      <point x="367" y="282" type="line"/>
       <point x="403" y="322"/>
       <point x="434" y="342"/>
-      <point type="curve" x="465" y="342"/>
+      <point x="465" y="342" type="curve"/>
       <point x="514" y="342"/>
       <point x="537" y="310"/>
-      <point type="curve" x="537" y="238"/>
-      <point type="line" x="537" y="0"/>
-      <point type="line" x="602" y="0"/>
-      <point type="line" x="602" y="246"/>
+      <point x="537" y="238" type="curve"/>
+      <point x="537" y="0" type="line"/>
+      <point x="602" y="0" type="line"/>
+      <point x="602" y="246" type="line"/>
       <point x="602" y="346"/>
       <point x="564" y="398"/>
-      <point type="curve" x="484" y="398"/>
+      <point x="484" y="398" type="curve"/>
       <point x="437" y="398"/>
       <point x="397" y="368"/>
-      <point type="curve" x="356" y="324"/>
+      <point x="356" y="324" type="curve"/>
       <point x="340" y="370"/>
       <point x="308" y="398"/>
-      <point type="curve" x="249" y="398"/>
+      <point x="249" y="398" type="curve"/>
       <point x="202" y="398" name="hintSet0016"/>
       <point x="162" y="370"/>
-      <point type="curve" x="128" y="333"/>
-      <point type="line" x="126" y="333"/>
-      <point type="line" x="120" y="389"/>
-      <point type="line" x="66" y="389" name="hintSet0019"/>
+      <point x="128" y="333" type="curve"/>
+      <point x="126" y="333" type="line"/>
+      <point x="120" y="389" type="line"/>
+      <point x="66" y="389" type="line" name="hintSet0019"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/n.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/n.glif
@@ -6,27 +6,27 @@
   <anchor x="222.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="66" y="0" name="hintSet0000"/>
-      <point type="line" x="131" y="0"/>
-      <point type="line" x="131" y="282"/>
+      <point x="66" y="0" type="line" name="hintSet0000"/>
+      <point x="131" y="0" type="line"/>
+      <point x="131" y="282" type="line"/>
       <point x="170" y="321"/>
       <point x="198" y="342"/>
-      <point type="curve" x="238" y="342"/>
+      <point x="238" y="342" type="curve"/>
       <point x="289" y="342"/>
       <point x="311" y="310"/>
-      <point type="curve" x="311" y="238"/>
-      <point type="line" x="311" y="0"/>
-      <point type="line" x="377" y="0"/>
-      <point type="line" x="377" y="246"/>
+      <point x="311" y="238" type="curve"/>
+      <point x="311" y="0" type="line"/>
+      <point x="377" y="0" type="line"/>
+      <point x="377" y="246" type="line"/>
       <point x="377" y="346"/>
       <point x="340" y="398"/>
-      <point type="curve" x="258" y="398"/>
+      <point x="258" y="398" type="curve"/>
       <point x="205" y="398" name="hintSet0009"/>
       <point x="165" y="370"/>
-      <point type="curve" x="128" y="333"/>
-      <point type="line" x="126" y="333"/>
-      <point type="line" x="120" y="389"/>
-      <point type="line" x="66" y="389" name="hintSet0012"/>
+      <point x="128" y="333" type="curve"/>
+      <point x="126" y="333" type="line"/>
+      <point x="120" y="389" type="line"/>
+      <point x="66" y="389" type="line" name="hintSet0012"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/nine.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/nine.glif
@@ -4,42 +4,42 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point type="curve" x="164" y="-10" name="hintSet0000"/>
+      <point x="164" y="-10" type="curve" name="hintSet0000"/>
       <point x="266" y="-10"/>
       <point x="358" y="70"/>
-      <point type="curve" x="358" y="274"/>
+      <point x="358" y="274" type="curve"/>
       <point x="358" y="438"/>
       <point x="283" y="520"/>
-      <point type="curve" x="182" y="520"/>
+      <point x="182" y="520" type="curve"/>
       <point x="101" y="520"/>
       <point x="32" y="454"/>
-      <point type="curve" x="32" y="356"/>
+      <point x="32" y="356" type="curve"/>
       <point x="32" y="251"/>
       <point x="89" y="198"/>
-      <point type="curve" x="177" y="198"/>
+      <point x="177" y="198" type="curve"/>
       <point x="221" y="198"/>
       <point x="268" y="225"/>
-      <point type="curve" x="300" y="268"/>
-      <point type="line" x="298" y="320"/>
+      <point x="300" y="268" type="curve"/>
+      <point x="298" y="320" type="line"/>
       <point x="262" y="268"/>
       <point x="222" y="248"/>
-      <point type="curve" x="188" y="248"/>
+      <point x="188" y="248" type="curve"/>
       <point x="125" y="248"/>
       <point x="94" y="290"/>
-      <point type="curve" x="94" y="356"/>
+      <point x="94" y="356" type="curve"/>
       <point x="94" y="423"/>
       <point x="133" y="468"/>
-      <point type="curve" x="182" y="468"/>
+      <point x="182" y="468" type="curve"/>
       <point x="256" y="468"/>
       <point x="297" y="400"/>
-      <point type="curve" x="297" y="274"/>
+      <point x="297" y="274" type="curve"/>
       <point x="297" y="103"/>
       <point x="235" y="45"/>
-      <point type="curve" x="162" y="45"/>
+      <point x="162" y="45" type="curve"/>
       <point x="130" y="45"/>
       <point x="98" y="61"/>
-      <point type="curve" x="78" y="86"/>
-      <point type="line" x="41" y="44"/>
+      <point x="78" y="86" type="curve"/>
+      <point x="41" y="44" type="line"/>
       <point x="69" y="14"/>
       <point x="110" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/numbersign.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/numbersign.glif
@@ -4,40 +4,40 @@
   <unicode hex="0023"/>
   <outline>
     <contour>
-      <point type="line" x="72" y="0" name="hintSet0000"/>
-      <point type="line" x="115" y="0"/>
-      <point type="line" x="135" y="163"/>
-      <point type="line" x="241" y="163"/>
-      <point type="line" x="222" y="0"/>
-      <point type="line" x="264" y="0"/>
-      <point type="line" x="284" y="163"/>
-      <point type="line" x="358" y="163"/>
-      <point type="line" x="358" y="209"/>
-      <point type="line" x="290" y="209"/>
-      <point type="line" x="304" y="327"/>
-      <point type="line" x="374" y="327"/>
-      <point type="line" x="374" y="374"/>
-      <point type="line" x="309" y="374"/>
-      <point type="line" x="328" y="520" name="hintSet0014"/>
-      <point type="line" x="286" y="520"/>
-      <point type="line" x="266" y="374" name="hintSet0016"/>
-      <point type="line" x="160" y="374"/>
-      <point type="line" x="178" y="520" name="hintSet0018"/>
-      <point type="line" x="136" y="520"/>
-      <point type="line" x="118" y="374" name="hintSet0020"/>
-      <point type="line" x="44" y="374"/>
-      <point type="line" x="44" y="327"/>
-      <point type="line" x="112" y="327"/>
-      <point type="line" x="98" y="209"/>
-      <point type="line" x="28" y="209"/>
-      <point type="line" x="28" y="163"/>
-      <point type="line" x="92" y="163"/>
+      <point x="72" y="0" type="line" name="hintSet0000"/>
+      <point x="115" y="0" type="line"/>
+      <point x="135" y="163" type="line"/>
+      <point x="241" y="163" type="line"/>
+      <point x="222" y="0" type="line"/>
+      <point x="264" y="0" type="line"/>
+      <point x="284" y="163" type="line"/>
+      <point x="358" y="163" type="line"/>
+      <point x="358" y="209" type="line"/>
+      <point x="290" y="209" type="line"/>
+      <point x="304" y="327" type="line"/>
+      <point x="374" y="327" type="line"/>
+      <point x="374" y="374" type="line"/>
+      <point x="309" y="374" type="line"/>
+      <point x="328" y="520" type="line" name="hintSet0014"/>
+      <point x="286" y="520" type="line"/>
+      <point x="266" y="374" type="line" name="hintSet0016"/>
+      <point x="160" y="374" type="line"/>
+      <point x="178" y="520" type="line" name="hintSet0018"/>
+      <point x="136" y="520" type="line"/>
+      <point x="118" y="374" type="line" name="hintSet0020"/>
+      <point x="44" y="374" type="line"/>
+      <point x="44" y="327" type="line"/>
+      <point x="112" y="327" type="line"/>
+      <point x="98" y="209" type="line"/>
+      <point x="28" y="209" type="line"/>
+      <point x="28" y="163" type="line"/>
+      <point x="92" y="163" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="141" y="209"/>
-      <point type="line" x="155" y="327"/>
-      <point type="line" x="261" y="327"/>
-      <point type="line" x="246" y="209"/>
+      <point x="141" y="209" type="line"/>
+      <point x="155" y="327" type="line"/>
+      <point x="261" y="327" type="line"/>
+      <point x="246" y="209" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/o.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/o.glif
@@ -8,30 +8,30 @@
   <anchor x="216.8" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="217" y="-10" name="hintSet0000"/>
+      <point x="217" y="-10" type="curve" name="hintSet0000"/>
       <point x="312" y="-10"/>
       <point x="397" y="65"/>
-      <point type="curve" x="397" y="194"/>
+      <point x="397" y="194" type="curve"/>
       <point x="397" y="324"/>
       <point x="312" y="398"/>
-      <point type="curve" x="217" y="398"/>
+      <point x="217" y="398" type="curve"/>
       <point x="122" y="398"/>
       <point x="37" y="324"/>
-      <point type="curve" x="37" y="194"/>
+      <point x="37" y="194" type="curve"/>
       <point x="37" y="65"/>
       <point x="122" y="-10"/>
     </contour>
     <contour>
-      <point type="curve" x="217" y="45"/>
+      <point x="217" y="45" type="curve"/>
       <point x="150" y="45"/>
       <point x="105" y="105"/>
-      <point type="curve" x="105" y="194"/>
+      <point x="105" y="194" type="curve"/>
       <point x="105" y="283"/>
       <point x="150" y="344"/>
-      <point type="curve" x="217" y="344"/>
+      <point x="217" y="344" type="curve"/>
       <point x="284" y="344"/>
       <point x="329" y="283"/>
-      <point type="curve" x="329" y="194"/>
+      <point x="329" y="194" type="curve"/>
       <point x="329" y="105"/>
       <point x="284" y="45"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/one.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/one.glif
@@ -4,19 +4,19 @@
   <unicode hex="0031"/>
   <outline>
     <contour>
-      <point type="line" x="63" y="0" name="hintSet0000"/>
-      <point type="line" x="351" y="0" name="hintSet0001"/>
-      <point type="line" x="351" y="54"/>
-      <point type="line" x="246" y="54" name="hintSet0003"/>
-      <point type="line" x="246" y="510"/>
-      <point type="line" x="195" y="510"/>
+      <point x="63" y="0" type="line" name="hintSet0000"/>
+      <point x="351" y="0" type="line" name="hintSet0001"/>
+      <point x="351" y="54" type="line"/>
+      <point x="246" y="54" type="line" name="hintSet0003"/>
+      <point x="246" y="510" type="line"/>
+      <point x="195" y="510" type="line"/>
       <point x="167" y="494"/>
       <point x="134" y="481"/>
-      <point type="curve" x="87" y="473"/>
-      <point type="line" x="87" y="430"/>
-      <point type="line" x="180" y="430"/>
-      <point type="line" x="180" y="54"/>
-      <point type="line" x="63" y="54"/>
+      <point x="87" y="473" type="curve"/>
+      <point x="87" y="430" type="line"/>
+      <point x="180" y="430" type="line"/>
+      <point x="180" y="54" type="line"/>
+      <point x="63" y="54" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/p.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/p.glif
@@ -6,38 +6,38 @@
   <anchor x="93.60000000000001" y="-174.4" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="66" y="-164" name="hintSet0000"/>
-      <point type="line" x="131" y="-164"/>
-      <point type="line" x="131" y="-33"/>
-      <point type="line" x="130" y="35"/>
+      <point x="66" y="-164" type="line" name="hintSet0000"/>
+      <point x="131" y="-164" type="line"/>
+      <point x="131" y="-33" type="line"/>
+      <point x="130" y="35" type="line"/>
       <point x="166" y="7"/>
       <point x="202" y="-10"/>
-      <point type="curve" x="238" y="-10"/>
+      <point x="238" y="-10" type="curve"/>
       <point x="326" y="-10"/>
       <point x="406" y="68"/>
-      <point type="curve" x="406" y="200"/>
+      <point x="406" y="200" type="curve"/>
       <point x="406" y="321"/>
       <point x="352" y="398"/>
-      <point type="curve" x="252" y="398"/>
+      <point x="252" y="398" type="curve"/>
       <point x="206" y="398" name="hintSet0007"/>
       <point x="163" y="374"/>
-      <point type="curve" x="128" y="344"/>
-      <point type="line" x="126" y="344"/>
-      <point type="line" x="120" y="389"/>
-      <point type="line" x="66" y="389" name="hintSet0010"/>
+      <point x="128" y="344" type="curve"/>
+      <point x="126" y="344" type="line"/>
+      <point x="120" y="389" type="line"/>
+      <point x="66" y="389" type="line" name="hintSet0010"/>
     </contour>
     <contour>
-      <point type="curve" x="226" y="46"/>
+      <point x="226" y="46" type="curve"/>
       <point x="201" y="46"/>
       <point x="166" y="57"/>
-      <point type="curve" x="131" y="86"/>
-      <point type="line" x="131" y="290"/>
+      <point x="131" y="86" type="curve"/>
+      <point x="131" y="290" type="line"/>
       <point x="170" y="325"/>
       <point x="202" y="343"/>
-      <point type="curve" x="235" y="343"/>
+      <point x="235" y="343" type="curve"/>
       <point x="309" y="343"/>
       <point x="338" y="286"/>
-      <point type="curve" x="338" y="200"/>
+      <point x="338" y="200" type="curve"/>
       <point x="338" y="104"/>
       <point x="290" y="46"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/parenleft.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/parenleft.glif
@@ -4,18 +4,18 @@
   <unicode hex="0028"/>
   <outline>
     <contour>
-      <point type="curve" x="171" y="-141" name="hintSet0000"/>
-      <point type="line" x="212" y="-122"/>
+      <point x="171" y="-141" type="curve" name="hintSet0000"/>
+      <point x="212" y="-122" type="line"/>
       <point x="150" y="-20"/>
       <point x="120" y="101"/>
-      <point type="curve" x="120" y="222"/>
+      <point x="120" y="222" type="curve"/>
       <point x="120" y="344"/>
       <point x="150" y="465"/>
-      <point type="curve" x="212" y="566"/>
-      <point type="line" x="171" y="586"/>
+      <point x="212" y="566" type="curve"/>
+      <point x="171" y="586" type="line"/>
       <point x="105" y="478"/>
       <point x="66" y="363"/>
-      <point type="curve" x="66" y="222"/>
+      <point x="66" y="222" type="curve"/>
       <point x="66" y="82"/>
       <point x="105" y="-34"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/parenright.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/parenright.glif
@@ -4,20 +4,20 @@
   <unicode hex="0029"/>
   <outline>
     <contour>
-      <point type="line" x="71" y="-141" name="hintSet0000"/>
+      <point x="71" y="-141" type="line" name="hintSet0000"/>
       <point x="138" y="-34"/>
       <point x="177" y="82"/>
-      <point type="curve" x="177" y="222"/>
+      <point x="177" y="222" type="curve"/>
       <point x="177" y="363"/>
       <point x="138" y="478"/>
-      <point type="curve" x="71" y="586"/>
-      <point type="line" x="30" y="566"/>
+      <point x="71" y="586" type="curve"/>
+      <point x="30" y="566" type="line"/>
       <point x="92" y="465"/>
       <point x="122" y="344"/>
-      <point type="curve" x="122" y="222"/>
+      <point x="122" y="222" type="curve"/>
       <point x="122" y="101"/>
       <point x="92" y="-20"/>
-      <point type="curve" x="30" y="-122"/>
+      <point x="30" y="-122" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/period.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/period.glif
@@ -4,16 +4,16 @@
   <unicode hex="002E"/>
   <outline>
     <contour>
-      <point type="curve" x="100" y="-10" name="hintSet0000"/>
+      <point x="100" y="-10" type="curve" name="hintSet0000"/>
       <point x="126" y="-10"/>
       <point x="147" y="11"/>
-      <point type="curve" x="147" y="40"/>
+      <point x="147" y="40" type="curve"/>
       <point x="147" y="70" name="hintSet0002"/>
       <point x="126" y="91"/>
-      <point type="curve" x="100" y="91"/>
+      <point x="100" y="91" type="curve"/>
       <point x="74" y="91"/>
       <point x="52" y="70"/>
-      <point type="curve" x="52" y="40"/>
+      <point x="52" y="40" type="curve"/>
       <point x="52" y="11" name="hintSet0004"/>
       <point x="74" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/plus.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/plus.glif
@@ -4,18 +4,18 @@
   <unicode hex="002B"/>
   <outline>
     <contour>
-      <point type="line" x="173" y="83" name="hintSet0000"/>
-      <point type="line" x="225" y="83"/>
-      <point type="line" x="225" y="239"/>
-      <point type="line" x="370" y="239"/>
-      <point type="line" x="370" y="289"/>
-      <point type="line" x="225" y="289"/>
-      <point type="line" x="225" y="445"/>
-      <point type="line" x="173" y="445"/>
-      <point type="line" x="173" y="289"/>
-      <point type="line" x="27" y="289"/>
-      <point type="line" x="27" y="239"/>
-      <point type="line" x="173" y="239"/>
+      <point x="173" y="83" type="line" name="hintSet0000"/>
+      <point x="225" y="83" type="line"/>
+      <point x="225" y="239" type="line"/>
+      <point x="370" y="239" type="line"/>
+      <point x="370" y="289" type="line"/>
+      <point x="225" y="289" type="line"/>
+      <point x="225" y="445" type="line"/>
+      <point x="173" y="445" type="line"/>
+      <point x="173" y="289" type="line"/>
+      <point x="27" y="289" type="line"/>
+      <point x="27" y="239" type="line"/>
+      <point x="173" y="239" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/q.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/q.glif
@@ -6,38 +6,38 @@
   <anchor x="340.8" y="-174.4" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="312" y="-164" name="hintSet0000"/>
-      <point type="line" x="378" y="-164"/>
-      <point type="line" x="378" y="389"/>
-      <point type="line" x="326" y="389" name="hintSet0003"/>
-      <point type="line" x="319" y="352"/>
-      <point type="line" x="318" y="352"/>
+      <point x="312" y="-164" type="line" name="hintSet0000"/>
+      <point x="378" y="-164" type="line"/>
+      <point x="378" y="389" type="line"/>
+      <point x="326" y="389" type="line" name="hintSet0003"/>
+      <point x="319" y="352" type="line"/>
+      <point x="318" y="352" type="line"/>
       <point x="282" y="382"/>
       <point x="251" y="398"/>
-      <point type="curve" x="206" y="398"/>
+      <point x="206" y="398" type="curve"/>
       <point x="118" y="398"/>
       <point x="38" y="320"/>
-      <point type="curve" x="38" y="194"/>
+      <point x="38" y="194" type="curve"/>
       <point x="38" y="64"/>
       <point x="101" y="-10"/>
-      <point type="curve" x="198" y="-10"/>
+      <point x="198" y="-10" type="curve"/>
       <point x="243" y="-10" name="hintSet0009"/>
       <point x="284" y="14"/>
-      <point type="curve" x="315" y="45"/>
-      <point type="line" x="312" y="-26"/>
+      <point x="315" y="45" type="curve"/>
+      <point x="312" y="-26" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="213" y="46"/>
+      <point x="213" y="46" type="curve"/>
       <point x="145" y="46"/>
       <point x="106" y="102"/>
-      <point type="curve" x="106" y="194"/>
+      <point x="106" y="194" type="curve"/>
       <point x="106" y="283"/>
       <point x="155" y="343"/>
-      <point type="curve" x="218" y="343"/>
+      <point x="218" y="343" type="curve"/>
       <point x="250" y="343"/>
       <point x="279" y="332"/>
-      <point type="curve" x="312" y="302"/>
-      <point type="line" x="312" y="99"/>
+      <point x="312" y="302" type="curve"/>
+      <point x="312" y="99" type="line"/>
       <point x="280" y="63"/>
       <point x="249" y="46"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/question.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/question.glif
@@ -4,38 +4,38 @@
   <unicode hex="003F"/>
   <outline>
     <contour>
-      <point type="curve" x="128" y="158" name="hintSet0000"/>
-      <point type="line" x="186" y="158"/>
+      <point x="128" y="158" type="curve" name="hintSet0000"/>
+      <point x="186" y="158" type="line"/>
       <point x="173" y="270"/>
       <point x="302" y="313"/>
-      <point type="curve" x="302" y="418"/>
+      <point x="302" y="418" type="curve"/>
       <point x="302" y="497"/>
       <point x="249" y="546"/>
-      <point type="curve" x="168" y="546"/>
+      <point x="168" y="546" type="curve"/>
       <point x="110" y="546"/>
       <point x="64" y="518"/>
-      <point type="curve" x="30" y="479"/>
-      <point type="line" x="68" y="445"/>
+      <point x="30" y="479" type="curve"/>
+      <point x="68" y="445" type="line"/>
       <point x="93" y="474"/>
       <point x="125" y="491"/>
-      <point type="curve" x="160" y="491"/>
+      <point x="160" y="491" type="curve"/>
       <point x="211" y="491"/>
       <point x="238" y="456"/>
-      <point type="curve" x="238" y="414"/>
+      <point x="238" y="414" type="curve"/>
       <point x="238" y="329"/>
       <point x="110" y="283"/>
     </contour>
     <contour>
-      <point type="curve" x="158" y="-10"/>
+      <point x="158" y="-10" type="curve"/>
       <point x="185" y="-10"/>
       <point x="206" y="11"/>
-      <point type="curve" x="206" y="40"/>
+      <point x="206" y="40" type="curve"/>
       <point x="206" y="70" name="hintSet0011"/>
       <point x="185" y="91"/>
-      <point type="curve" x="158" y="91"/>
+      <point x="158" y="91" type="curve"/>
       <point x="132" y="91"/>
       <point x="111" y="70"/>
-      <point type="curve" x="111" y="40"/>
+      <point x="111" y="40" type="curve"/>
       <point x="111" y="11" name="hintSet0013"/>
       <point x="132" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/quotedbl.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/quotedbl.glif
@@ -4,20 +4,20 @@
   <unicode hex="0022"/>
   <outline>
     <contour>
-      <point type="line" x="63" y="276" name="hintSet0000"/>
-      <point type="line" x="95" y="276"/>
-      <point type="line" x="106" y="383"/>
-      <point type="line" x="108" y="442"/>
-      <point type="line" x="51" y="442"/>
-      <point type="line" x="53" y="383"/>
+      <point x="63" y="276" type="line" name="hintSet0000"/>
+      <point x="95" y="276" type="line"/>
+      <point x="106" y="383" type="line"/>
+      <point x="108" y="442" type="line"/>
+      <point x="51" y="442" type="line"/>
+      <point x="53" y="383" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="205" y="276"/>
-      <point type="line" x="237" y="276"/>
-      <point type="line" x="247" y="383"/>
-      <point type="line" x="249" y="442"/>
-      <point type="line" x="193" y="442"/>
-      <point type="line" x="195" y="383"/>
+      <point x="205" y="276" type="line"/>
+      <point x="237" y="276" type="line"/>
+      <point x="247" y="383" type="line"/>
+      <point x="249" y="442" type="line"/>
+      <point x="193" y="442" type="line"/>
+      <point x="195" y="383" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/quotesingle.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/quotesingle.glif
@@ -4,12 +4,12 @@
   <unicode hex="0027"/>
   <outline>
     <contour>
-      <point type="line" x="79" y="345" name="hintSet0000"/>
-      <point type="line" x="119" y="345"/>
-      <point type="line" x="132" y="478"/>
-      <point type="line" x="134" y="552"/>
-      <point type="line" x="64" y="552"/>
-      <point type="line" x="66" y="478"/>
+      <point x="79" y="345" type="line" name="hintSet0000"/>
+      <point x="119" y="345" type="line"/>
+      <point x="132" y="478" type="line"/>
+      <point x="134" y="552" type="line"/>
+      <point x="64" y="552" type="line"/>
+      <point x="66" y="478" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/r.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/r.glif
@@ -6,25 +6,25 @@
   <anchor x="98.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="66" y="0" name="hintSet0000"/>
-      <point type="line" x="131" y="0"/>
-      <point type="line" x="131" y="250"/>
+      <point x="66" y="0" type="line" name="hintSet0000"/>
+      <point x="131" y="0" type="line"/>
+      <point x="131" y="250" type="line"/>
       <point x="158" y="315"/>
       <point x="197" y="339"/>
-      <point type="curve" x="230" y="339"/>
+      <point x="230" y="339" type="curve"/>
       <point x="246" y="339"/>
       <point x="254" y="337"/>
-      <point type="curve" x="267" y="333"/>
-      <point type="line" x="280" y="390"/>
+      <point x="267" y="333" type="curve"/>
+      <point x="280" y="390" type="line"/>
       <point x="267" y="396"/>
       <point x="255" y="398"/>
-      <point type="curve" x="238" y="398"/>
+      <point x="238" y="398" type="curve"/>
       <point x="194" y="398" name="hintSet0007"/>
       <point x="154" y="367"/>
-      <point type="curve" x="128" y="318"/>
-      <point type="line" x="126" y="318"/>
-      <point type="line" x="120" y="389"/>
-      <point type="line" x="66" y="389" name="hintSet0010"/>
+      <point x="128" y="318" type="curve"/>
+      <point x="126" y="318" type="line"/>
+      <point x="120" y="389" type="line"/>
+      <point x="66" y="389" type="line" name="hintSet0010"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/s.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/s.glif
@@ -7,42 +7,42 @@
   <anchor x="178.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="167" y="-10" name="hintSet0000"/>
+      <point x="167" y="-10" type="curve" name="hintSet0000"/>
       <point x="259" y="-10"/>
       <point x="310" y="43"/>
-      <point type="curve" x="310" y="106"/>
+      <point x="310" y="106" type="curve"/>
       <point x="310" y="180"/>
       <point x="247" y="203"/>
-      <point type="curve" x="191" y="224"/>
+      <point x="191" y="224" type="curve"/>
       <point x="147" y="241"/>
       <point x="105" y="254"/>
-      <point type="curve" x="105" y="291"/>
+      <point x="105" y="291" type="curve"/>
       <point x="105" y="321"/>
       <point x="127" y="347"/>
-      <point type="curve" x="176" y="347"/>
+      <point x="176" y="347" type="curve"/>
       <point x="210" y="347"/>
       <point x="238" y="333"/>
-      <point type="curve" x="265" y="313"/>
-      <point type="line" x="296" y="354"/>
+      <point x="265" y="313" type="curve"/>
+      <point x="296" y="354" type="line"/>
       <point x="266" y="378"/>
       <point x="224" y="398"/>
-      <point type="curve" x="175" y="398"/>
+      <point x="175" y="398" type="curve"/>
       <point x="91" y="398"/>
       <point x="42" y="350"/>
-      <point type="curve" x="42" y="288"/>
+      <point x="42" y="288" type="curve"/>
       <point x="42" y="222"/>
       <point x="102" y="196"/>
-      <point type="curve" x="158" y="176"/>
+      <point x="158" y="176" type="curve"/>
       <point x="200" y="160"/>
       <point x="246" y="142"/>
-      <point type="curve" x="246" y="102"/>
+      <point x="246" y="102" type="curve"/>
       <point x="246" y="69"/>
       <point x="221" y="42"/>
-      <point type="curve" x="170" y="42"/>
+      <point x="170" y="42" type="curve"/>
       <point x="123" y="42"/>
       <point x="89" y="61"/>
-      <point type="curve" x="55" y="88"/>
-      <point type="line" x="22" y="44"/>
+      <point x="55" y="88" type="curve"/>
+      <point x="22" y="44" type="line"/>
       <point x="59" y="14"/>
       <point x="112" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/semicolon.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/semicolon.glif
@@ -4,41 +4,41 @@
   <unicode hex="003B"/>
   <outline>
     <contour>
-      <point type="curve" x="80" y="281" name="hintSet0000"/>
+      <point x="80" y="281" type="curve" name="hintSet0000"/>
       <point x="100" y="281"/>
       <point x="118" y="298"/>
-      <point type="curve" x="118" y="321"/>
+      <point x="118" y="321" type="curve"/>
       <point x="118" y="345"/>
       <point x="100" y="362"/>
-      <point type="curve" x="80" y="362"/>
+      <point x="80" y="362" type="curve"/>
       <point x="59" y="362"/>
       <point x="42" y="345"/>
-      <point type="curve" x="42" y="321"/>
+      <point x="42" y="321" type="curve"/>
       <point x="42" y="298"/>
       <point x="59" y="281"/>
     </contour>
     <contour>
-      <point type="line" x="43" y="-109" name="hintSet0005"/>
+      <point x="43" y="-109" type="line" name="hintSet0005"/>
       <point x="95" y="-87"/>
       <point x="127" y="-44"/>
-      <point type="curve" x="127" y="11"/>
+      <point x="127" y="11" type="curve"/>
       <point x="127" y="49"/>
       <point x="110" y="73"/>
-      <point type="curve" x="83" y="73"/>
+      <point x="83" y="73" type="curve"/>
       <point x="61" y="73"/>
       <point x="44" y="59"/>
-      <point type="curve" x="44" y="36"/>
+      <point x="44" y="36" type="curve"/>
       <point x="44" y="12"/>
       <point x="61" y="-1"/>
-      <point type="curve" x="81" y="-1"/>
+      <point x="81" y="-1" type="curve"/>
       <point x="92" y="-1"/>
       <point x="101" y="2"/>
-      <point type="curve" x="108" y="10"/>
-      <point type="line" x="82" y="49"/>
-      <point type="line" x="88" y="1"/>
+      <point x="108" y="10" type="curve"/>
+      <point x="82" y="49" type="line"/>
+      <point x="88" y="1" type="line"/>
       <point x="88" y="-34"/>
       <point x="67" y="-62"/>
-      <point type="curve" x="30" y="-78"/>
+      <point x="30" y="-78" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/seven.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/seven.glif
@@ -4,15 +4,15 @@
   <unicode hex="0037"/>
   <outline>
     <contour>
-      <point type="curve" x="142" y="0" name="hintSet0000"/>
-      <point type="line" x="210" y="0"/>
+      <point x="142" y="0" type="curve" name="hintSet0000"/>
+      <point x="210" y="0" type="line"/>
       <point x="218" y="199"/>
       <point x="243" y="315"/>
-      <point type="curve" x="364" y="470"/>
-      <point type="line" x="364" y="510"/>
-      <point type="line" x="35" y="510"/>
-      <point type="line" x="35" y="454"/>
-      <point type="line" x="290" y="454"/>
+      <point x="364" y="470" type="curve"/>
+      <point x="364" y="510" type="line"/>
+      <point x="35" y="510" type="line"/>
+      <point x="35" y="454" type="line"/>
+      <point x="290" y="454" type="line"/>
       <point x="189" y="314"/>
       <point x="150" y="192"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/six.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/six.glif
@@ -4,42 +4,42 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point type="curve" x="214" y="-10" name="hintSet0000"/>
+      <point x="214" y="-10" type="curve" name="hintSet0000"/>
       <point x="297" y="-10"/>
       <point x="366" y="57"/>
-      <point type="curve" x="366" y="154"/>
+      <point x="366" y="154" type="curve"/>
       <point x="366" y="259"/>
       <point x="308" y="312"/>
-      <point type="curve" x="220" y="312"/>
+      <point x="220" y="312" type="curve"/>
       <point x="177" y="312"/>
       <point x="129" y="285"/>
-      <point type="curve" x="97" y="242"/>
-      <point type="line" x="99" y="190"/>
+      <point x="97" y="242" type="curve"/>
+      <point x="99" y="190" type="line"/>
       <point x="134" y="242"/>
       <point x="176" y="262"/>
-      <point type="curve" x="209" y="262"/>
+      <point x="209" y="262" type="curve"/>
       <point x="272" y="262"/>
       <point x="303" y="221"/>
-      <point type="curve" x="303" y="154"/>
+      <point x="303" y="154" type="curve"/>
       <point x="303" y="87"/>
       <point x="265" y="42"/>
-      <point type="curve" x="214" y="42"/>
+      <point x="214" y="42" type="curve"/>
       <point x="142" y="42"/>
       <point x="101" y="110"/>
-      <point type="curve" x="101" y="236"/>
+      <point x="101" y="236" type="curve"/>
       <point x="101" y="407"/>
       <point x="162" y="465"/>
-      <point type="curve" x="235" y="465"/>
+      <point x="235" y="465" type="curve"/>
       <point x="267" y="465"/>
       <point x="298" y="450"/>
-      <point type="curve" x="319" y="425"/>
-      <point type="line" x="356" y="466"/>
+      <point x="319" y="425" type="curve"/>
+      <point x="356" y="466" type="line"/>
       <point x="327" y="497"/>
       <point x="288" y="520"/>
-      <point type="curve" x="233" y="520"/>
+      <point x="233" y="520" type="curve"/>
       <point x="131" y="520"/>
       <point x="38" y="441"/>
-      <point type="curve" x="38" y="236"/>
+      <point x="38" y="236" type="curve"/>
       <point x="38" y="72"/>
       <point x="114" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/slash.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/slash.glif
@@ -4,10 +4,10 @@
   <unicode hex="002F"/>
   <outline>
     <contour>
-      <point type="line" x="8" y="-128" name="hintSet0000"/>
-      <point type="line" x="56" y="-128"/>
-      <point type="line" x="270" y="568"/>
-      <point type="line" x="222" y="568"/>
+      <point x="8" y="-128" type="line" name="hintSet0000"/>
+      <point x="56" y="-128" type="line"/>
+      <point x="270" y="568" type="line"/>
+      <point x="222" y="568" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/t.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/t.glif
@@ -7,28 +7,28 @@
   <anchor x="169.60000000000002" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="188" y="-10" name="hintSet0000"/>
+      <point x="188" y="-10" type="curve" name="hintSet0000"/>
       <point x="212" y="-10"/>
       <point x="238" y="-2"/>
-      <point type="curve" x="260" y="5"/>
-      <point type="line" x="247" y="54"/>
+      <point x="260" y="5" type="curve"/>
+      <point x="247" y="54" type="line"/>
       <point x="234" y="50"/>
       <point x="217" y="44"/>
-      <point type="curve" x="203" y="44"/>
+      <point x="203" y="44" type="curve"/>
       <point x="158" y="44"/>
       <point x="143" y="71"/>
-      <point type="curve" x="143" y="119"/>
-      <point type="line" x="143" y="335"/>
-      <point type="line" x="248" y="335"/>
-      <point type="line" x="248" y="389" name="hintSet0007"/>
-      <point type="line" x="143" y="389"/>
-      <point type="line" x="143" y="498" name="hintSet0009"/>
-      <point type="line" x="88" y="498" name="hintSet0010"/>
-      <point type="line" x="80" y="389" name="hintSet0011"/>
-      <point type="line" x="19" y="385" name="hintSet0012"/>
-      <point type="line" x="19" y="335" name="hintSet0013"/>
-      <point type="line" x="77" y="335"/>
-      <point type="line" x="77" y="120"/>
+      <point x="143" y="119" type="curve"/>
+      <point x="143" y="335" type="line"/>
+      <point x="248" y="335" type="line"/>
+      <point x="248" y="389" type="line" name="hintSet0007"/>
+      <point x="143" y="389" type="line"/>
+      <point x="143" y="498" type="line" name="hintSet0009"/>
+      <point x="88" y="498" type="line" name="hintSet0010"/>
+      <point x="80" y="389" type="line" name="hintSet0011"/>
+      <point x="19" y="385" type="line" name="hintSet0012"/>
+      <point x="19" y="335" type="line" name="hintSet0013"/>
+      <point x="77" y="335" type="line"/>
+      <point x="77" y="120" type="line"/>
       <point x="77" y="43"/>
       <point x="105" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/three.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/three.glif
@@ -4,44 +4,44 @@
   <unicode hex="0033"/>
   <outline>
     <contour>
-      <point type="curve" x="189" y="-10" name="hintSet0000"/>
+      <point x="189" y="-10" type="curve" name="hintSet0000"/>
       <point x="282" y="-10"/>
       <point x="357" y="46"/>
-      <point type="curve" x="357" y="136"/>
+      <point x="357" y="136" type="curve"/>
       <point x="357" y="206"/>
       <point x="308" y="251"/>
-      <point type="curve" x="246" y="266"/>
-      <point type="line" x="246" y="269"/>
+      <point x="246" y="266" type="curve"/>
+      <point x="246" y="269" type="line"/>
       <point x="302" y="290" name="hintSet0004"/>
       <point x="339" y="329"/>
-      <point type="curve" x="339" y="390"/>
+      <point x="339" y="390" type="curve"/>
       <point x="339" y="473"/>
       <point x="275" y="520"/>
-      <point type="curve" x="186" y="520"/>
+      <point x="186" y="520" type="curve"/>
       <point x="126" y="520"/>
       <point x="79" y="493"/>
-      <point type="curve" x="40" y="456"/>
-      <point type="line" x="75" y="414"/>
+      <point x="40" y="456" type="curve"/>
+      <point x="75" y="414" type="line"/>
       <point x="106" y="445"/>
       <point x="142" y="466"/>
-      <point type="curve" x="184" y="466"/>
+      <point x="184" y="466" type="curve"/>
       <point x="238" y="466"/>
       <point x="272" y="435"/>
-      <point type="curve" x="272" y="386"/>
+      <point x="272" y="386" type="curve"/>
       <point x="272" y="332"/>
       <point x="236" y="290"/>
-      <point type="curve" x="127" y="290"/>
-      <point type="line" x="127" y="240" name="hintSet0011"/>
+      <point x="127" y="290" type="curve"/>
+      <point x="127" y="240" type="line" name="hintSet0011"/>
       <point x="249" y="240"/>
       <point x="290" y="199"/>
-      <point type="curve" x="290" y="138"/>
+      <point x="290" y="138" type="curve"/>
       <point x="290" y="82"/>
       <point x="246" y="45"/>
-      <point type="curve" x="185" y="45"/>
+      <point x="185" y="45" type="curve"/>
       <point x="125" y="45"/>
       <point x="85" y="74"/>
-      <point type="curve" x="54" y="106"/>
-      <point type="line" x="21" y="62"/>
+      <point x="54" y="106" type="curve"/>
+      <point x="21" y="62" type="line"/>
       <point x="55" y="25"/>
       <point x="107" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/two.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/two.glif
@@ -4,32 +4,32 @@
   <unicode hex="0032"/>
   <outline>
     <contour>
-      <point type="line" x="32" y="0" name="hintSet0000"/>
-      <point type="line" x="362" y="0"/>
-      <point type="line" x="362" y="57"/>
-      <point type="line" x="214" y="57"/>
+      <point x="32" y="0" type="line" name="hintSet0000"/>
+      <point x="362" y="0" type="line"/>
+      <point x="362" y="57" type="line"/>
+      <point x="214" y="57" type="line"/>
       <point x="187" y="57"/>
       <point x="156" y="54"/>
-      <point type="curve" x="128" y="52"/>
+      <point x="128" y="52" type="curve"/>
       <point x="249" y="178"/>
       <point x="336" y="274"/>
-      <point type="curve" x="336" y="370"/>
+      <point x="336" y="370" type="curve"/>
       <point x="336" y="460"/>
       <point x="278" y="520"/>
-      <point type="curve" x="183" y="520"/>
+      <point x="183" y="520" type="curve"/>
       <point x="117" y="520"/>
       <point x="71" y="489"/>
-      <point type="curve" x="29" y="442"/>
-      <point type="line" x="66" y="405"/>
+      <point x="29" y="442" type="curve"/>
+      <point x="66" y="405" type="line"/>
       <point x="96" y="439"/>
       <point x="133" y="466"/>
-      <point type="curve" x="175" y="466"/>
+      <point x="175" y="466" type="curve"/>
       <point x="240" y="466"/>
       <point x="272" y="425"/>
-      <point type="curve" x="272" y="366"/>
+      <point x="272" y="366" type="curve"/>
       <point x="272" y="284"/>
       <point x="186" y="192"/>
-      <point type="curve" x="32" y="39"/>
+      <point x="32" y="39" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/u.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/u.glif
@@ -8,25 +8,25 @@
   <anchor x="232.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="179" y="-10" name="hintSet0000"/>
+      <point x="179" y="-10" type="curve" name="hintSet0000"/>
       <point x="233" y="-10" name="hintSet0001"/>
       <point x="271" y="18"/>
-      <point type="curve" x="307" y="61"/>
-      <point type="line" x="310" y="61"/>
-      <point type="line" x="315" y="0" name="hintSet0003"/>
-      <point type="line" x="370" y="0" name="hintSet0004"/>
-      <point type="line" x="370" y="389"/>
-      <point type="line" x="304" y="389"/>
-      <point type="line" x="304" y="113" name="hintSet0007"/>
+      <point x="307" y="61" type="curve"/>
+      <point x="310" y="61" type="line"/>
+      <point x="315" y="0" type="line" name="hintSet0003"/>
+      <point x="370" y="0" type="line" name="hintSet0004"/>
+      <point x="370" y="389" type="line"/>
+      <point x="304" y="389" type="line"/>
+      <point x="304" y="113" type="line" name="hintSet0007"/>
       <point x="267" y="67"/>
       <point x="239" y="47"/>
-      <point type="curve" x="199" y="47"/>
+      <point x="199" y="47" type="curve"/>
       <point x="148" y="47"/>
       <point x="126" y="78"/>
-      <point type="curve" x="126" y="151"/>
-      <point type="line" x="126" y="389"/>
-      <point type="line" x="60" y="389"/>
-      <point type="line" x="60" y="142"/>
+      <point x="126" y="151" type="curve"/>
+      <point x="126" y="389" type="line"/>
+      <point x="60" y="389" type="line"/>
+      <point x="60" y="142" type="line"/>
       <point x="60" y="43"/>
       <point x="97" y="-10"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/underscore.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/underscore.glif
@@ -4,10 +4,10 @@
   <unicode hex="005F"/>
   <outline>
     <contour>
-      <point type="line" x="10" y="-101" name="hintSet0000"/>
-      <point type="line" x="390" y="-101"/>
-      <point type="line" x="390" y="-57"/>
-      <point type="line" x="10" y="-57"/>
+      <point x="10" y="-101" type="line" name="hintSet0000"/>
+      <point x="390" y="-101" type="line"/>
+      <point x="390" y="-57" type="line"/>
+      <point x="10" y="-57" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/v.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/v.glif
@@ -6,20 +6,20 @@
   <anchor x="188.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="150" y="0" name="hintSet0000"/>
-      <point type="line" x="226" y="0"/>
-      <point type="line" x="364" y="389"/>
-      <point type="line" x="299" y="389"/>
-      <point type="line" x="226" y="168"/>
+      <point x="150" y="0" type="line" name="hintSet0000"/>
+      <point x="226" y="0" type="line"/>
+      <point x="364" y="389" type="line"/>
+      <point x="299" y="389" type="line"/>
+      <point x="226" y="168" type="line"/>
       <point x="214" y="130"/>
       <point x="202" y="90"/>
-      <point type="curve" x="190" y="54"/>
-      <point type="line" x="187" y="54"/>
+      <point x="190" y="54" type="curve"/>
+      <point x="187" y="54" type="line"/>
       <point x="175" y="90"/>
       <point x="162" y="130"/>
-      <point type="curve" x="151" y="168"/>
-      <point type="line" x="78" y="389"/>
-      <point type="line" x="10" y="389"/>
+      <point x="151" y="168" type="curve"/>
+      <point x="78" y="389" type="line"/>
+      <point x="10" y="389" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/w.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/w.glif
@@ -6,40 +6,40 @@
   <anchor x="288.0" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="127" y="0" name="hintSet0000"/>
-      <point type="line" x="204" y="0"/>
-      <point type="line" x="258" y="208"/>
+      <point x="127" y="0" type="line" name="hintSet0000"/>
+      <point x="204" y="0" type="line"/>
+      <point x="258" y="208" type="line"/>
       <point x="269" y="245"/>
       <point x="277" y="282"/>
-      <point type="curve" x="286" y="321"/>
-      <point type="line" x="289" y="321"/>
+      <point x="286" y="321" type="curve"/>
+      <point x="289" y="321" type="line"/>
       <point x="298" y="282"/>
       <point x="306" y="246"/>
-      <point type="curve" x="315" y="209"/>
-      <point type="line" x="371" y="0"/>
-      <point type="line" x="451" y="0"/>
-      <point type="line" x="555" y="389"/>
-      <point type="line" x="493" y="389"/>
-      <point type="line" x="436" y="164"/>
+      <point x="315" y="209" type="curve"/>
+      <point x="371" y="0" type="line"/>
+      <point x="451" y="0" type="line"/>
+      <point x="555" y="389" type="line"/>
+      <point x="493" y="389" type="line"/>
+      <point x="436" y="164" type="line"/>
       <point x="428" y="127"/>
       <point x="421" y="92"/>
-      <point type="curve" x="412" y="56"/>
-      <point type="line" x="409" y="56"/>
+      <point x="412" y="56" type="curve"/>
+      <point x="409" y="56" type="line"/>
       <point x="400" y="92"/>
       <point x="391" y="127"/>
-      <point type="curve" x="382" y="164"/>
-      <point type="line" x="321" y="389"/>
-      <point type="line" x="257" y="389"/>
-      <point type="line" x="197" y="164"/>
+      <point x="382" y="164" type="curve"/>
+      <point x="321" y="389" type="line"/>
+      <point x="257" y="389" type="line"/>
+      <point x="197" y="164" type="line"/>
       <point x="187" y="128"/>
       <point x="179" y="92"/>
-      <point type="curve" x="170" y="56"/>
-      <point type="line" x="167" y="56"/>
+      <point x="170" y="56" type="curve"/>
+      <point x="167" y="56" type="line"/>
       <point x="160" y="92"/>
       <point x="153" y="127"/>
-      <point type="curve" x="144" y="164"/>
-      <point type="line" x="86" y="389"/>
-      <point type="line" x="19" y="389"/>
+      <point x="144" y="164" type="curve"/>
+      <point x="86" y="389" type="line"/>
+      <point x="19" y="389" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/x.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/x.glif
@@ -6,32 +6,32 @@
   <anchor x="178.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="11" y="0" name="hintSet0000"/>
-      <point type="line" x="80" y="0"/>
-      <point type="line" x="133" y="90"/>
+      <point x="11" y="0" type="line" name="hintSet0000"/>
+      <point x="80" y="0" type="line"/>
+      <point x="133" y="90" type="line"/>
       <point x="146" y="114"/>
       <point x="158" y="138"/>
-      <point type="curve" x="172" y="160"/>
-      <point type="line" x="175" y="160"/>
+      <point x="172" y="160" type="curve"/>
+      <point x="175" y="160" type="line"/>
       <point x="190" y="138"/>
       <point x="204" y="114"/>
-      <point type="curve" x="218" y="90"/>
-      <point type="line" x="274" y="0"/>
-      <point type="line" x="346" y="0"/>
-      <point type="line" x="219" y="196"/>
-      <point type="line" x="337" y="389"/>
-      <point type="line" x="268" y="389"/>
-      <point type="line" x="221" y="303"/>
+      <point x="218" y="90" type="curve"/>
+      <point x="274" y="0" type="line"/>
+      <point x="346" y="0" type="line"/>
+      <point x="219" y="196" type="line"/>
+      <point x="337" y="389" type="line"/>
+      <point x="268" y="389" type="line"/>
+      <point x="221" y="303" type="line"/>
       <point x="209" y="282"/>
       <point x="197" y="260"/>
-      <point type="curve" x="186" y="238"/>
-      <point type="line" x="182" y="238"/>
+      <point x="186" y="238" type="curve"/>
+      <point x="182" y="238" type="line"/>
       <point x="169" y="260"/>
       <point x="156" y="282"/>
-      <point type="curve" x="144" y="303"/>
-      <point type="line" x="92" y="389"/>
-      <point type="line" x="21" y="389"/>
-      <point type="line" x="138" y="203"/>
+      <point x="144" y="303" type="curve"/>
+      <point x="92" y="389" type="line"/>
+      <point x="21" y="389" type="line"/>
+      <point x="138" y="203" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/y.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/y.glif
@@ -6,31 +6,31 @@
   <anchor x="160.0" y="-193.60000000000002" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="72" y="-167" name="hintSet0000"/>
+      <point x="72" y="-167" type="curve" name="hintSet0000"/>
       <point x="150" y="-167"/>
       <point x="190" y="-109"/>
-      <point type="curve" x="218" y="-32"/>
-      <point type="line" x="364" y="389"/>
-      <point type="line" x="300" y="389"/>
-      <point type="line" x="230" y="174"/>
+      <point x="218" y="-32" type="curve"/>
+      <point x="364" y="389" type="line"/>
+      <point x="300" y="389" type="line"/>
+      <point x="230" y="174" type="line"/>
       <point x="220" y="139"/>
       <point x="209" y="99"/>
-      <point type="curve" x="198" y="64"/>
-      <point type="line" x="194" y="64"/>
+      <point x="198" y="64" type="curve"/>
+      <point x="194" y="64" type="line"/>
       <point x="182" y="100"/>
       <point x="169" y="140"/>
-      <point type="curve" x="157" y="174"/>
-      <point type="line" x="78" y="389"/>
-      <point type="line" x="10" y="389"/>
-      <point type="line" x="166" y="-1"/>
-      <point type="line" x="157" y="-30"/>
+      <point x="157" y="174" type="curve"/>
+      <point x="78" y="389" type="line"/>
+      <point x="10" y="389" type="line"/>
+      <point x="166" y="-1" type="line"/>
+      <point x="157" y="-30" type="line"/>
       <point x="141" y="-78"/>
       <point x="113" y="-113"/>
-      <point type="curve" x="69" y="-113"/>
+      <point x="69" y="-113" type="curve"/>
       <point x="59" y="-113"/>
       <point x="47" y="-110"/>
-      <point type="curve" x="39" y="-107"/>
-      <point type="line" x="26" y="-159"/>
+      <point x="39" y="-107" type="curve"/>
+      <point x="26" y="-159" type="line"/>
       <point x="39" y="-164"/>
       <point x="54" y="-167"/>
     </contour>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/z.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/z.glif
@@ -6,16 +6,16 @@
   <anchor x="182.4" y="-17.6" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="25" y="0" name="hintSet0000"/>
-      <point type="line" x="319" y="0"/>
-      <point type="line" x="319" y="54"/>
-      <point type="line" x="108" y="54"/>
-      <point type="line" x="313" y="354"/>
-      <point type="line" x="313" y="389"/>
-      <point type="line" x="47" y="389"/>
-      <point type="line" x="47" y="335"/>
-      <point type="line" x="230" y="335"/>
-      <point type="line" x="25" y="35"/>
+      <point x="25" y="0" type="line" name="hintSet0000"/>
+      <point x="319" y="0" type="line"/>
+      <point x="319" y="54" type="line"/>
+      <point x="108" y="54" type="line"/>
+      <point x="313" y="354" type="line"/>
+      <point x="313" y="389" type="line"/>
+      <point x="47" y="389" type="line"/>
+      <point x="47" y="335" type="line"/>
+      <point x="230" y="335" type="line"/>
+      <point x="25" y="35" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/zero.glif
+++ b/tests/autohint_data/expected_output/decimals.ufo/glyphs.com.adobe.type.processedglyphs/zero.glif
@@ -4,30 +4,30 @@
   <unicode hex="0030"/>
   <outline>
     <contour>
-      <point type="curve" x="199" y="-10" name="hintSet0000"/>
+      <point x="199" y="-10" type="curve" name="hintSet0000"/>
       <point x="301" y="-10"/>
       <point x="362" y="86"/>
-      <point type="curve" x="362" y="257"/>
+      <point x="362" y="257" type="curve"/>
       <point x="362" y="428"/>
       <point x="301" y="520"/>
-      <point type="curve" x="199" y="520"/>
+      <point x="199" y="520" type="curve"/>
       <point x="97" y="520"/>
       <point x="35" y="428"/>
-      <point type="curve" x="35" y="257"/>
+      <point x="35" y="257" type="curve"/>
       <point x="35" y="86"/>
       <point x="97" y="-10"/>
     </contour>
     <contour>
-      <point type="curve" x="199" y="43"/>
+      <point x="199" y="43" type="curve"/>
       <point x="139" y="43"/>
       <point x="99" y="107"/>
-      <point type="curve" x="99" y="257"/>
+      <point x="99" y="257" type="curve"/>
       <point x="99" y="406"/>
       <point x="139" y="467"/>
-      <point type="curve" x="199" y="467"/>
+      <point x="199" y="467" type="curve"/>
       <point x="258" y="467"/>
       <point x="298" y="406"/>
-      <point type="curve" x="298" y="257"/>
+      <point x="298" y="257" type="curve"/>
       <point x="298" y="107"/>
       <point x="258" y="43"/>
     </contour>

--- a/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/no_width-no_height.glif
+++ b/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/no_width-no_height.glif
@@ -2,10 +2,10 @@
 <glyph name="no_width-no_height" format="2">
   <outline>
     <contour>
-      <point type="line" x="0" y="0" name="hintSet0000"/>
-      <point type="line" x="140" y="0"/>
-      <point type="line" x="140" y="140"/>
-      <point type="line" x="0" y="140"/>
+      <point x="0" y="0" type="line" name="hintSet0000"/>
+      <point x="140" y="0" type="line"/>
+      <point x="140" y="140" type="line"/>
+      <point x="0" y="140" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/no_width-some_height.glif
+++ b/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/no_width-some_height.glif
@@ -3,10 +3,10 @@
   <advance height="800"/>
   <outline>
     <contour>
-      <point type="line" x="0" y="0" name="hintSet0000"/>
-      <point type="line" x="140" y="0"/>
-      <point type="line" x="140" y="140"/>
-      <point type="line" x="0" y="140"/>
+      <point x="0" y="0" type="line" name="hintSet0000"/>
+      <point x="140" y="0" type="line"/>
+      <point x="140" y="140" type="line"/>
+      <point x="0" y="140" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/no_width-zero_height.glif
+++ b/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/no_width-zero_height.glif
@@ -3,10 +3,10 @@
   <advance height="0"/>
   <outline>
     <contour>
-      <point type="line" x="0" y="0" name="hintSet0000"/>
-      <point type="line" x="140" y="0"/>
-      <point type="line" x="140" y="140"/>
-      <point type="line" x="0" y="140"/>
+      <point x="0" y="0" type="line" name="hintSet0000"/>
+      <point x="140" y="0" type="line"/>
+      <point x="140" y="140" type="line"/>
+      <point x="0" y="140" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/some_width-no_height.glif
+++ b/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/some_width-no_height.glif
@@ -3,10 +3,10 @@
   <advance width="500"/>
   <outline>
     <contour>
-      <point type="line" x="0" y="0" name="hintSet0000"/>
-      <point type="line" x="140" y="0"/>
-      <point type="line" x="140" y="140"/>
-      <point type="line" x="0" y="140"/>
+      <point x="0" y="0" type="line" name="hintSet0000"/>
+      <point x="140" y="0" type="line"/>
+      <point x="140" y="140" type="line"/>
+      <point x="0" y="140" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/some_width-some_height.glif
+++ b/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/some_width-some_height.glif
@@ -3,10 +3,10 @@
   <advance width="500" height="800"/>
   <outline>
     <contour>
-      <point type="line" x="0" y="0" name="hintSet0000"/>
-      <point type="line" x="140" y="0"/>
-      <point type="line" x="140" y="140"/>
-      <point type="line" x="0" y="140"/>
+      <point x="0" y="0" type="line" name="hintSet0000"/>
+      <point x="140" y="0" type="line"/>
+      <point x="140" y="140" type="line"/>
+      <point x="0" y="140" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/some_width-zero_height.glif
+++ b/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/some_width-zero_height.glif
@@ -3,10 +3,10 @@
   <advance width="500" height="0"/>
   <outline>
     <contour>
-      <point type="line" x="0" y="0" name="hintSet0000"/>
-      <point type="line" x="140" y="0"/>
-      <point type="line" x="140" y="140"/>
-      <point type="line" x="0" y="140"/>
+      <point x="0" y="0" type="line" name="hintSet0000"/>
+      <point x="140" y="0" type="line"/>
+      <point x="140" y="140" type="line"/>
+      <point x="0" y="140" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/zero_width-no_height.glif
+++ b/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/zero_width-no_height.glif
@@ -3,10 +3,10 @@
   <advance width="0"/>
   <outline>
     <contour>
-      <point type="line" x="0" y="0" name="hintSet0000"/>
-      <point type="line" x="140" y="0"/>
-      <point type="line" x="140" y="140"/>
-      <point type="line" x="0" y="140"/>
+      <point x="0" y="0" type="line" name="hintSet0000"/>
+      <point x="140" y="0" type="line"/>
+      <point x="140" y="140" type="line"/>
+      <point x="0" y="140" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/zero_width-some_height.glif
+++ b/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/zero_width-some_height.glif
@@ -3,10 +3,10 @@
   <advance width="0" height="800"/>
   <outline>
     <contour>
-      <point type="line" x="0" y="0" name="hintSet0000"/>
-      <point type="line" x="140" y="0"/>
-      <point type="line" x="140" y="140"/>
-      <point type="line" x="0" y="140"/>
+      <point x="0" y="0" type="line" name="hintSet0000"/>
+      <point x="140" y="0" type="line"/>
+      <point x="140" y="140" type="line"/>
+      <point x="0" y="140" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/zero_width-zero_height.glif
+++ b/tests/autohint_data/expected_output/hashmap_advance.ufo/glyphs.com.adobe.type.processedglyphs/zero_width-zero_height.glif
@@ -3,10 +3,10 @@
   <advance width="0" height="0"/>
   <outline>
     <contour>
-      <point type="line" x="0" y="0" name="hintSet0000"/>
-      <point type="line" x="140" y="0"/>
-      <point type="line" x="140" y="140"/>
-      <point type="line" x="0" y="140"/>
+      <point x="0" y="0" type="line" name="hintSet0000"/>
+      <point x="140" y="0" type="line"/>
+      <point x="140" y="140" type="line"/>
+      <point x="0" y="140" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_dflt_layer-wd.ufo/glyphs/a.glif
+++ b/tests/autohint_data/expected_output/hashmap_dflt_layer-wd.ufo/glyphs/a.glif
@@ -3,10 +3,10 @@
   <advance width="500"/>
   <outline>
     <contour>
-      <point type="line" x="0" y="0" name="hintSet0000"/>
-      <point type="line" x="140" y="0"/>
-      <point type="line" x="140" y="140"/>
-      <point type="line" x="0" y="140"/>
+      <point x="0" y="0" type="line" name="hintSet0000"/>
+      <point x="140" y="0" type="line"/>
+      <point x="140" y="140" type="line"/>
+      <point x="0" y="140" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_dflt_layer-wd.ufo/glyphs/after.glif
+++ b/tests/autohint_data/expected_output/hashmap_dflt_layer-wd.ufo/glyphs/after.glif
@@ -3,10 +3,10 @@
   <advance width="500"/>
   <outline>
     <contour>
-      <point type="line" x="200" y="0" name="hintSet0000"/>
-      <point type="line" x="340" y="0"/>
-      <point type="line" x="340" y="140"/>
-      <point type="line" x="200" y="140"/>
+      <point x="200" y="0" type="line" name="hintSet0000"/>
+      <point x="340" y="0" type="line"/>
+      <point x="340" y="140" type="line"/>
+      <point x="200" y="140" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_dflt_layer-wd.ufo/glyphs/before.glif
+++ b/tests/autohint_data/expected_output/hashmap_dflt_layer-wd.ufo/glyphs/before.glif
@@ -3,10 +3,10 @@
   <advance width="500"/>
   <outline>
     <contour>
-      <point type="line" x="0" y="200" name="hintSet0000"/>
-      <point type="line" x="140" y="200"/>
-      <point type="line" x="140" y="340"/>
-      <point type="line" x="0" y="340"/>
+      <point x="0" y="200" type="line" name="hintSet0000"/>
+      <point x="140" y="200" type="line"/>
+      <point x="140" y="340" type="line"/>
+      <point x="0" y="340" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_dflt_layer.ufo/glyphs/a.glif
+++ b/tests/autohint_data/expected_output/hashmap_dflt_layer.ufo/glyphs/a.glif
@@ -3,10 +3,10 @@
   <advance width="500"/>
   <outline>
     <contour>
-      <point type="line" x="0" y="0" name="hintSet0000"/>
-      <point type="line" x="140" y="0"/>
-      <point type="line" x="140" y="140"/>
-      <point type="line" x="0" y="140"/>
+      <point x="0" y="0" type="line" name="hintSet0000"/>
+      <point x="140" y="0" type="line"/>
+      <point x="140" y="140" type="line"/>
+      <point x="0" y="140" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_dflt_layer.ufo/glyphs/after.glif
+++ b/tests/autohint_data/expected_output/hashmap_dflt_layer.ufo/glyphs/after.glif
@@ -3,10 +3,10 @@
   <advance width="500"/>
   <outline>
     <contour>
-      <point type="line" x="200" y="0" name="hintSet0000"/>
-      <point type="line" x="340" y="0"/>
-      <point type="line" x="340" y="140"/>
-      <point type="line" x="200" y="140"/>
+      <point x="200" y="0" type="line" name="hintSet0000"/>
+      <point x="340" y="0" type="line"/>
+      <point x="340" y="140" type="line"/>
+      <point x="200" y="140" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_dflt_layer.ufo/glyphs/before.glif
+++ b/tests/autohint_data/expected_output/hashmap_dflt_layer.ufo/glyphs/before.glif
@@ -3,10 +3,10 @@
   <advance width="500"/>
   <outline>
     <contour>
-      <point type="line" x="0" y="200" name="hintSet0000"/>
-      <point type="line" x="140" y="200"/>
-      <point type="line" x="140" y="340"/>
-      <point type="line" x="0" y="340"/>
+      <point x="0" y="200" type="line" name="hintSet0000"/>
+      <point x="140" y="200" type="line"/>
+      <point x="140" y="340" type="line"/>
+      <point x="0" y="340" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_transform.ufo/glyphs.com.adobe.type.processedglyphs/a.glif
+++ b/tests/autohint_data/expected_output/hashmap_transform.ufo/glyphs.com.adobe.type.processedglyphs/a.glif
@@ -3,10 +3,10 @@
   <advance width="500"/>
   <outline>
     <contour>
-      <point type="line" x="0" y="0" name="hintSet0000"/>
-      <point type="line" x="140" y="0"/>
-      <point type="line" x="140" y="140"/>
-      <point type="line" x="0" y="140"/>
+      <point x="0" y="0" type="line" name="hintSet0000"/>
+      <point x="140" y="0" type="line"/>
+      <point x="140" y="140" type="line"/>
+      <point x="0" y="140" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_transform.ufo/glyphs.com.adobe.type.processedglyphs/after.glif
+++ b/tests/autohint_data/expected_output/hashmap_transform.ufo/glyphs.com.adobe.type.processedglyphs/after.glif
@@ -3,10 +3,10 @@
   <advance width="500"/>
   <outline>
     <contour>
-      <point type="line" x="200" y="0" name="hintSet0000"/>
-      <point type="line" x="340" y="0"/>
-      <point type="line" x="340" y="140"/>
-      <point type="line" x="200" y="140"/>
+      <point x="200" y="0" type="line" name="hintSet0000"/>
+      <point x="340" y="0" type="line"/>
+      <point x="340" y="140" type="line"/>
+      <point x="200" y="140" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_transform.ufo/glyphs.com.adobe.type.processedglyphs/before.glif
+++ b/tests/autohint_data/expected_output/hashmap_transform.ufo/glyphs.com.adobe.type.processedglyphs/before.glif
@@ -3,10 +3,10 @@
   <advance width="500"/>
   <outline>
     <contour>
-      <point type="line" x="0" y="200" name="hintSet0000"/>
-      <point type="line" x="140" y="200"/>
-      <point type="line" x="140" y="340"/>
-      <point type="line" x="0" y="340"/>
+      <point x="0" y="200" type="line" name="hintSet0000"/>
+      <point x="140" y="200" type="line"/>
+      <point x="140" y="340" type="line"/>
+      <point x="0" y="340" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_unnormalized_floats.ufo/glyphs.com.adobe.type.processedglyphs/exclam.glif
+++ b/tests/autohint_data/expected_output/hashmap_unnormalized_floats.ufo/glyphs.com.adobe.type.processedglyphs/exclam.glif
@@ -3,16 +3,16 @@
   <advance width="235.0"/>
   <outline>
     <contour>
-      <point type="line" x="99" y="398" name="hintSet0000"/>
-      <point type="line" x="102" y="119"/>
-      <point type="line" x="140" y="119"/>
-      <point type="line" x="143" y="398"/>
+      <point x="99" y="398" type="line" name="hintSet0000"/>
+      <point x="102" y="119" type="line"/>
+      <point x="140" y="119" type="line"/>
+      <point x="143" y="398" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="121" y="-7"/>
-      <point type="line" x="154" y="25"/>
-      <point type="line" x="121" y="57"/>
-      <point type="line" x="88" y="25"/>
+      <point x="121" y="-7" type="line"/>
+      <point x="154" y="25" type="line"/>
+      <point x="121" y="57" type="line"/>
+      <point x="88" y="25" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/hashmap_unnormalized_floats.ufo/glyphs.com.adobe.type.processedglyphs/exclamdown.glif
+++ b/tests/autohint_data/expected_output/hashmap_unnormalized_floats.ufo/glyphs.com.adobe.type.processedglyphs/exclamdown.glif
@@ -3,16 +3,16 @@
   <advance width="196.0"/>
   <outline>
     <contour>
-      <point type="line" x="130" y="82" name="hintSet0000"/>
-      <point type="line" x="127" y="361"/>
-      <point type="line" x="89" y="361"/>
-      <point type="line" x="86" y="82"/>
+      <point x="130" y="82" type="line" name="hintSet0000"/>
+      <point x="127" y="361" type="line"/>
+      <point x="89" y="361" type="line"/>
+      <point x="86" y="82" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="108" y="487"/>
-      <point type="line" x="75" y="455"/>
-      <point type="line" x="108" y="423"/>
-      <point type="line" x="141" y="455"/>
+      <point x="108" y="487" type="line"/>
+      <point x="75" y="455" type="line"/>
+      <point x="108" y="423" type="line"/>
+      <point x="141" y="455" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/A_.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/A_.glif
@@ -4,27 +4,27 @@
   <unicode hex="0041"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/A_acute.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/A_acute.glif
@@ -4,43 +4,43 @@
   <unicode hex="00C1"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="266" y="745"/>
-      <point type="line" x="284" y="720"/>
+      <point x="266" y="745" type="curve"/>
+      <point x="284" y="720" type="line"/>
       <point x="326" y="742"/>
       <point x="368" y="765"/>
-      <point type="curve" x="410" y="788"/>
+      <point x="410" y="788" type="curve"/>
       <point x="448" y="809"/>
       <point x="460" y="825"/>
-      <point type="curve" x="460" y="843"/>
+      <point x="460" y="843" type="curve"/>
       <point x="460" y="863"/>
       <point x="443" y="877"/>
-      <point type="curve" x="422" y="877"/>
+      <point x="422" y="877" type="curve"/>
       <point x="405" y="877"/>
       <point x="388" y="867"/>
-      <point type="curve" x="360" y="839"/>
+      <point x="360" y="839" type="curve"/>
       <point x="328" y="809"/>
       <point x="297" y="778"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/A_dieresis.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/A_dieresis.glif
@@ -4,53 +4,53 @@
   <unicode hex="00C4"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="220" y="744" name="hintSet0019"/>
+      <point x="220" y="744" type="curve" name="hintSet0019"/>
       <point x="252" y="744"/>
       <point x="277" y="767"/>
-      <point type="curve" x="277" y="799"/>
+      <point x="277" y="799" type="curve"/>
       <point x="277" y="831"/>
       <point x="252" y="854"/>
-      <point type="curve" x="220" y="854"/>
+      <point x="220" y="854" type="curve"/>
       <point x="189" y="854"/>
       <point x="162" y="831"/>
-      <point type="curve" x="162" y="799"/>
+      <point x="162" y="799" type="curve"/>
       <point x="162" y="767"/>
       <point x="189" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="443" y="744"/>
+      <point x="443" y="744" type="curve"/>
       <point x="474" y="744"/>
       <point x="501" y="767"/>
-      <point type="curve" x="501" y="799"/>
+      <point x="501" y="799" type="curve"/>
       <point x="501" y="831"/>
       <point x="474" y="854"/>
-      <point type="curve" x="443" y="854"/>
+      <point x="443" y="854" type="curve"/>
       <point x="411" y="854"/>
       <point x="386" y="831"/>
-      <point type="curve" x="386" y="799"/>
+      <point x="386" y="799" type="curve"/>
       <point x="386" y="767"/>
       <point x="411" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/A_tilde.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/A_tilde.glif
@@ -4,53 +4,53 @@
   <unicode hex="00C3"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="151" y="734"/>
-      <point type="line" x="181" y="725"/>
+      <point x="151" y="734" type="curve"/>
+      <point x="181" y="725" type="line"/>
       <point x="196" y="774"/>
       <point x="217" y="804"/>
-      <point type="curve" x="249" y="804"/>
+      <point x="249" y="804" type="curve"/>
       <point x="279" y="804"/>
       <point x="300" y="777"/>
-      <point type="curve" x="325" y="756"/>
+      <point x="325" y="756" type="curve"/>
       <point x="347" y="739" name="hintSet0023"/>
       <point x="370" y="723"/>
-      <point type="curve" x="407" y="723"/>
+      <point x="407" y="723" type="curve"/>
       <point x="468" y="723"/>
       <point x="498" y="774"/>
-      <point type="curve" x="511" y="851"/>
-      <point type="line" x="481" y="861"/>
+      <point x="511" y="851" type="curve"/>
+      <point x="481" y="861" type="line"/>
       <point x="466" y="812"/>
       <point x="446" y="781"/>
-      <point type="curve" x="413" y="781"/>
+      <point x="413" y="781" type="curve"/>
       <point x="383" y="781"/>
       <point x="362" y="809"/>
-      <point type="curve" x="337" y="829"/>
+      <point x="337" y="829" type="curve"/>
       <point x="314" y="847" name="hintSet0028"/>
       <point x="292" y="863"/>
-      <point type="curve" x="256" y="863"/>
+      <point x="256" y="863" type="curve"/>
       <point x="195" y="863" name="hintSet0029"/>
       <point x="163" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/Y_.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/Y_.glif
@@ -4,31 +4,31 @@
   <unicode hex="0059"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/Y_acute.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/Y_acute.glif
@@ -4,47 +4,47 @@
   <unicode hex="00DD"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="305" y="735"/>
-      <point type="line" x="323" y="710"/>
+      <point x="305" y="735" type="curve"/>
+      <point x="323" y="710" type="line"/>
       <point x="365" y="732"/>
       <point x="407" y="755"/>
-      <point type="curve" x="449" y="778"/>
+      <point x="449" y="778" type="curve"/>
       <point x="487" y="799"/>
       <point x="499" y="815"/>
-      <point type="curve" x="499" y="833"/>
+      <point x="499" y="833" type="curve"/>
       <point x="499" y="853"/>
       <point x="482" y="867"/>
-      <point type="curve" x="461" y="867"/>
+      <point x="461" y="867" type="curve"/>
       <point x="444" y="867"/>
       <point x="427" y="857"/>
-      <point type="curve" x="399" y="829"/>
+      <point x="399" y="829" type="curve"/>
       <point x="367" y="799"/>
       <point x="336" y="768"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/Y_dieresis.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/Y_dieresis.glif
@@ -4,57 +4,57 @@
   <unicode hex="0178"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="235" y="744"/>
+      <point x="235" y="744" type="curve"/>
       <point x="267" y="744"/>
       <point x="292" y="767"/>
-      <point type="curve" x="292" y="799"/>
+      <point x="292" y="799" type="curve"/>
       <point x="292" y="831"/>
       <point x="267" y="854"/>
-      <point type="curve" x="235" y="854"/>
+      <point x="235" y="854" type="curve"/>
       <point x="204" y="854"/>
       <point x="177" y="831"/>
-      <point type="curve" x="177" y="799"/>
+      <point x="177" y="799" type="curve"/>
       <point x="177" y="767"/>
       <point x="204" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="458" y="744" name="hintSet0026"/>
+      <point x="458" y="744" type="curve" name="hintSet0026"/>
       <point x="489" y="744"/>
       <point x="516" y="767"/>
-      <point type="curve" x="516" y="799"/>
+      <point x="516" y="799" type="curve"/>
       <point x="516" y="831"/>
       <point x="489" y="854"/>
-      <point type="curve" x="458" y="854"/>
+      <point x="458" y="854" type="curve"/>
       <point x="426" y="854"/>
       <point x="401" y="831"/>
-      <point type="curve" x="401" y="799"/>
+      <point x="401" y="799" type="curve"/>
       <point x="401" y="767"/>
       <point x="426" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/Y_tilde.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/Y_tilde.glif
@@ -4,57 +4,57 @@
   <unicode hex="1EF8"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="166" y="734"/>
-      <point type="line" x="196" y="725"/>
+      <point x="166" y="734" type="curve"/>
+      <point x="196" y="725" type="line"/>
       <point x="211" y="774"/>
       <point x="232" y="804"/>
-      <point type="curve" x="264" y="804"/>
+      <point x="264" y="804" type="curve"/>
       <point x="294" y="804"/>
       <point x="315" y="777"/>
-      <point type="curve" x="340" y="756"/>
+      <point x="340" y="756" type="curve"/>
       <point x="362" y="739" name="hintSet0025"/>
       <point x="385" y="723"/>
-      <point type="curve" x="422" y="723"/>
+      <point x="422" y="723" type="curve"/>
       <point x="483" y="723"/>
       <point x="513" y="774"/>
-      <point type="curve" x="526" y="851"/>
-      <point type="line" x="496" y="861"/>
+      <point x="526" y="851" type="curve"/>
+      <point x="496" y="861" type="line"/>
       <point x="481" y="812"/>
       <point x="461" y="781"/>
-      <point type="curve" x="428" y="781"/>
+      <point x="428" y="781" type="curve"/>
       <point x="398" y="781"/>
       <point x="377" y="809"/>
-      <point type="curve" x="352" y="829"/>
+      <point x="352" y="829" type="curve"/>
       <point x="329" y="847" name="hintSet0030"/>
       <point x="307" y="863"/>
-      <point type="curve" x="271" y="863"/>
+      <point x="271" y="863" type="curve"/>
       <point x="210" y="863" name="hintSet0031"/>
       <point x="178" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/a.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/a.glif
@@ -4,65 +4,65 @@
   <unicode hex="0061"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/aacute.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/aacute.glif
@@ -4,83 +4,83 @@
   <unicode hex="00E1"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="219" y="576"/>
-      <point type="line" x="245" y="557"/>
+      <point x="219" y="576" type="curve"/>
+      <point x="245" y="557" type="line"/>
       <point x="286" y="593"/>
       <point x="325" y="628"/>
-      <point type="curve" x="366" y="665"/>
+      <point x="366" y="665" type="curve"/>
       <point x="394" y="691"/>
       <point x="400" y="706"/>
-      <point type="curve" x="400" y="720"/>
+      <point x="400" y="720" type="curve"/>
       <point x="400" y="746"/>
       <point x="381" y="758"/>
-      <point type="curve" x="362" y="758"/>
+      <point x="362" y="758" type="curve"/>
       <point x="344" y="758"/>
       <point x="327" y="748"/>
-      <point type="curve" x="308" y="717"/>
+      <point x="308" y="717" type="curve"/>
       <point x="276" y="669"/>
       <point x="247" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/acutecmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/acutecmb.cap.glif
@@ -3,20 +3,20 @@
   <advance width="0"/>
   <outline>
     <contour>
-      <point type="curve" x="-67" y="745" name="hintSet0000"/>
-      <point type="line" x="-49" y="720"/>
+      <point x="-67" y="745" type="curve" name="hintSet0000"/>
+      <point x="-49" y="720" type="line"/>
       <point x="-7" y="742"/>
       <point x="35" y="765"/>
-      <point type="curve" x="77" y="788"/>
+      <point x="77" y="788" type="curve"/>
       <point x="115" y="809"/>
       <point x="127" y="825"/>
-      <point type="curve" x="127" y="843"/>
+      <point x="127" y="843" type="curve"/>
       <point x="127" y="863"/>
       <point x="110" y="877"/>
-      <point type="curve" x="89" y="877"/>
+      <point x="89" y="877" type="curve"/>
       <point x="72" y="877"/>
       <point x="55" y="867"/>
-      <point type="curve" x="27" y="839"/>
+      <point x="27" y="839" type="curve"/>
       <point x="-5" y="809"/>
       <point x="-36" y="778"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/acutecmb.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/acutecmb.glif
@@ -4,20 +4,20 @@
   <unicode hex="0301"/>
   <outline>
     <contour>
-      <point type="curve" x="-59" y="576" name="hintSet0000"/>
-      <point type="line" x="-33" y="557"/>
+      <point x="-59" y="576" type="curve" name="hintSet0000"/>
+      <point x="-33" y="557" type="line"/>
       <point x="8" y="593"/>
       <point x="47" y="628"/>
-      <point type="curve" x="88" y="665"/>
+      <point x="88" y="665" type="curve"/>
       <point x="116" y="691"/>
       <point x="122" y="706"/>
-      <point type="curve" x="122" y="720"/>
+      <point x="122" y="720" type="curve"/>
       <point x="122" y="746"/>
       <point x="103" y="758"/>
-      <point type="curve" x="84" y="758"/>
+      <point x="84" y="758" type="curve"/>
       <point x="66" y="758"/>
       <point x="49" y="748"/>
-      <point type="curve" x="30" y="717"/>
+      <point x="30" y="717" type="curve"/>
       <point x="-2" y="669"/>
       <point x="-31" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/adieresis.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/adieresis.glif
@@ -4,93 +4,93 @@
   <unicode hex="00E4"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="355" y="596" name="hintSet0025"/>
+      <point x="355" y="596" type="curve" name="hintSet0025"/>
       <point x="387" y="596"/>
       <point x="414" y="620"/>
-      <point type="curve" x="414" y="653"/>
+      <point x="414" y="653" type="curve"/>
       <point x="414" y="685"/>
       <point x="387" y="710"/>
-      <point type="curve" x="355" y="710"/>
+      <point x="355" y="710" type="curve"/>
       <point x="322" y="710"/>
       <point x="295" y="685"/>
-      <point type="curve" x="295" y="653"/>
+      <point x="295" y="653" type="curve"/>
       <point x="295" y="620"/>
       <point x="322" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="145" y="596"/>
+      <point x="145" y="596" type="curve"/>
       <point x="178" y="596"/>
       <point x="205" y="620"/>
-      <point type="curve" x="205" y="653"/>
+      <point x="205" y="653" type="curve"/>
       <point x="205" y="685"/>
       <point x="178" y="710"/>
-      <point type="curve" x="145" y="710"/>
+      <point x="145" y="710" type="curve"/>
       <point x="113" y="710"/>
       <point x="86" y="685"/>
-      <point type="curve" x="86" y="653"/>
+      <point x="86" y="653" type="curve"/>
       <point x="86" y="620"/>
       <point x="113" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/atilde.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/atilde.glif
@@ -4,93 +4,93 @@
   <unicode hex="00E3"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="80" y="586" name="hintSet0025"/>
-      <point type="line" x="107" y="577"/>
+      <point x="80" y="586" type="curve" name="hintSet0025"/>
+      <point x="107" y="577" type="line"/>
       <point x="121" y="626"/>
       <point x="139" y="656"/>
-      <point type="curve" x="169" y="656"/>
+      <point x="169" y="656" type="curve"/>
       <point x="196" y="656"/>
       <point x="215" y="629"/>
-      <point type="curve" x="238" y="608"/>
+      <point x="238" y="608" type="curve"/>
       <point x="257" y="591" name="hintSet0029"/>
       <point x="278" y="575"/>
-      <point type="curve" x="311" y="575"/>
+      <point x="311" y="575" type="curve"/>
       <point x="367" y="575"/>
       <point x="394" y="626"/>
-      <point type="curve" x="406" y="703"/>
-      <point type="line" x="379" y="713"/>
+      <point x="406" y="703" type="curve"/>
+      <point x="379" y="713" type="line"/>
       <point x="365" y="664"/>
       <point x="347" y="633"/>
-      <point type="curve" x="317" y="633"/>
+      <point x="317" y="633" type="curve"/>
       <point x="290" y="633"/>
       <point x="271" y="661"/>
-      <point type="curve" x="248" y="681"/>
+      <point x="248" y="681" type="curve"/>
       <point x="228" y="699" name="hintSet0034"/>
       <point x="208" y="715"/>
-      <point type="curve" x="175" y="715"/>
+      <point x="175" y="715" type="curve"/>
       <point x="120" y="715"/>
       <point x="91" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/dieresiscmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/dieresiscmb.cap.glif
@@ -3,30 +3,30 @@
   <advance width="0"/>
   <outline>
     <contour>
-      <point type="curve" x="-112" y="744" name="hintSet0000"/>
+      <point x="-112" y="744" type="curve" name="hintSet0000"/>
       <point x="-80" y="744"/>
       <point x="-55" y="767"/>
-      <point type="curve" x="-55" y="799"/>
+      <point x="-55" y="799" type="curve"/>
       <point x="-55" y="831"/>
       <point x="-80" y="854"/>
-      <point type="curve" x="-112" y="854"/>
+      <point x="-112" y="854" type="curve"/>
       <point x="-143" y="854"/>
       <point x="-170" y="831"/>
-      <point type="curve" x="-170" y="799"/>
+      <point x="-170" y="799" type="curve"/>
       <point x="-170" y="767"/>
       <point x="-143" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="111" y="744"/>
+      <point x="111" y="744" type="curve"/>
       <point x="142" y="744"/>
       <point x="169" y="767"/>
-      <point type="curve" x="169" y="799"/>
+      <point x="169" y="799" type="curve"/>
       <point x="169" y="831"/>
       <point x="142" y="854"/>
-      <point type="curve" x="111" y="854"/>
+      <point x="111" y="854" type="curve"/>
       <point x="79" y="854"/>
       <point x="54" y="831"/>
-      <point type="curve" x="54" y="799"/>
+      <point x="54" y="799" type="curve"/>
       <point x="54" y="767"/>
       <point x="79" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/dieresiscmb.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/dieresiscmb.glif
@@ -4,30 +4,30 @@
   <unicode hex="0308"/>
   <outline>
     <contour>
-      <point type="curve" x="105" y="596" name="hintSet0000"/>
+      <point x="105" y="596" type="curve" name="hintSet0000"/>
       <point x="137" y="596"/>
       <point x="164" y="620"/>
-      <point type="curve" x="164" y="653"/>
+      <point x="164" y="653" type="curve"/>
       <point x="164" y="685"/>
       <point x="137" y="710"/>
-      <point type="curve" x="105" y="710"/>
+      <point x="105" y="710" type="curve"/>
       <point x="72" y="710"/>
       <point x="45" y="685"/>
-      <point type="curve" x="45" y="653"/>
+      <point x="45" y="653" type="curve"/>
       <point x="45" y="620"/>
       <point x="72" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="-105" y="596"/>
+      <point x="-105" y="596" type="curve"/>
       <point x="-72" y="596"/>
       <point x="-45" y="620"/>
-      <point type="curve" x="-45" y="653"/>
+      <point x="-45" y="653" type="curve"/>
       <point x="-45" y="685"/>
       <point x="-72" y="710"/>
-      <point type="curve" x="-105" y="710"/>
+      <point x="-105" y="710" type="curve"/>
       <point x="-137" y="710"/>
       <point x="-164" y="685"/>
-      <point type="curve" x="-164" y="653"/>
+      <point x="-164" y="653" type="curve"/>
       <point x="-164" y="620"/>
       <point x="-137" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/tildecmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/tildecmb.cap.glif
@@ -3,30 +3,30 @@
   <advance width="0"/>
   <outline>
     <contour>
-      <point type="curve" x="-180" y="734" name="hintSet0000"/>
-      <point type="line" x="-150" y="725"/>
+      <point x="-180" y="734" type="curve" name="hintSet0000"/>
+      <point x="-150" y="725" type="line"/>
       <point x="-135" y="774"/>
       <point x="-114" y="804"/>
-      <point type="curve" x="-82" y="804"/>
+      <point x="-82" y="804" type="curve"/>
       <point x="-52" y="804"/>
       <point x="-31" y="777"/>
-      <point type="curve" x="-6" y="756"/>
+      <point x="-6" y="756" type="curve"/>
       <point x="16" y="739" name="hintSet0004"/>
       <point x="39" y="723"/>
-      <point type="curve" x="76" y="723"/>
+      <point x="76" y="723" type="curve"/>
       <point x="137" y="723"/>
       <point x="167" y="774"/>
-      <point type="curve" x="180" y="851"/>
-      <point type="line" x="150" y="861"/>
+      <point x="180" y="851" type="curve"/>
+      <point x="150" y="861" type="line"/>
       <point x="135" y="812"/>
       <point x="115" y="781"/>
-      <point type="curve" x="82" y="781"/>
+      <point x="82" y="781" type="curve"/>
       <point x="52" y="781"/>
       <point x="31" y="809"/>
-      <point type="curve" x="6" y="829"/>
+      <point x="6" y="829" type="curve"/>
       <point x="-17" y="847" name="hintSet0009"/>
       <point x="-39" y="863"/>
-      <point type="curve" x="-75" y="863"/>
+      <point x="-75" y="863" type="curve"/>
       <point x="-136" y="863"/>
       <point x="-168" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/tildecmb.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/tildecmb.glif
@@ -4,30 +4,30 @@
   <unicode hex="0303"/>
   <outline>
     <contour>
-      <point type="curve" x="-163" y="586" name="hintSet0000"/>
-      <point type="line" x="-136" y="577"/>
+      <point x="-163" y="586" type="curve" name="hintSet0000"/>
+      <point x="-136" y="577" type="line"/>
       <point x="-122" y="626"/>
       <point x="-104" y="656"/>
-      <point type="curve" x="-74" y="656"/>
+      <point x="-74" y="656" type="curve"/>
       <point x="-47" y="656"/>
       <point x="-28" y="629"/>
-      <point type="curve" x="-5" y="608"/>
+      <point x="-5" y="608" type="curve"/>
       <point x="14" y="591" name="hintSet0004"/>
       <point x="35" y="575"/>
-      <point type="curve" x="68" y="575"/>
+      <point x="68" y="575" type="curve"/>
       <point x="124" y="575"/>
       <point x="151" y="626"/>
-      <point type="curve" x="163" y="703"/>
-      <point type="line" x="136" y="713"/>
+      <point x="163" y="703" type="curve"/>
+      <point x="136" y="713" type="line"/>
       <point x="122" y="664"/>
       <point x="104" y="633"/>
-      <point type="curve" x="74" y="633"/>
+      <point x="74" y="633" type="curve"/>
       <point x="47" y="633"/>
       <point x="28" y="661"/>
-      <point type="curve" x="5" y="681"/>
+      <point x="5" y="681" type="curve"/>
       <point x="-15" y="699" name="hintSet0009"/>
       <point x="-35" y="715"/>
-      <point type="curve" x="-68" y="715"/>
+      <point x="-68" y="715" type="curve"/>
       <point x="-123" y="715"/>
       <point x="-152" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/y.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/y.glif
@@ -4,35 +4,35 @@
   <unicode hex="0079"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/yacute.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/yacute.glif
@@ -4,53 +4,53 @@
   <unicode hex="00FD"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="247" y="576"/>
-      <point type="line" x="273" y="557"/>
+      <point x="247" y="576" type="curve"/>
+      <point x="273" y="557" type="line"/>
       <point x="314" y="593"/>
       <point x="353" y="628"/>
-      <point type="curve" x="394" y="665"/>
+      <point x="394" y="665" type="curve"/>
       <point x="422" y="691"/>
       <point x="428" y="706"/>
-      <point type="curve" x="428" y="720"/>
+      <point x="428" y="720" type="curve"/>
       <point x="428" y="746"/>
       <point x="409" y="758"/>
-      <point type="curve" x="390" y="758"/>
+      <point x="390" y="758" type="curve"/>
       <point x="372" y="758"/>
       <point x="355" y="748"/>
-      <point type="curve" x="336" y="717"/>
+      <point x="336" y="717" type="curve"/>
       <point x="304" y="669"/>
       <point x="275" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/ydieresis.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/ydieresis.glif
@@ -4,63 +4,63 @@
   <unicode hex="00FF"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="389" y="596"/>
+      <point x="389" y="596" type="curve"/>
       <point x="421" y="596"/>
       <point x="448" y="620"/>
-      <point type="curve" x="448" y="653"/>
+      <point x="448" y="653" type="curve"/>
       <point x="448" y="685"/>
       <point x="421" y="710"/>
-      <point type="curve" x="389" y="710"/>
+      <point x="389" y="710" type="curve"/>
       <point x="356" y="710"/>
       <point x="329" y="685"/>
-      <point type="curve" x="329" y="653"/>
+      <point x="329" y="653" type="curve"/>
       <point x="329" y="620"/>
       <point x="356" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="179" y="596"/>
+      <point x="179" y="596" type="curve"/>
       <point x="212" y="596"/>
       <point x="239" y="620"/>
-      <point type="curve" x="239" y="653"/>
+      <point x="239" y="653" type="curve"/>
       <point x="239" y="685"/>
       <point x="212" y="710"/>
-      <point type="curve" x="179" y="710"/>
+      <point x="179" y="710" type="curve"/>
       <point x="147" y="710"/>
       <point x="120" y="685"/>
-      <point type="curve" x="120" y="653"/>
+      <point x="120" y="653" type="curve"/>
       <point x="120" y="620"/>
       <point x="147" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/ytilde.glif
+++ b/tests/autohint_data/expected_output/ufo2-fi.ufo/glyphs.com.adobe.type.processedglyphs/ytilde.glif
@@ -4,63 +4,63 @@
   <unicode hex="1EF9"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="111" y="586" name="hintSet0022"/>
-      <point type="line" x="138" y="577"/>
+      <point x="111" y="586" type="curve" name="hintSet0022"/>
+      <point x="138" y="577" type="line"/>
       <point x="152" y="626"/>
       <point x="170" y="656"/>
-      <point type="curve" x="200" y="656"/>
+      <point x="200" y="656" type="curve"/>
       <point x="227" y="656"/>
       <point x="246" y="629"/>
-      <point type="curve" x="269" y="608"/>
+      <point x="269" y="608" type="curve"/>
       <point x="288" y="591" name="hintSet0026"/>
       <point x="309" y="575"/>
-      <point type="curve" x="342" y="575"/>
+      <point x="342" y="575" type="curve"/>
       <point x="398" y="575"/>
       <point x="425" y="626"/>
-      <point type="curve" x="437" y="703"/>
-      <point type="line" x="410" y="713"/>
+      <point x="437" y="703" type="curve"/>
+      <point x="410" y="713" type="line"/>
       <point x="396" y="664"/>
       <point x="378" y="633"/>
-      <point type="curve" x="348" y="633"/>
+      <point x="348" y="633" type="curve"/>
       <point x="321" y="633"/>
       <point x="302" y="661"/>
-      <point type="curve" x="279" y="681"/>
+      <point x="279" y="681" type="curve"/>
       <point x="259" y="699" name="hintSet0031"/>
       <point x="239" y="715"/>
-      <point type="curve" x="206" y="715"/>
+      <point x="206" y="715" type="curve"/>
       <point x="151" y="715"/>
       <point x="122" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/A_.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/A_.glif
@@ -4,27 +4,27 @@
   <unicode hex="0041"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/A_acute.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/A_acute.glif
@@ -4,43 +4,43 @@
   <unicode hex="00C1"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="266" y="745"/>
-      <point type="line" x="284" y="720"/>
+      <point x="266" y="745" type="curve"/>
+      <point x="284" y="720" type="line"/>
       <point x="326" y="742"/>
       <point x="368" y="765"/>
-      <point type="curve" x="410" y="788"/>
+      <point x="410" y="788" type="curve"/>
       <point x="448" y="809"/>
       <point x="460" y="825"/>
-      <point type="curve" x="460" y="843"/>
+      <point x="460" y="843" type="curve"/>
       <point x="460" y="863"/>
       <point x="443" y="877"/>
-      <point type="curve" x="422" y="877"/>
+      <point x="422" y="877" type="curve"/>
       <point x="405" y="877"/>
       <point x="388" y="867"/>
-      <point type="curve" x="360" y="839"/>
+      <point x="360" y="839" type="curve"/>
       <point x="328" y="809"/>
       <point x="297" y="778"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/A_dieresis.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/A_dieresis.glif
@@ -4,53 +4,53 @@
   <unicode hex="00C4"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="220" y="744" name="hintSet0019"/>
+      <point x="220" y="744" type="curve" name="hintSet0019"/>
       <point x="252" y="744"/>
       <point x="277" y="767"/>
-      <point type="curve" x="277" y="799"/>
+      <point x="277" y="799" type="curve"/>
       <point x="277" y="831"/>
       <point x="252" y="854"/>
-      <point type="curve" x="220" y="854"/>
+      <point x="220" y="854" type="curve"/>
       <point x="189" y="854"/>
       <point x="162" y="831"/>
-      <point type="curve" x="162" y="799"/>
+      <point x="162" y="799" type="curve"/>
       <point x="162" y="767"/>
       <point x="189" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="443" y="744"/>
+      <point x="443" y="744" type="curve"/>
       <point x="474" y="744"/>
       <point x="501" y="767"/>
-      <point type="curve" x="501" y="799"/>
+      <point x="501" y="799" type="curve"/>
       <point x="501" y="831"/>
       <point x="474" y="854"/>
-      <point type="curve" x="443" y="854"/>
+      <point x="443" y="854" type="curve"/>
       <point x="411" y="854"/>
       <point x="386" y="831"/>
-      <point type="curve" x="386" y="799"/>
+      <point x="386" y="799" type="curve"/>
       <point x="386" y="767"/>
       <point x="411" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/A_tilde.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/A_tilde.glif
@@ -4,53 +4,53 @@
   <unicode hex="00C3"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="151" y="734"/>
-      <point type="line" x="181" y="725"/>
+      <point x="151" y="734" type="curve"/>
+      <point x="181" y="725" type="line"/>
       <point x="196" y="774"/>
       <point x="217" y="804"/>
-      <point type="curve" x="249" y="804"/>
+      <point x="249" y="804" type="curve"/>
       <point x="279" y="804"/>
       <point x="300" y="777"/>
-      <point type="curve" x="325" y="756"/>
+      <point x="325" y="756" type="curve"/>
       <point x="347" y="739" name="hintSet0023"/>
       <point x="370" y="723"/>
-      <point type="curve" x="407" y="723"/>
+      <point x="407" y="723" type="curve"/>
       <point x="468" y="723"/>
       <point x="498" y="774"/>
-      <point type="curve" x="511" y="851"/>
-      <point type="line" x="481" y="861"/>
+      <point x="511" y="851" type="curve"/>
+      <point x="481" y="861" type="line"/>
       <point x="466" y="812"/>
       <point x="446" y="781"/>
-      <point type="curve" x="413" y="781"/>
+      <point x="413" y="781" type="curve"/>
       <point x="383" y="781"/>
       <point x="362" y="809"/>
-      <point type="curve" x="337" y="829"/>
+      <point x="337" y="829" type="curve"/>
       <point x="314" y="847" name="hintSet0028"/>
       <point x="292" y="863"/>
-      <point type="curve" x="256" y="863"/>
+      <point x="256" y="863" type="curve"/>
       <point x="195" y="863" name="hintSet0029"/>
       <point x="163" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/Y_.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/Y_.glif
@@ -4,31 +4,31 @@
   <unicode hex="0059"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/Y_acute.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/Y_acute.glif
@@ -4,47 +4,47 @@
   <unicode hex="00DD"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="305" y="735"/>
-      <point type="line" x="323" y="710"/>
+      <point x="305" y="735" type="curve"/>
+      <point x="323" y="710" type="line"/>
       <point x="365" y="732"/>
       <point x="407" y="755"/>
-      <point type="curve" x="449" y="778"/>
+      <point x="449" y="778" type="curve"/>
       <point x="487" y="799"/>
       <point x="499" y="815"/>
-      <point type="curve" x="499" y="833"/>
+      <point x="499" y="833" type="curve"/>
       <point x="499" y="853"/>
       <point x="482" y="867"/>
-      <point type="curve" x="461" y="867"/>
+      <point x="461" y="867" type="curve"/>
       <point x="444" y="867"/>
       <point x="427" y="857"/>
-      <point type="curve" x="399" y="829"/>
+      <point x="399" y="829" type="curve"/>
       <point x="367" y="799"/>
       <point x="336" y="768"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/Y_dieresis.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/Y_dieresis.glif
@@ -4,57 +4,57 @@
   <unicode hex="0178"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="235" y="744"/>
+      <point x="235" y="744" type="curve"/>
       <point x="267" y="744"/>
       <point x="292" y="767"/>
-      <point type="curve" x="292" y="799"/>
+      <point x="292" y="799" type="curve"/>
       <point x="292" y="831"/>
       <point x="267" y="854"/>
-      <point type="curve" x="235" y="854"/>
+      <point x="235" y="854" type="curve"/>
       <point x="204" y="854"/>
       <point x="177" y="831"/>
-      <point type="curve" x="177" y="799"/>
+      <point x="177" y="799" type="curve"/>
       <point x="177" y="767"/>
       <point x="204" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="458" y="744" name="hintSet0026"/>
+      <point x="458" y="744" type="curve" name="hintSet0026"/>
       <point x="489" y="744"/>
       <point x="516" y="767"/>
-      <point type="curve" x="516" y="799"/>
+      <point x="516" y="799" type="curve"/>
       <point x="516" y="831"/>
       <point x="489" y="854"/>
-      <point type="curve" x="458" y="854"/>
+      <point x="458" y="854" type="curve"/>
       <point x="426" y="854"/>
       <point x="401" y="831"/>
-      <point type="curve" x="401" y="799"/>
+      <point x="401" y="799" type="curve"/>
       <point x="401" y="767"/>
       <point x="426" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/Y_tilde.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/Y_tilde.glif
@@ -4,57 +4,57 @@
   <unicode hex="1EF8"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="166" y="734"/>
-      <point type="line" x="196" y="725"/>
+      <point x="166" y="734" type="curve"/>
+      <point x="196" y="725" type="line"/>
       <point x="211" y="774"/>
       <point x="232" y="804"/>
-      <point type="curve" x="264" y="804"/>
+      <point x="264" y="804" type="curve"/>
       <point x="294" y="804"/>
       <point x="315" y="777"/>
-      <point type="curve" x="340" y="756"/>
+      <point x="340" y="756" type="curve"/>
       <point x="362" y="739" name="hintSet0025"/>
       <point x="385" y="723"/>
-      <point type="curve" x="422" y="723"/>
+      <point x="422" y="723" type="curve"/>
       <point x="483" y="723"/>
       <point x="513" y="774"/>
-      <point type="curve" x="526" y="851"/>
-      <point type="line" x="496" y="861"/>
+      <point x="526" y="851" type="curve"/>
+      <point x="496" y="861" type="line"/>
       <point x="481" y="812"/>
       <point x="461" y="781"/>
-      <point type="curve" x="428" y="781"/>
+      <point x="428" y="781" type="curve"/>
       <point x="398" y="781"/>
       <point x="377" y="809"/>
-      <point type="curve" x="352" y="829"/>
+      <point x="352" y="829" type="curve"/>
       <point x="329" y="847" name="hintSet0030"/>
       <point x="307" y="863"/>
-      <point type="curve" x="271" y="863"/>
+      <point x="271" y="863" type="curve"/>
       <point x="210" y="863" name="hintSet0031"/>
       <point x="178" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/a.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/a.glif
@@ -4,65 +4,65 @@
   <unicode hex="0061"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/aacute.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/aacute.glif
@@ -4,83 +4,83 @@
   <unicode hex="00E1"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="219" y="576"/>
-      <point type="line" x="245" y="557"/>
+      <point x="219" y="576" type="curve"/>
+      <point x="245" y="557" type="line"/>
       <point x="286" y="593"/>
       <point x="325" y="628"/>
-      <point type="curve" x="366" y="665"/>
+      <point x="366" y="665" type="curve"/>
       <point x="394" y="691"/>
       <point x="400" y="706"/>
-      <point type="curve" x="400" y="720"/>
+      <point x="400" y="720" type="curve"/>
       <point x="400" y="746"/>
       <point x="381" y="758"/>
-      <point type="curve" x="362" y="758"/>
+      <point x="362" y="758" type="curve"/>
       <point x="344" y="758"/>
       <point x="327" y="748"/>
-      <point type="curve" x="308" y="717"/>
+      <point x="308" y="717" type="curve"/>
       <point x="276" y="669"/>
       <point x="247" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/acutecmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/acutecmb.cap.glif
@@ -3,20 +3,20 @@
   <advance width="0"/>
   <outline>
     <contour>
-      <point type="curve" x="-67" y="745" name="hintSet0000"/>
-      <point type="line" x="-49" y="720"/>
+      <point x="-67" y="745" type="curve" name="hintSet0000"/>
+      <point x="-49" y="720" type="line"/>
       <point x="-7" y="742"/>
       <point x="35" y="765"/>
-      <point type="curve" x="77" y="788"/>
+      <point x="77" y="788" type="curve"/>
       <point x="115" y="809"/>
       <point x="127" y="825"/>
-      <point type="curve" x="127" y="843"/>
+      <point x="127" y="843" type="curve"/>
       <point x="127" y="863"/>
       <point x="110" y="877"/>
-      <point type="curve" x="89" y="877"/>
+      <point x="89" y="877" type="curve"/>
       <point x="72" y="877"/>
       <point x="55" y="867"/>
-      <point type="curve" x="27" y="839"/>
+      <point x="27" y="839" type="curve"/>
       <point x="-5" y="809"/>
       <point x="-36" y="778"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/acutecmb.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/acutecmb.glif
@@ -4,20 +4,20 @@
   <unicode hex="0301"/>
   <outline>
     <contour>
-      <point type="curve" x="-59" y="576" name="hintSet0000"/>
-      <point type="line" x="-33" y="557"/>
+      <point x="-59" y="576" type="curve" name="hintSet0000"/>
+      <point x="-33" y="557" type="line"/>
       <point x="8" y="593"/>
       <point x="47" y="628"/>
-      <point type="curve" x="88" y="665"/>
+      <point x="88" y="665" type="curve"/>
       <point x="116" y="691"/>
       <point x="122" y="706"/>
-      <point type="curve" x="122" y="720"/>
+      <point x="122" y="720" type="curve"/>
       <point x="122" y="746"/>
       <point x="103" y="758"/>
-      <point type="curve" x="84" y="758"/>
+      <point x="84" y="758" type="curve"/>
       <point x="66" y="758"/>
       <point x="49" y="748"/>
-      <point type="curve" x="30" y="717"/>
+      <point x="30" y="717" type="curve"/>
       <point x="-2" y="669"/>
       <point x="-31" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/adieresis.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/adieresis.glif
@@ -4,93 +4,93 @@
   <unicode hex="00E4"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="355" y="596" name="hintSet0025"/>
+      <point x="355" y="596" type="curve" name="hintSet0025"/>
       <point x="387" y="596"/>
       <point x="414" y="620"/>
-      <point type="curve" x="414" y="653"/>
+      <point x="414" y="653" type="curve"/>
       <point x="414" y="685"/>
       <point x="387" y="710"/>
-      <point type="curve" x="355" y="710"/>
+      <point x="355" y="710" type="curve"/>
       <point x="322" y="710"/>
       <point x="295" y="685"/>
-      <point type="curve" x="295" y="653"/>
+      <point x="295" y="653" type="curve"/>
       <point x="295" y="620"/>
       <point x="322" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="145" y="596"/>
+      <point x="145" y="596" type="curve"/>
       <point x="178" y="596"/>
       <point x="205" y="620"/>
-      <point type="curve" x="205" y="653"/>
+      <point x="205" y="653" type="curve"/>
       <point x="205" y="685"/>
       <point x="178" y="710"/>
-      <point type="curve" x="145" y="710"/>
+      <point x="145" y="710" type="curve"/>
       <point x="113" y="710"/>
       <point x="86" y="685"/>
-      <point type="curve" x="86" y="653"/>
+      <point x="86" y="653" type="curve"/>
       <point x="86" y="620"/>
       <point x="113" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/atilde.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/atilde.glif
@@ -4,93 +4,93 @@
   <unicode hex="00E3"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="80" y="586" name="hintSet0025"/>
-      <point type="line" x="107" y="577"/>
+      <point x="80" y="586" type="curve" name="hintSet0025"/>
+      <point x="107" y="577" type="line"/>
       <point x="121" y="626"/>
       <point x="139" y="656"/>
-      <point type="curve" x="169" y="656"/>
+      <point x="169" y="656" type="curve"/>
       <point x="196" y="656"/>
       <point x="215" y="629"/>
-      <point type="curve" x="238" y="608"/>
+      <point x="238" y="608" type="curve"/>
       <point x="257" y="591" name="hintSet0029"/>
       <point x="278" y="575"/>
-      <point type="curve" x="311" y="575"/>
+      <point x="311" y="575" type="curve"/>
       <point x="367" y="575"/>
       <point x="394" y="626"/>
-      <point type="curve" x="406" y="703"/>
-      <point type="line" x="379" y="713"/>
+      <point x="406" y="703" type="curve"/>
+      <point x="379" y="713" type="line"/>
       <point x="365" y="664"/>
       <point x="347" y="633"/>
-      <point type="curve" x="317" y="633"/>
+      <point x="317" y="633" type="curve"/>
       <point x="290" y="633"/>
       <point x="271" y="661"/>
-      <point type="curve" x="248" y="681"/>
+      <point x="248" y="681" type="curve"/>
       <point x="228" y="699" name="hintSet0034"/>
       <point x="208" y="715"/>
-      <point type="curve" x="175" y="715"/>
+      <point x="175" y="715" type="curve"/>
       <point x="120" y="715"/>
       <point x="91" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/dieresiscmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/dieresiscmb.cap.glif
@@ -3,30 +3,30 @@
   <advance width="0"/>
   <outline>
     <contour>
-      <point type="curve" x="-112" y="744" name="hintSet0000"/>
+      <point x="-112" y="744" type="curve" name="hintSet0000"/>
       <point x="-80" y="744"/>
       <point x="-55" y="767"/>
-      <point type="curve" x="-55" y="799"/>
+      <point x="-55" y="799" type="curve"/>
       <point x="-55" y="831"/>
       <point x="-80" y="854"/>
-      <point type="curve" x="-112" y="854"/>
+      <point x="-112" y="854" type="curve"/>
       <point x="-143" y="854"/>
       <point x="-170" y="831"/>
-      <point type="curve" x="-170" y="799"/>
+      <point x="-170" y="799" type="curve"/>
       <point x="-170" y="767"/>
       <point x="-143" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="111" y="744"/>
+      <point x="111" y="744" type="curve"/>
       <point x="142" y="744"/>
       <point x="169" y="767"/>
-      <point type="curve" x="169" y="799"/>
+      <point x="169" y="799" type="curve"/>
       <point x="169" y="831"/>
       <point x="142" y="854"/>
-      <point type="curve" x="111" y="854"/>
+      <point x="111" y="854" type="curve"/>
       <point x="79" y="854"/>
       <point x="54" y="831"/>
-      <point type="curve" x="54" y="799"/>
+      <point x="54" y="799" type="curve"/>
       <point x="54" y="767"/>
       <point x="79" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/dieresiscmb.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/dieresiscmb.glif
@@ -4,30 +4,30 @@
   <unicode hex="0308"/>
   <outline>
     <contour>
-      <point type="curve" x="105" y="596" name="hintSet0000"/>
+      <point x="105" y="596" type="curve" name="hintSet0000"/>
       <point x="137" y="596"/>
       <point x="164" y="620"/>
-      <point type="curve" x="164" y="653"/>
+      <point x="164" y="653" type="curve"/>
       <point x="164" y="685"/>
       <point x="137" y="710"/>
-      <point type="curve" x="105" y="710"/>
+      <point x="105" y="710" type="curve"/>
       <point x="72" y="710"/>
       <point x="45" y="685"/>
-      <point type="curve" x="45" y="653"/>
+      <point x="45" y="653" type="curve"/>
       <point x="45" y="620"/>
       <point x="72" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="-105" y="596"/>
+      <point x="-105" y="596" type="curve"/>
       <point x="-72" y="596"/>
       <point x="-45" y="620"/>
-      <point type="curve" x="-45" y="653"/>
+      <point x="-45" y="653" type="curve"/>
       <point x="-45" y="685"/>
       <point x="-72" y="710"/>
-      <point type="curve" x="-105" y="710"/>
+      <point x="-105" y="710" type="curve"/>
       <point x="-137" y="710"/>
       <point x="-164" y="685"/>
-      <point type="curve" x="-164" y="653"/>
+      <point x="-164" y="653" type="curve"/>
       <point x="-164" y="620"/>
       <point x="-137" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/tildecmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/tildecmb.cap.glif
@@ -3,30 +3,30 @@
   <advance width="0"/>
   <outline>
     <contour>
-      <point type="curve" x="-180" y="734" name="hintSet0000"/>
-      <point type="line" x="-150" y="725"/>
+      <point x="-180" y="734" type="curve" name="hintSet0000"/>
+      <point x="-150" y="725" type="line"/>
       <point x="-135" y="774"/>
       <point x="-114" y="804"/>
-      <point type="curve" x="-82" y="804"/>
+      <point x="-82" y="804" type="curve"/>
       <point x="-52" y="804"/>
       <point x="-31" y="777"/>
-      <point type="curve" x="-6" y="756"/>
+      <point x="-6" y="756" type="curve"/>
       <point x="16" y="739" name="hintSet0004"/>
       <point x="39" y="723"/>
-      <point type="curve" x="76" y="723"/>
+      <point x="76" y="723" type="curve"/>
       <point x="137" y="723"/>
       <point x="167" y="774"/>
-      <point type="curve" x="180" y="851"/>
-      <point type="line" x="150" y="861"/>
+      <point x="180" y="851" type="curve"/>
+      <point x="150" y="861" type="line"/>
       <point x="135" y="812"/>
       <point x="115" y="781"/>
-      <point type="curve" x="82" y="781"/>
+      <point x="82" y="781" type="curve"/>
       <point x="52" y="781"/>
       <point x="31" y="809"/>
-      <point type="curve" x="6" y="829"/>
+      <point x="6" y="829" type="curve"/>
       <point x="-17" y="847" name="hintSet0009"/>
       <point x="-39" y="863"/>
-      <point type="curve" x="-75" y="863"/>
+      <point x="-75" y="863" type="curve"/>
       <point x="-136" y="863"/>
       <point x="-168" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/tildecmb.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/tildecmb.glif
@@ -4,30 +4,30 @@
   <unicode hex="0303"/>
   <outline>
     <contour>
-      <point type="curve" x="-163" y="586" name="hintSet0000"/>
-      <point type="line" x="-136" y="577"/>
+      <point x="-163" y="586" type="curve" name="hintSet0000"/>
+      <point x="-136" y="577" type="line"/>
       <point x="-122" y="626"/>
       <point x="-104" y="656"/>
-      <point type="curve" x="-74" y="656"/>
+      <point x="-74" y="656" type="curve"/>
       <point x="-47" y="656"/>
       <point x="-28" y="629"/>
-      <point type="curve" x="-5" y="608"/>
+      <point x="-5" y="608" type="curve"/>
       <point x="14" y="591" name="hintSet0004"/>
       <point x="35" y="575"/>
-      <point type="curve" x="68" y="575"/>
+      <point x="68" y="575" type="curve"/>
       <point x="124" y="575"/>
       <point x="151" y="626"/>
-      <point type="curve" x="163" y="703"/>
-      <point type="line" x="136" y="713"/>
+      <point x="163" y="703" type="curve"/>
+      <point x="136" y="713" type="line"/>
       <point x="122" y="664"/>
       <point x="104" y="633"/>
-      <point type="curve" x="74" y="633"/>
+      <point x="74" y="633" type="curve"/>
       <point x="47" y="633"/>
       <point x="28" y="661"/>
-      <point type="curve" x="5" y="681"/>
+      <point x="5" y="681" type="curve"/>
       <point x="-15" y="699" name="hintSet0009"/>
       <point x="-35" y="715"/>
-      <point type="curve" x="-68" y="715"/>
+      <point x="-68" y="715" type="curve"/>
       <point x="-123" y="715"/>
       <point x="-152" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/y.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/y.glif
@@ -4,35 +4,35 @@
   <unicode hex="0079"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/yacute.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/yacute.glif
@@ -4,53 +4,53 @@
   <unicode hex="00FD"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="247" y="576"/>
-      <point type="line" x="273" y="557"/>
+      <point x="247" y="576" type="curve"/>
+      <point x="273" y="557" type="line"/>
       <point x="314" y="593"/>
       <point x="353" y="628"/>
-      <point type="curve" x="394" y="665"/>
+      <point x="394" y="665" type="curve"/>
       <point x="422" y="691"/>
       <point x="428" y="706"/>
-      <point type="curve" x="428" y="720"/>
+      <point x="428" y="720" type="curve"/>
       <point x="428" y="746"/>
       <point x="409" y="758"/>
-      <point type="curve" x="390" y="758"/>
+      <point x="390" y="758" type="curve"/>
       <point x="372" y="758"/>
       <point x="355" y="748"/>
-      <point type="curve" x="336" y="717"/>
+      <point x="336" y="717" type="curve"/>
       <point x="304" y="669"/>
       <point x="275" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/ydieresis.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/ydieresis.glif
@@ -4,63 +4,63 @@
   <unicode hex="00FF"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="389" y="596"/>
+      <point x="389" y="596" type="curve"/>
       <point x="421" y="596"/>
       <point x="448" y="620"/>
-      <point type="curve" x="448" y="653"/>
+      <point x="448" y="653" type="curve"/>
       <point x="448" y="685"/>
       <point x="421" y="710"/>
-      <point type="curve" x="389" y="710"/>
+      <point x="389" y="710" type="curve"/>
       <point x="356" y="710"/>
       <point x="329" y="685"/>
-      <point type="curve" x="329" y="653"/>
+      <point x="329" y="653" type="curve"/>
       <point x="329" y="620"/>
       <point x="356" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="179" y="596"/>
+      <point x="179" y="596" type="curve"/>
       <point x="212" y="596"/>
       <point x="239" y="620"/>
-      <point type="curve" x="239" y="653"/>
+      <point x="239" y="653" type="curve"/>
       <point x="239" y="685"/>
       <point x="212" y="710"/>
-      <point type="curve" x="179" y="710"/>
+      <point x="179" y="710" type="curve"/>
       <point x="147" y="710"/>
       <point x="120" y="685"/>
-      <point type="curve" x="120" y="653"/>
+      <point x="120" y="653" type="curve"/>
       <point x="120" y="620"/>
       <point x="147" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/ytilde.glif
+++ b/tests/autohint_data/expected_output/ufo2-wd.ufo/glyphs/ytilde.glif
@@ -4,63 +4,63 @@
   <unicode hex="1EF9"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="111" y="586" name="hintSet0022"/>
-      <point type="line" x="138" y="577"/>
+      <point x="111" y="586" type="curve" name="hintSet0022"/>
+      <point x="138" y="577" type="line"/>
       <point x="152" y="626"/>
       <point x="170" y="656"/>
-      <point type="curve" x="200" y="656"/>
+      <point x="200" y="656" type="curve"/>
       <point x="227" y="656"/>
       <point x="246" y="629"/>
-      <point type="curve" x="269" y="608"/>
+      <point x="269" y="608" type="curve"/>
       <point x="288" y="591" name="hintSet0026"/>
       <point x="309" y="575"/>
-      <point type="curve" x="342" y="575"/>
+      <point x="342" y="575" type="curve"/>
       <point x="398" y="575"/>
       <point x="425" y="626"/>
-      <point type="curve" x="437" y="703"/>
-      <point type="line" x="410" y="713"/>
+      <point x="437" y="703" type="curve"/>
+      <point x="410" y="713" type="line"/>
       <point x="396" y="664"/>
       <point x="378" y="633"/>
-      <point type="curve" x="348" y="633"/>
+      <point x="348" y="633" type="curve"/>
       <point x="321" y="633"/>
       <point x="302" y="661"/>
-      <point type="curve" x="279" y="681"/>
+      <point x="279" y="681" type="curve"/>
       <point x="259" y="699" name="hintSet0031"/>
       <point x="239" y="715"/>
-      <point type="curve" x="206" y="715"/>
+      <point x="206" y="715" type="curve"/>
       <point x="151" y="715"/>
       <point x="122" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/A_.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/A_.glif
@@ -4,27 +4,27 @@
   <unicode hex="0041"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/A_acute.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/A_acute.glif
@@ -4,43 +4,43 @@
   <unicode hex="00C1"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="266" y="745"/>
-      <point type="line" x="284" y="720"/>
+      <point x="266" y="745" type="curve"/>
+      <point x="284" y="720" type="line"/>
       <point x="326" y="742"/>
       <point x="368" y="765"/>
-      <point type="curve" x="410" y="788"/>
+      <point x="410" y="788" type="curve"/>
       <point x="448" y="809"/>
       <point x="460" y="825"/>
-      <point type="curve" x="460" y="843"/>
+      <point x="460" y="843" type="curve"/>
       <point x="460" y="863"/>
       <point x="443" y="877"/>
-      <point type="curve" x="422" y="877"/>
+      <point x="422" y="877" type="curve"/>
       <point x="405" y="877"/>
       <point x="388" y="867"/>
-      <point type="curve" x="360" y="839"/>
+      <point x="360" y="839" type="curve"/>
       <point x="328" y="809"/>
       <point x="297" y="778"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/A_dieresis.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/A_dieresis.glif
@@ -4,53 +4,53 @@
   <unicode hex="00C4"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="220" y="744" name="hintSet0019"/>
+      <point x="220" y="744" type="curve" name="hintSet0019"/>
       <point x="252" y="744"/>
       <point x="277" y="767"/>
-      <point type="curve" x="277" y="799"/>
+      <point x="277" y="799" type="curve"/>
       <point x="277" y="831"/>
       <point x="252" y="854"/>
-      <point type="curve" x="220" y="854"/>
+      <point x="220" y="854" type="curve"/>
       <point x="189" y="854"/>
       <point x="162" y="831"/>
-      <point type="curve" x="162" y="799"/>
+      <point x="162" y="799" type="curve"/>
       <point x="162" y="767"/>
       <point x="189" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="443" y="744"/>
+      <point x="443" y="744" type="curve"/>
       <point x="474" y="744"/>
       <point x="501" y="767"/>
-      <point type="curve" x="501" y="799"/>
+      <point x="501" y="799" type="curve"/>
       <point x="501" y="831"/>
       <point x="474" y="854"/>
-      <point type="curve" x="443" y="854"/>
+      <point x="443" y="854" type="curve"/>
       <point x="411" y="854"/>
       <point x="386" y="831"/>
-      <point type="curve" x="386" y="799"/>
+      <point x="386" y="799" type="curve"/>
       <point x="386" y="767"/>
       <point x="411" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/A_tilde.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/A_tilde.glif
@@ -4,53 +4,53 @@
   <unicode hex="00C3"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="151" y="734"/>
-      <point type="line" x="181" y="725"/>
+      <point x="151" y="734" type="curve"/>
+      <point x="181" y="725" type="line"/>
       <point x="196" y="774"/>
       <point x="217" y="804"/>
-      <point type="curve" x="249" y="804"/>
+      <point x="249" y="804" type="curve"/>
       <point x="279" y="804"/>
       <point x="300" y="777"/>
-      <point type="curve" x="325" y="756"/>
+      <point x="325" y="756" type="curve"/>
       <point x="347" y="739" name="hintSet0023"/>
       <point x="370" y="723"/>
-      <point type="curve" x="407" y="723"/>
+      <point x="407" y="723" type="curve"/>
       <point x="468" y="723"/>
       <point x="498" y="774"/>
-      <point type="curve" x="511" y="851"/>
-      <point type="line" x="481" y="861"/>
+      <point x="511" y="851" type="curve"/>
+      <point x="481" y="861" type="line"/>
       <point x="466" y="812"/>
       <point x="446" y="781"/>
-      <point type="curve" x="413" y="781"/>
+      <point x="413" y="781" type="curve"/>
       <point x="383" y="781"/>
       <point x="362" y="809"/>
-      <point type="curve" x="337" y="829"/>
+      <point x="337" y="829" type="curve"/>
       <point x="314" y="847" name="hintSet0028"/>
       <point x="292" y="863"/>
-      <point type="curve" x="256" y="863"/>
+      <point x="256" y="863" type="curve"/>
       <point x="195" y="863" name="hintSet0029"/>
       <point x="163" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/Y_.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/Y_.glif
@@ -4,31 +4,31 @@
   <unicode hex="0059"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/Y_acute.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/Y_acute.glif
@@ -4,47 +4,47 @@
   <unicode hex="00DD"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="305" y="735"/>
-      <point type="line" x="323" y="710"/>
+      <point x="305" y="735" type="curve"/>
+      <point x="323" y="710" type="line"/>
       <point x="365" y="732"/>
       <point x="407" y="755"/>
-      <point type="curve" x="449" y="778"/>
+      <point x="449" y="778" type="curve"/>
       <point x="487" y="799"/>
       <point x="499" y="815"/>
-      <point type="curve" x="499" y="833"/>
+      <point x="499" y="833" type="curve"/>
       <point x="499" y="853"/>
       <point x="482" y="867"/>
-      <point type="curve" x="461" y="867"/>
+      <point x="461" y="867" type="curve"/>
       <point x="444" y="867"/>
       <point x="427" y="857"/>
-      <point type="curve" x="399" y="829"/>
+      <point x="399" y="829" type="curve"/>
       <point x="367" y="799"/>
       <point x="336" y="768"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/Y_dieresis.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/Y_dieresis.glif
@@ -4,57 +4,57 @@
   <unicode hex="0178"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="235" y="744"/>
+      <point x="235" y="744" type="curve"/>
       <point x="267" y="744"/>
       <point x="292" y="767"/>
-      <point type="curve" x="292" y="799"/>
+      <point x="292" y="799" type="curve"/>
       <point x="292" y="831"/>
       <point x="267" y="854"/>
-      <point type="curve" x="235" y="854"/>
+      <point x="235" y="854" type="curve"/>
       <point x="204" y="854"/>
       <point x="177" y="831"/>
-      <point type="curve" x="177" y="799"/>
+      <point x="177" y="799" type="curve"/>
       <point x="177" y="767"/>
       <point x="204" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="458" y="744" name="hintSet0026"/>
+      <point x="458" y="744" type="curve" name="hintSet0026"/>
       <point x="489" y="744"/>
       <point x="516" y="767"/>
-      <point type="curve" x="516" y="799"/>
+      <point x="516" y="799" type="curve"/>
       <point x="516" y="831"/>
       <point x="489" y="854"/>
-      <point type="curve" x="458" y="854"/>
+      <point x="458" y="854" type="curve"/>
       <point x="426" y="854"/>
       <point x="401" y="831"/>
-      <point type="curve" x="401" y="799"/>
+      <point x="401" y="799" type="curve"/>
       <point x="401" y="767"/>
       <point x="426" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/Y_tilde.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/Y_tilde.glif
@@ -4,57 +4,57 @@
   <unicode hex="1EF8"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="166" y="734"/>
-      <point type="line" x="196" y="725"/>
+      <point x="166" y="734" type="curve"/>
+      <point x="196" y="725" type="line"/>
       <point x="211" y="774"/>
       <point x="232" y="804"/>
-      <point type="curve" x="264" y="804"/>
+      <point x="264" y="804" type="curve"/>
       <point x="294" y="804"/>
       <point x="315" y="777"/>
-      <point type="curve" x="340" y="756"/>
+      <point x="340" y="756" type="curve"/>
       <point x="362" y="739" name="hintSet0025"/>
       <point x="385" y="723"/>
-      <point type="curve" x="422" y="723"/>
+      <point x="422" y="723" type="curve"/>
       <point x="483" y="723"/>
       <point x="513" y="774"/>
-      <point type="curve" x="526" y="851"/>
-      <point type="line" x="496" y="861"/>
+      <point x="526" y="851" type="curve"/>
+      <point x="496" y="861" type="line"/>
       <point x="481" y="812"/>
       <point x="461" y="781"/>
-      <point type="curve" x="428" y="781"/>
+      <point x="428" y="781" type="curve"/>
       <point x="398" y="781"/>
       <point x="377" y="809"/>
-      <point type="curve" x="352" y="829"/>
+      <point x="352" y="829" type="curve"/>
       <point x="329" y="847" name="hintSet0030"/>
       <point x="307" y="863"/>
-      <point type="curve" x="271" y="863"/>
+      <point x="271" y="863" type="curve"/>
       <point x="210" y="863" name="hintSet0031"/>
       <point x="178" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/a.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/a.glif
@@ -4,65 +4,65 @@
   <unicode hex="0061"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/aacute.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/aacute.glif
@@ -4,83 +4,83 @@
   <unicode hex="00E1"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="219" y="576"/>
-      <point type="line" x="245" y="557"/>
+      <point x="219" y="576" type="curve"/>
+      <point x="245" y="557" type="line"/>
       <point x="286" y="593"/>
       <point x="325" y="628"/>
-      <point type="curve" x="366" y="665"/>
+      <point x="366" y="665" type="curve"/>
       <point x="394" y="691"/>
       <point x="400" y="706"/>
-      <point type="curve" x="400" y="720"/>
+      <point x="400" y="720" type="curve"/>
       <point x="400" y="746"/>
       <point x="381" y="758"/>
-      <point type="curve" x="362" y="758"/>
+      <point x="362" y="758" type="curve"/>
       <point x="344" y="758"/>
       <point x="327" y="748"/>
-      <point type="curve" x="308" y="717"/>
+      <point x="308" y="717" type="curve"/>
       <point x="276" y="669"/>
       <point x="247" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/acutecmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/acutecmb.cap.glif
@@ -3,20 +3,20 @@
   <advance width="0"/>
   <outline>
     <contour>
-      <point type="curve" x="-67" y="745" name="hintSet0000"/>
-      <point type="line" x="-49" y="720"/>
+      <point x="-67" y="745" type="curve" name="hintSet0000"/>
+      <point x="-49" y="720" type="line"/>
       <point x="-7" y="742"/>
       <point x="35" y="765"/>
-      <point type="curve" x="77" y="788"/>
+      <point x="77" y="788" type="curve"/>
       <point x="115" y="809"/>
       <point x="127" y="825"/>
-      <point type="curve" x="127" y="843"/>
+      <point x="127" y="843" type="curve"/>
       <point x="127" y="863"/>
       <point x="110" y="877"/>
-      <point type="curve" x="89" y="877"/>
+      <point x="89" y="877" type="curve"/>
       <point x="72" y="877"/>
       <point x="55" y="867"/>
-      <point type="curve" x="27" y="839"/>
+      <point x="27" y="839" type="curve"/>
       <point x="-5" y="809"/>
       <point x="-36" y="778"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/acutecmb.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/acutecmb.glif
@@ -4,20 +4,20 @@
   <unicode hex="0301"/>
   <outline>
     <contour>
-      <point type="curve" x="-59" y="576" name="hintSet0000"/>
-      <point type="line" x="-33" y="557"/>
+      <point x="-59" y="576" type="curve" name="hintSet0000"/>
+      <point x="-33" y="557" type="line"/>
       <point x="8" y="593"/>
       <point x="47" y="628"/>
-      <point type="curve" x="88" y="665"/>
+      <point x="88" y="665" type="curve"/>
       <point x="116" y="691"/>
       <point x="122" y="706"/>
-      <point type="curve" x="122" y="720"/>
+      <point x="122" y="720" type="curve"/>
       <point x="122" y="746"/>
       <point x="103" y="758"/>
-      <point type="curve" x="84" y="758"/>
+      <point x="84" y="758" type="curve"/>
       <point x="66" y="758"/>
       <point x="49" y="748"/>
-      <point type="curve" x="30" y="717"/>
+      <point x="30" y="717" type="curve"/>
       <point x="-2" y="669"/>
       <point x="-31" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/adieresis.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/adieresis.glif
@@ -4,93 +4,93 @@
   <unicode hex="00E4"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="355" y="596" name="hintSet0025"/>
+      <point x="355" y="596" type="curve" name="hintSet0025"/>
       <point x="387" y="596"/>
       <point x="414" y="620"/>
-      <point type="curve" x="414" y="653"/>
+      <point x="414" y="653" type="curve"/>
       <point x="414" y="685"/>
       <point x="387" y="710"/>
-      <point type="curve" x="355" y="710"/>
+      <point x="355" y="710" type="curve"/>
       <point x="322" y="710"/>
       <point x="295" y="685"/>
-      <point type="curve" x="295" y="653"/>
+      <point x="295" y="653" type="curve"/>
       <point x="295" y="620"/>
       <point x="322" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="145" y="596"/>
+      <point x="145" y="596" type="curve"/>
       <point x="178" y="596"/>
       <point x="205" y="620"/>
-      <point type="curve" x="205" y="653"/>
+      <point x="205" y="653" type="curve"/>
       <point x="205" y="685"/>
       <point x="178" y="710"/>
-      <point type="curve" x="145" y="710"/>
+      <point x="145" y="710" type="curve"/>
       <point x="113" y="710"/>
       <point x="86" y="685"/>
-      <point type="curve" x="86" y="653"/>
+      <point x="86" y="653" type="curve"/>
       <point x="86" y="620"/>
       <point x="113" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/atilde.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/atilde.glif
@@ -4,93 +4,93 @@
   <unicode hex="00E3"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="80" y="586" name="hintSet0025"/>
-      <point type="line" x="107" y="577"/>
+      <point x="80" y="586" type="curve" name="hintSet0025"/>
+      <point x="107" y="577" type="line"/>
       <point x="121" y="626"/>
       <point x="139" y="656"/>
-      <point type="curve" x="169" y="656"/>
+      <point x="169" y="656" type="curve"/>
       <point x="196" y="656"/>
       <point x="215" y="629"/>
-      <point type="curve" x="238" y="608"/>
+      <point x="238" y="608" type="curve"/>
       <point x="257" y="591" name="hintSet0029"/>
       <point x="278" y="575"/>
-      <point type="curve" x="311" y="575"/>
+      <point x="311" y="575" type="curve"/>
       <point x="367" y="575"/>
       <point x="394" y="626"/>
-      <point type="curve" x="406" y="703"/>
-      <point type="line" x="379" y="713"/>
+      <point x="406" y="703" type="curve"/>
+      <point x="379" y="713" type="line"/>
       <point x="365" y="664"/>
       <point x="347" y="633"/>
-      <point type="curve" x="317" y="633"/>
+      <point x="317" y="633" type="curve"/>
       <point x="290" y="633"/>
       <point x="271" y="661"/>
-      <point type="curve" x="248" y="681"/>
+      <point x="248" y="681" type="curve"/>
       <point x="228" y="699" name="hintSet0034"/>
       <point x="208" y="715"/>
-      <point type="curve" x="175" y="715"/>
+      <point x="175" y="715" type="curve"/>
       <point x="120" y="715"/>
       <point x="91" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/dieresiscmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/dieresiscmb.cap.glif
@@ -3,30 +3,30 @@
   <advance width="0"/>
   <outline>
     <contour>
-      <point type="curve" x="-112" y="744" name="hintSet0000"/>
+      <point x="-112" y="744" type="curve" name="hintSet0000"/>
       <point x="-80" y="744"/>
       <point x="-55" y="767"/>
-      <point type="curve" x="-55" y="799"/>
+      <point x="-55" y="799" type="curve"/>
       <point x="-55" y="831"/>
       <point x="-80" y="854"/>
-      <point type="curve" x="-112" y="854"/>
+      <point x="-112" y="854" type="curve"/>
       <point x="-143" y="854"/>
       <point x="-170" y="831"/>
-      <point type="curve" x="-170" y="799"/>
+      <point x="-170" y="799" type="curve"/>
       <point x="-170" y="767"/>
       <point x="-143" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="111" y="744"/>
+      <point x="111" y="744" type="curve"/>
       <point x="142" y="744"/>
       <point x="169" y="767"/>
-      <point type="curve" x="169" y="799"/>
+      <point x="169" y="799" type="curve"/>
       <point x="169" y="831"/>
       <point x="142" y="854"/>
-      <point type="curve" x="111" y="854"/>
+      <point x="111" y="854" type="curve"/>
       <point x="79" y="854"/>
       <point x="54" y="831"/>
-      <point type="curve" x="54" y="799"/>
+      <point x="54" y="799" type="curve"/>
       <point x="54" y="767"/>
       <point x="79" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/dieresiscmb.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/dieresiscmb.glif
@@ -4,30 +4,30 @@
   <unicode hex="0308"/>
   <outline>
     <contour>
-      <point type="curve" x="105" y="596" name="hintSet0000"/>
+      <point x="105" y="596" type="curve" name="hintSet0000"/>
       <point x="137" y="596"/>
       <point x="164" y="620"/>
-      <point type="curve" x="164" y="653"/>
+      <point x="164" y="653" type="curve"/>
       <point x="164" y="685"/>
       <point x="137" y="710"/>
-      <point type="curve" x="105" y="710"/>
+      <point x="105" y="710" type="curve"/>
       <point x="72" y="710"/>
       <point x="45" y="685"/>
-      <point type="curve" x="45" y="653"/>
+      <point x="45" y="653" type="curve"/>
       <point x="45" y="620"/>
       <point x="72" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="-105" y="596"/>
+      <point x="-105" y="596" type="curve"/>
       <point x="-72" y="596"/>
       <point x="-45" y="620"/>
-      <point type="curve" x="-45" y="653"/>
+      <point x="-45" y="653" type="curve"/>
       <point x="-45" y="685"/>
       <point x="-72" y="710"/>
-      <point type="curve" x="-105" y="710"/>
+      <point x="-105" y="710" type="curve"/>
       <point x="-137" y="710"/>
       <point x="-164" y="685"/>
-      <point type="curve" x="-164" y="653"/>
+      <point x="-164" y="653" type="curve"/>
       <point x="-164" y="620"/>
       <point x="-137" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/tildecmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/tildecmb.cap.glif
@@ -3,30 +3,30 @@
   <advance width="0"/>
   <outline>
     <contour>
-      <point type="curve" x="-180" y="734" name="hintSet0000"/>
-      <point type="line" x="-150" y="725"/>
+      <point x="-180" y="734" type="curve" name="hintSet0000"/>
+      <point x="-150" y="725" type="line"/>
       <point x="-135" y="774"/>
       <point x="-114" y="804"/>
-      <point type="curve" x="-82" y="804"/>
+      <point x="-82" y="804" type="curve"/>
       <point x="-52" y="804"/>
       <point x="-31" y="777"/>
-      <point type="curve" x="-6" y="756"/>
+      <point x="-6" y="756" type="curve"/>
       <point x="16" y="739" name="hintSet0004"/>
       <point x="39" y="723"/>
-      <point type="curve" x="76" y="723"/>
+      <point x="76" y="723" type="curve"/>
       <point x="137" y="723"/>
       <point x="167" y="774"/>
-      <point type="curve" x="180" y="851"/>
-      <point type="line" x="150" y="861"/>
+      <point x="180" y="851" type="curve"/>
+      <point x="150" y="861" type="line"/>
       <point x="135" y="812"/>
       <point x="115" y="781"/>
-      <point type="curve" x="82" y="781"/>
+      <point x="82" y="781" type="curve"/>
       <point x="52" y="781"/>
       <point x="31" y="809"/>
-      <point type="curve" x="6" y="829"/>
+      <point x="6" y="829" type="curve"/>
       <point x="-17" y="847" name="hintSet0009"/>
       <point x="-39" y="863"/>
-      <point type="curve" x="-75" y="863"/>
+      <point x="-75" y="863" type="curve"/>
       <point x="-136" y="863"/>
       <point x="-168" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/tildecmb.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/tildecmb.glif
@@ -4,30 +4,30 @@
   <unicode hex="0303"/>
   <outline>
     <contour>
-      <point type="curve" x="-163" y="586" name="hintSet0000"/>
-      <point type="line" x="-136" y="577"/>
+      <point x="-163" y="586" type="curve" name="hintSet0000"/>
+      <point x="-136" y="577" type="line"/>
       <point x="-122" y="626"/>
       <point x="-104" y="656"/>
-      <point type="curve" x="-74" y="656"/>
+      <point x="-74" y="656" type="curve"/>
       <point x="-47" y="656"/>
       <point x="-28" y="629"/>
-      <point type="curve" x="-5" y="608"/>
+      <point x="-5" y="608" type="curve"/>
       <point x="14" y="591" name="hintSet0004"/>
       <point x="35" y="575"/>
-      <point type="curve" x="68" y="575"/>
+      <point x="68" y="575" type="curve"/>
       <point x="124" y="575"/>
       <point x="151" y="626"/>
-      <point type="curve" x="163" y="703"/>
-      <point type="line" x="136" y="713"/>
+      <point x="163" y="703" type="curve"/>
+      <point x="136" y="713" type="line"/>
       <point x="122" y="664"/>
       <point x="104" y="633"/>
-      <point type="curve" x="74" y="633"/>
+      <point x="74" y="633" type="curve"/>
       <point x="47" y="633"/>
       <point x="28" y="661"/>
-      <point type="curve" x="5" y="681"/>
+      <point x="5" y="681" type="curve"/>
       <point x="-15" y="699" name="hintSet0009"/>
       <point x="-35" y="715"/>
-      <point type="curve" x="-68" y="715"/>
+      <point x="-68" y="715" type="curve"/>
       <point x="-123" y="715"/>
       <point x="-152" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/y.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/y.glif
@@ -4,35 +4,35 @@
   <unicode hex="0079"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/yacute.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/yacute.glif
@@ -4,53 +4,53 @@
   <unicode hex="00FD"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="247" y="576"/>
-      <point type="line" x="273" y="557"/>
+      <point x="247" y="576" type="curve"/>
+      <point x="273" y="557" type="line"/>
       <point x="314" y="593"/>
       <point x="353" y="628"/>
-      <point type="curve" x="394" y="665"/>
+      <point x="394" y="665" type="curve"/>
       <point x="422" y="691"/>
       <point x="428" y="706"/>
-      <point type="curve" x="428" y="720"/>
+      <point x="428" y="720" type="curve"/>
       <point x="428" y="746"/>
       <point x="409" y="758"/>
-      <point type="curve" x="390" y="758"/>
+      <point x="390" y="758" type="curve"/>
       <point x="372" y="758"/>
       <point x="355" y="748"/>
-      <point type="curve" x="336" y="717"/>
+      <point x="336" y="717" type="curve"/>
       <point x="304" y="669"/>
       <point x="275" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/ydieresis.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/ydieresis.glif
@@ -4,63 +4,63 @@
   <unicode hex="00FF"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="389" y="596"/>
+      <point x="389" y="596" type="curve"/>
       <point x="421" y="596"/>
       <point x="448" y="620"/>
-      <point type="curve" x="448" y="653"/>
+      <point x="448" y="653" type="curve"/>
       <point x="448" y="685"/>
       <point x="421" y="710"/>
-      <point type="curve" x="389" y="710"/>
+      <point x="389" y="710" type="curve"/>
       <point x="356" y="710"/>
       <point x="329" y="685"/>
-      <point type="curve" x="329" y="653"/>
+      <point x="329" y="653" type="curve"/>
       <point x="329" y="620"/>
       <point x="356" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="179" y="596"/>
+      <point x="179" y="596" type="curve"/>
       <point x="212" y="596"/>
       <point x="239" y="620"/>
-      <point type="curve" x="239" y="653"/>
+      <point x="239" y="653" type="curve"/>
       <point x="239" y="685"/>
       <point x="212" y="710"/>
-      <point type="curve" x="179" y="710"/>
+      <point x="179" y="710" type="curve"/>
       <point x="147" y="710"/>
       <point x="120" y="685"/>
-      <point type="curve" x="120" y="653"/>
+      <point x="120" y="653" type="curve"/>
       <point x="120" y="620"/>
       <point x="147" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/ytilde.glif
+++ b/tests/autohint_data/expected_output/ufo2.ufo/glyphs.com.adobe.type.processedglyphs/ytilde.glif
@@ -4,63 +4,63 @@
   <unicode hex="1EF9"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="111" y="586" name="hintSet0022"/>
-      <point type="line" x="138" y="577"/>
+      <point x="111" y="586" type="curve" name="hintSet0022"/>
+      <point x="138" y="577" type="line"/>
       <point x="152" y="626"/>
       <point x="170" y="656"/>
-      <point type="curve" x="200" y="656"/>
+      <point x="200" y="656" type="curve"/>
       <point x="227" y="656"/>
       <point x="246" y="629"/>
-      <point type="curve" x="269" y="608"/>
+      <point x="269" y="608" type="curve"/>
       <point x="288" y="591" name="hintSet0026"/>
       <point x="309" y="575"/>
-      <point type="curve" x="342" y="575"/>
+      <point x="342" y="575" type="curve"/>
       <point x="398" y="575"/>
       <point x="425" y="626"/>
-      <point type="curve" x="437" y="703"/>
-      <point type="line" x="410" y="713"/>
+      <point x="437" y="703" type="curve"/>
+      <point x="410" y="713" type="line"/>
       <point x="396" y="664"/>
       <point x="378" y="633"/>
-      <point type="curve" x="348" y="633"/>
+      <point x="348" y="633" type="curve"/>
       <point x="321" y="633"/>
       <point x="302" y="661"/>
-      <point type="curve" x="279" y="681"/>
+      <point x="279" y="681" type="curve"/>
       <point x="259" y="699" name="hintSet0031"/>
       <point x="239" y="715"/>
-      <point type="curve" x="206" y="715"/>
+      <point x="206" y="715" type="curve"/>
       <point x="151" y="715"/>
       <point x="122" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/A_.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/A_.glif
@@ -7,27 +7,27 @@
   <anchor x="312" y="-22" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/A_acute.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/A_acute.glif
@@ -4,43 +4,43 @@
   <unicode hex="00C1"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="266" y="745"/>
-      <point type="line" x="284" y="720"/>
+      <point x="266" y="745" type="curve"/>
+      <point x="284" y="720" type="line"/>
       <point x="326" y="742"/>
       <point x="368" y="765"/>
-      <point type="curve" x="410" y="788"/>
+      <point x="410" y="788" type="curve"/>
       <point x="448" y="809"/>
       <point x="460" y="825"/>
-      <point type="curve" x="460" y="843"/>
+      <point x="460" y="843" type="curve"/>
       <point x="460" y="863"/>
       <point x="443" y="877"/>
-      <point type="curve" x="422" y="877"/>
+      <point x="422" y="877" type="curve"/>
       <point x="405" y="877"/>
       <point x="388" y="867"/>
-      <point type="curve" x="360" y="839"/>
+      <point x="360" y="839" type="curve"/>
       <point x="328" y="809"/>
       <point x="297" y="778"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/A_dieresis.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/A_dieresis.glif
@@ -4,53 +4,53 @@
   <unicode hex="00C4"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="220" y="744" name="hintSet0019"/>
+      <point x="220" y="744" type="curve" name="hintSet0019"/>
       <point x="252" y="744"/>
       <point x="277" y="767"/>
-      <point type="curve" x="277" y="799"/>
+      <point x="277" y="799" type="curve"/>
       <point x="277" y="831"/>
       <point x="252" y="854"/>
-      <point type="curve" x="220" y="854"/>
+      <point x="220" y="854" type="curve"/>
       <point x="189" y="854"/>
       <point x="162" y="831"/>
-      <point type="curve" x="162" y="799"/>
+      <point x="162" y="799" type="curve"/>
       <point x="162" y="767"/>
       <point x="189" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="443" y="744"/>
+      <point x="443" y="744" type="curve"/>
       <point x="474" y="744"/>
       <point x="501" y="767"/>
-      <point type="curve" x="501" y="799"/>
+      <point x="501" y="799" type="curve"/>
       <point x="501" y="831"/>
       <point x="474" y="854"/>
-      <point type="curve" x="443" y="854"/>
+      <point x="443" y="854" type="curve"/>
       <point x="411" y="854"/>
       <point x="386" y="831"/>
-      <point type="curve" x="386" y="799"/>
+      <point x="386" y="799" type="curve"/>
       <point x="386" y="767"/>
       <point x="411" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/A_tilde.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/A_tilde.glif
@@ -4,53 +4,53 @@
   <unicode hex="00C3"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="151" y="734"/>
-      <point type="line" x="181" y="725"/>
+      <point x="151" y="734" type="curve"/>
+      <point x="181" y="725" type="line"/>
       <point x="196" y="774"/>
       <point x="217" y="804"/>
-      <point type="curve" x="249" y="804"/>
+      <point x="249" y="804" type="curve"/>
       <point x="279" y="804"/>
       <point x="300" y="777"/>
-      <point type="curve" x="325" y="756"/>
+      <point x="325" y="756" type="curve"/>
       <point x="347" y="739" name="hintSet0023"/>
       <point x="370" y="723"/>
-      <point type="curve" x="407" y="723"/>
+      <point x="407" y="723" type="curve"/>
       <point x="468" y="723"/>
       <point x="498" y="774"/>
-      <point type="curve" x="511" y="851"/>
-      <point type="line" x="481" y="861"/>
+      <point x="511" y="851" type="curve"/>
+      <point x="481" y="861" type="line"/>
       <point x="466" y="812"/>
       <point x="446" y="781"/>
-      <point type="curve" x="413" y="781"/>
+      <point x="413" y="781" type="curve"/>
       <point x="383" y="781"/>
       <point x="362" y="809"/>
-      <point type="curve" x="337" y="829"/>
+      <point x="337" y="829" type="curve"/>
       <point x="314" y="847" name="hintSet0028"/>
       <point x="292" y="863"/>
-      <point type="curve" x="256" y="863"/>
+      <point x="256" y="863" type="curve"/>
       <point x="195" y="863" name="hintSet0029"/>
       <point x="163" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/Y_.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/Y_.glif
@@ -6,31 +6,31 @@
   <anchor x="316" y="-22" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/Y_acute.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/Y_acute.glif
@@ -4,47 +4,47 @@
   <unicode hex="00DD"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="305" y="735"/>
-      <point type="line" x="323" y="710"/>
+      <point x="305" y="735" type="curve"/>
+      <point x="323" y="710" type="line"/>
       <point x="365" y="732"/>
       <point x="407" y="755"/>
-      <point type="curve" x="449" y="778"/>
+      <point x="449" y="778" type="curve"/>
       <point x="487" y="799"/>
       <point x="499" y="815"/>
-      <point type="curve" x="499" y="833"/>
+      <point x="499" y="833" type="curve"/>
       <point x="499" y="853"/>
       <point x="482" y="867"/>
-      <point type="curve" x="461" y="867"/>
+      <point x="461" y="867" type="curve"/>
       <point x="444" y="867"/>
       <point x="427" y="857"/>
-      <point type="curve" x="399" y="829"/>
+      <point x="399" y="829" type="curve"/>
       <point x="367" y="799"/>
       <point x="336" y="768"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/Y_dieresis.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/Y_dieresis.glif
@@ -4,57 +4,57 @@
   <unicode hex="0178"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="235" y="744"/>
+      <point x="235" y="744" type="curve"/>
       <point x="267" y="744"/>
       <point x="292" y="767"/>
-      <point type="curve" x="292" y="799"/>
+      <point x="292" y="799" type="curve"/>
       <point x="292" y="831"/>
       <point x="267" y="854"/>
-      <point type="curve" x="235" y="854"/>
+      <point x="235" y="854" type="curve"/>
       <point x="204" y="854"/>
       <point x="177" y="831"/>
-      <point type="curve" x="177" y="799"/>
+      <point x="177" y="799" type="curve"/>
       <point x="177" y="767"/>
       <point x="204" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="458" y="744" name="hintSet0026"/>
+      <point x="458" y="744" type="curve" name="hintSet0026"/>
       <point x="489" y="744"/>
       <point x="516" y="767"/>
-      <point type="curve" x="516" y="799"/>
+      <point x="516" y="799" type="curve"/>
       <point x="516" y="831"/>
       <point x="489" y="854"/>
-      <point type="curve" x="458" y="854"/>
+      <point x="458" y="854" type="curve"/>
       <point x="426" y="854"/>
       <point x="401" y="831"/>
-      <point type="curve" x="401" y="799"/>
+      <point x="401" y="799" type="curve"/>
       <point x="401" y="767"/>
       <point x="426" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/Y_tilde.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/Y_tilde.glif
@@ -4,57 +4,57 @@
   <unicode hex="1EF8"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="166" y="734"/>
-      <point type="line" x="196" y="725"/>
+      <point x="166" y="734" type="curve"/>
+      <point x="196" y="725" type="line"/>
       <point x="211" y="774"/>
       <point x="232" y="804"/>
-      <point type="curve" x="264" y="804"/>
+      <point x="264" y="804" type="curve"/>
       <point x="294" y="804"/>
       <point x="315" y="777"/>
-      <point type="curve" x="340" y="756"/>
+      <point x="340" y="756" type="curve"/>
       <point x="362" y="739" name="hintSet0025"/>
       <point x="385" y="723"/>
-      <point type="curve" x="422" y="723"/>
+      <point x="422" y="723" type="curve"/>
       <point x="483" y="723"/>
       <point x="513" y="774"/>
-      <point type="curve" x="526" y="851"/>
-      <point type="line" x="496" y="861"/>
+      <point x="526" y="851" type="curve"/>
+      <point x="496" y="861" type="line"/>
       <point x="481" y="812"/>
       <point x="461" y="781"/>
-      <point type="curve" x="428" y="781"/>
+      <point x="428" y="781" type="curve"/>
       <point x="398" y="781"/>
       <point x="377" y="809"/>
-      <point type="curve" x="352" y="829"/>
+      <point x="352" y="829" type="curve"/>
       <point x="329" y="847" name="hintSet0030"/>
       <point x="307" y="863"/>
-      <point type="curve" x="271" y="863"/>
+      <point x="271" y="863" type="curve"/>
       <point x="210" y="863" name="hintSet0031"/>
       <point x="178" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/a.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/a.glif
@@ -7,65 +7,65 @@
   <anchor x="244" y="-22" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/aacute.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/aacute.glif
@@ -4,83 +4,83 @@
   <unicode hex="00E1"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="219" y="576"/>
-      <point type="line" x="245" y="557"/>
+      <point x="219" y="576" type="curve"/>
+      <point x="245" y="557" type="line"/>
       <point x="286" y="593"/>
       <point x="325" y="628"/>
-      <point type="curve" x="366" y="665"/>
+      <point x="366" y="665" type="curve"/>
       <point x="394" y="691"/>
       <point x="400" y="706"/>
-      <point type="curve" x="400" y="720"/>
+      <point x="400" y="720" type="curve"/>
       <point x="400" y="746"/>
       <point x="381" y="758"/>
-      <point type="curve" x="362" y="758"/>
+      <point x="362" y="758" type="curve"/>
       <point x="344" y="758"/>
       <point x="327" y="748"/>
-      <point type="curve" x="308" y="717"/>
+      <point x="308" y="717" type="curve"/>
       <point x="276" y="669"/>
       <point x="247" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/acutecmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/acutecmb.cap.glif
@@ -3,20 +3,20 @@
   <anchor x="0" y="691" name="_aboveUC"/>
   <outline>
     <contour>
-      <point type="curve" x="-67" y="745" name="hintSet0000"/>
-      <point type="line" x="-49" y="720"/>
+      <point x="-67" y="745" type="curve" name="hintSet0000"/>
+      <point x="-49" y="720" type="line"/>
       <point x="-7" y="742"/>
       <point x="35" y="765"/>
-      <point type="curve" x="77" y="788"/>
+      <point x="77" y="788" type="curve"/>
       <point x="115" y="809"/>
       <point x="127" y="825"/>
-      <point type="curve" x="127" y="843"/>
+      <point x="127" y="843" type="curve"/>
       <point x="127" y="863"/>
       <point x="110" y="877"/>
-      <point type="curve" x="89" y="877"/>
+      <point x="89" y="877" type="curve"/>
       <point x="72" y="877"/>
       <point x="55" y="867"/>
-      <point type="curve" x="27" y="839"/>
+      <point x="27" y="839" type="curve"/>
       <point x="-5" y="809"/>
       <point x="-36" y="778"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/acutecmb.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/acutecmb.glif
@@ -4,20 +4,20 @@
   <anchor x="0" y="507" name="_aboveLC"/>
   <outline>
     <contour>
-      <point type="curve" x="-59" y="576" name="hintSet0000"/>
-      <point type="line" x="-33" y="557"/>
+      <point x="-59" y="576" type="curve" name="hintSet0000"/>
+      <point x="-33" y="557" type="line"/>
       <point x="8" y="593"/>
       <point x="47" y="628"/>
-      <point type="curve" x="88" y="665"/>
+      <point x="88" y="665" type="curve"/>
       <point x="116" y="691"/>
       <point x="122" y="706"/>
-      <point type="curve" x="122" y="720"/>
+      <point x="122" y="720" type="curve"/>
       <point x="122" y="746"/>
       <point x="103" y="758"/>
-      <point type="curve" x="84" y="758"/>
+      <point x="84" y="758" type="curve"/>
       <point x="66" y="758"/>
       <point x="49" y="748"/>
-      <point type="curve" x="30" y="717"/>
+      <point x="30" y="717" type="curve"/>
       <point x="-2" y="669"/>
       <point x="-31" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/adieresis.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/adieresis.glif
@@ -4,93 +4,93 @@
   <unicode hex="00E4"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="355" y="596" name="hintSet0025"/>
+      <point x="355" y="596" type="curve" name="hintSet0025"/>
       <point x="387" y="596"/>
       <point x="414" y="620"/>
-      <point type="curve" x="414" y="653"/>
+      <point x="414" y="653" type="curve"/>
       <point x="414" y="685"/>
       <point x="387" y="710"/>
-      <point type="curve" x="355" y="710"/>
+      <point x="355" y="710" type="curve"/>
       <point x="322" y="710"/>
       <point x="295" y="685"/>
-      <point type="curve" x="295" y="653"/>
+      <point x="295" y="653" type="curve"/>
       <point x="295" y="620"/>
       <point x="322" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="145" y="596"/>
+      <point x="145" y="596" type="curve"/>
       <point x="178" y="596"/>
       <point x="205" y="620"/>
-      <point type="curve" x="205" y="653"/>
+      <point x="205" y="653" type="curve"/>
       <point x="205" y="685"/>
       <point x="178" y="710"/>
-      <point type="curve" x="145" y="710"/>
+      <point x="145" y="710" type="curve"/>
       <point x="113" y="710"/>
       <point x="86" y="685"/>
-      <point type="curve" x="86" y="653"/>
+      <point x="86" y="653" type="curve"/>
       <point x="86" y="620"/>
       <point x="113" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/atilde.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/atilde.glif
@@ -4,93 +4,93 @@
   <unicode hex="00E3"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="80" y="586" name="hintSet0025"/>
-      <point type="line" x="107" y="577"/>
+      <point x="80" y="586" type="curve" name="hintSet0025"/>
+      <point x="107" y="577" type="line"/>
       <point x="121" y="626"/>
       <point x="139" y="656"/>
-      <point type="curve" x="169" y="656"/>
+      <point x="169" y="656" type="curve"/>
       <point x="196" y="656"/>
       <point x="215" y="629"/>
-      <point type="curve" x="238" y="608"/>
+      <point x="238" y="608" type="curve"/>
       <point x="257" y="591" name="hintSet0029"/>
       <point x="278" y="575"/>
-      <point type="curve" x="311" y="575"/>
+      <point x="311" y="575" type="curve"/>
       <point x="367" y="575"/>
       <point x="394" y="626"/>
-      <point type="curve" x="406" y="703"/>
-      <point type="line" x="379" y="713"/>
+      <point x="406" y="703" type="curve"/>
+      <point x="379" y="713" type="line"/>
       <point x="365" y="664"/>
       <point x="347" y="633"/>
-      <point type="curve" x="317" y="633"/>
+      <point x="317" y="633" type="curve"/>
       <point x="290" y="633"/>
       <point x="271" y="661"/>
-      <point type="curve" x="248" y="681"/>
+      <point x="248" y="681" type="curve"/>
       <point x="228" y="699" name="hintSet0034"/>
       <point x="208" y="715"/>
-      <point type="curve" x="175" y="715"/>
+      <point x="175" y="715" type="curve"/>
       <point x="120" y="715"/>
       <point x="91" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/dieresiscmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/dieresiscmb.cap.glif
@@ -3,30 +3,30 @@
   <anchor x="0" y="691" name="_aboveUC"/>
   <outline>
     <contour>
-      <point type="curve" x="-112" y="744" name="hintSet0000"/>
+      <point x="-112" y="744" type="curve" name="hintSet0000"/>
       <point x="-80" y="744"/>
       <point x="-55" y="767"/>
-      <point type="curve" x="-55" y="799"/>
+      <point x="-55" y="799" type="curve"/>
       <point x="-55" y="831"/>
       <point x="-80" y="854"/>
-      <point type="curve" x="-112" y="854"/>
+      <point x="-112" y="854" type="curve"/>
       <point x="-143" y="854"/>
       <point x="-170" y="831"/>
-      <point type="curve" x="-170" y="799"/>
+      <point x="-170" y="799" type="curve"/>
       <point x="-170" y="767"/>
       <point x="-143" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="111" y="744"/>
+      <point x="111" y="744" type="curve"/>
       <point x="142" y="744"/>
       <point x="169" y="767"/>
-      <point type="curve" x="169" y="799"/>
+      <point x="169" y="799" type="curve"/>
       <point x="169" y="831"/>
       <point x="142" y="854"/>
-      <point type="curve" x="111" y="854"/>
+      <point x="111" y="854" type="curve"/>
       <point x="79" y="854"/>
       <point x="54" y="831"/>
-      <point type="curve" x="54" y="799"/>
+      <point x="54" y="799" type="curve"/>
       <point x="54" y="767"/>
       <point x="79" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/dieresiscmb.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/dieresiscmb.glif
@@ -5,30 +5,30 @@
   <anchor x="0" y="682" name="aboveLC"/>
   <outline>
     <contour>
-      <point type="curve" x="105" y="596" name="hintSet0000"/>
+      <point x="105" y="596" type="curve" name="hintSet0000"/>
       <point x="137" y="596"/>
       <point x="164" y="620"/>
-      <point type="curve" x="164" y="653"/>
+      <point x="164" y="653" type="curve"/>
       <point x="164" y="685"/>
       <point x="137" y="710"/>
-      <point type="curve" x="105" y="710"/>
+      <point x="105" y="710" type="curve"/>
       <point x="72" y="710"/>
       <point x="45" y="685"/>
-      <point type="curve" x="45" y="653"/>
+      <point x="45" y="653" type="curve"/>
       <point x="45" y="620"/>
       <point x="72" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="-105" y="596"/>
+      <point x="-105" y="596" type="curve"/>
       <point x="-72" y="596"/>
       <point x="-45" y="620"/>
-      <point type="curve" x="-45" y="653"/>
+      <point x="-45" y="653" type="curve"/>
       <point x="-45" y="685"/>
       <point x="-72" y="710"/>
-      <point type="curve" x="-105" y="710"/>
+      <point x="-105" y="710" type="curve"/>
       <point x="-137" y="710"/>
       <point x="-164" y="685"/>
-      <point type="curve" x="-164" y="653"/>
+      <point x="-164" y="653" type="curve"/>
       <point x="-164" y="620"/>
       <point x="-137" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/tildecmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/tildecmb.cap.glif
@@ -3,30 +3,30 @@
   <anchor x="0" y="691" name="_aboveUC"/>
   <outline>
     <contour>
-      <point type="curve" x="-180" y="734" name="hintSet0000"/>
-      <point type="line" x="-150" y="725"/>
+      <point x="-180" y="734" type="curve" name="hintSet0000"/>
+      <point x="-150" y="725" type="line"/>
       <point x="-135" y="774"/>
       <point x="-114" y="804"/>
-      <point type="curve" x="-82" y="804"/>
+      <point x="-82" y="804" type="curve"/>
       <point x="-52" y="804"/>
       <point x="-31" y="777"/>
-      <point type="curve" x="-6" y="756"/>
+      <point x="-6" y="756" type="curve"/>
       <point x="16" y="739" name="hintSet0004"/>
       <point x="39" y="723"/>
-      <point type="curve" x="76" y="723"/>
+      <point x="76" y="723" type="curve"/>
       <point x="137" y="723"/>
       <point x="167" y="774"/>
-      <point type="curve" x="180" y="851"/>
-      <point type="line" x="150" y="861"/>
+      <point x="180" y="851" type="curve"/>
+      <point x="150" y="861" type="line"/>
       <point x="135" y="812"/>
       <point x="115" y="781"/>
-      <point type="curve" x="82" y="781"/>
+      <point x="82" y="781" type="curve"/>
       <point x="52" y="781"/>
       <point x="31" y="809"/>
-      <point type="curve" x="6" y="829"/>
+      <point x="6" y="829" type="curve"/>
       <point x="-17" y="847" name="hintSet0009"/>
       <point x="-39" y="863"/>
-      <point type="curve" x="-75" y="863"/>
+      <point x="-75" y="863" type="curve"/>
       <point x="-136" y="863"/>
       <point x="-168" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/tildecmb.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/tildecmb.glif
@@ -4,30 +4,30 @@
   <anchor x="0" y="507" name="_aboveLC"/>
   <outline>
     <contour>
-      <point type="curve" x="-163" y="586" name="hintSet0000"/>
-      <point type="line" x="-136" y="577"/>
+      <point x="-163" y="586" type="curve" name="hintSet0000"/>
+      <point x="-136" y="577" type="line"/>
       <point x="-122" y="626"/>
       <point x="-104" y="656"/>
-      <point type="curve" x="-74" y="656"/>
+      <point x="-74" y="656" type="curve"/>
       <point x="-47" y="656"/>
       <point x="-28" y="629"/>
-      <point type="curve" x="-5" y="608"/>
+      <point x="-5" y="608" type="curve"/>
       <point x="14" y="591" name="hintSet0004"/>
       <point x="35" y="575"/>
-      <point type="curve" x="68" y="575"/>
+      <point x="68" y="575" type="curve"/>
       <point x="124" y="575"/>
       <point x="151" y="626"/>
-      <point type="curve" x="163" y="703"/>
-      <point type="line" x="136" y="713"/>
+      <point x="163" y="703" type="curve"/>
+      <point x="136" y="713" type="line"/>
       <point x="122" y="664"/>
       <point x="104" y="633"/>
-      <point type="curve" x="74" y="633"/>
+      <point x="74" y="633" type="curve"/>
       <point x="47" y="633"/>
       <point x="28" y="661"/>
-      <point type="curve" x="5" y="681"/>
+      <point x="5" y="681" type="curve"/>
       <point x="-15" y="699" name="hintSet0009"/>
       <point x="-35" y="715"/>
-      <point type="curve" x="-68" y="715"/>
+      <point x="-68" y="715" type="curve"/>
       <point x="-123" y="715"/>
       <point x="-152" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/y.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/y.glif
@@ -6,35 +6,35 @@
   <anchor x="124" y="-254" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/yacute.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/yacute.glif
@@ -4,53 +4,53 @@
   <unicode hex="00FD"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="247" y="576"/>
-      <point type="line" x="273" y="557"/>
+      <point x="247" y="576" type="curve"/>
+      <point x="273" y="557" type="line"/>
       <point x="314" y="593"/>
       <point x="353" y="628"/>
-      <point type="curve" x="394" y="665"/>
+      <point x="394" y="665" type="curve"/>
       <point x="422" y="691"/>
       <point x="428" y="706"/>
-      <point type="curve" x="428" y="720"/>
+      <point x="428" y="720" type="curve"/>
       <point x="428" y="746"/>
       <point x="409" y="758"/>
-      <point type="curve" x="390" y="758"/>
+      <point x="390" y="758" type="curve"/>
       <point x="372" y="758"/>
       <point x="355" y="748"/>
-      <point type="curve" x="336" y="717"/>
+      <point x="336" y="717" type="curve"/>
       <point x="304" y="669"/>
       <point x="275" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/ydieresis.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/ydieresis.glif
@@ -4,63 +4,63 @@
   <unicode hex="00FF"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="389" y="596"/>
+      <point x="389" y="596" type="curve"/>
       <point x="421" y="596"/>
       <point x="448" y="620"/>
-      <point type="curve" x="448" y="653"/>
+      <point x="448" y="653" type="curve"/>
       <point x="448" y="685"/>
       <point x="421" y="710"/>
-      <point type="curve" x="389" y="710"/>
+      <point x="389" y="710" type="curve"/>
       <point x="356" y="710"/>
       <point x="329" y="685"/>
-      <point type="curve" x="329" y="653"/>
+      <point x="329" y="653" type="curve"/>
       <point x="329" y="620"/>
       <point x="356" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="179" y="596"/>
+      <point x="179" y="596" type="curve"/>
       <point x="212" y="596"/>
       <point x="239" y="620"/>
-      <point type="curve" x="239" y="653"/>
+      <point x="239" y="653" type="curve"/>
       <point x="239" y="685"/>
       <point x="212" y="710"/>
-      <point type="curve" x="179" y="710"/>
+      <point x="179" y="710" type="curve"/>
       <point x="147" y="710"/>
       <point x="120" y="685"/>
-      <point type="curve" x="120" y="653"/>
+      <point x="120" y="653" type="curve"/>
       <point x="120" y="620"/>
       <point x="147" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/ytilde.glif
+++ b/tests/autohint_data/expected_output/ufo3-fi.ufo/glyphs.com.adobe.type.processedglyphs/ytilde.glif
@@ -4,63 +4,63 @@
   <unicode hex="1EF9"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="111" y="586" name="hintSet0022"/>
-      <point type="line" x="138" y="577"/>
+      <point x="111" y="586" type="curve" name="hintSet0022"/>
+      <point x="138" y="577" type="line"/>
       <point x="152" y="626"/>
       <point x="170" y="656"/>
-      <point type="curve" x="200" y="656"/>
+      <point x="200" y="656" type="curve"/>
       <point x="227" y="656"/>
       <point x="246" y="629"/>
-      <point type="curve" x="269" y="608"/>
+      <point x="269" y="608" type="curve"/>
       <point x="288" y="591" name="hintSet0026"/>
       <point x="309" y="575"/>
-      <point type="curve" x="342" y="575"/>
+      <point x="342" y="575" type="curve"/>
       <point x="398" y="575"/>
       <point x="425" y="626"/>
-      <point type="curve" x="437" y="703"/>
-      <point type="line" x="410" y="713"/>
+      <point x="437" y="703" type="curve"/>
+      <point x="410" y="713" type="line"/>
       <point x="396" y="664"/>
       <point x="378" y="633"/>
-      <point type="curve" x="348" y="633"/>
+      <point x="348" y="633" type="curve"/>
       <point x="321" y="633"/>
       <point x="302" y="661"/>
-      <point type="curve" x="279" y="681"/>
+      <point x="279" y="681" type="curve"/>
       <point x="259" y="699" name="hintSet0031"/>
       <point x="239" y="715"/>
-      <point type="curve" x="206" y="715"/>
+      <point x="206" y="715" type="curve"/>
       <point x="151" y="715"/>
       <point x="122" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/A_.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/A_.glif
@@ -7,27 +7,27 @@
   <anchor x="312" y="-22" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/A_acute.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/A_acute.glif
@@ -4,43 +4,43 @@
   <unicode hex="00C1"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="266" y="745"/>
-      <point type="line" x="284" y="720"/>
+      <point x="266" y="745" type="curve"/>
+      <point x="284" y="720" type="line"/>
       <point x="326" y="742"/>
       <point x="368" y="765"/>
-      <point type="curve" x="410" y="788"/>
+      <point x="410" y="788" type="curve"/>
       <point x="448" y="809"/>
       <point x="460" y="825"/>
-      <point type="curve" x="460" y="843"/>
+      <point x="460" y="843" type="curve"/>
       <point x="460" y="863"/>
       <point x="443" y="877"/>
-      <point type="curve" x="422" y="877"/>
+      <point x="422" y="877" type="curve"/>
       <point x="405" y="877"/>
       <point x="388" y="867"/>
-      <point type="curve" x="360" y="839"/>
+      <point x="360" y="839" type="curve"/>
       <point x="328" y="809"/>
       <point x="297" y="778"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/A_dieresis.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/A_dieresis.glif
@@ -4,53 +4,53 @@
   <unicode hex="00C4"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="220" y="744" name="hintSet0019"/>
+      <point x="220" y="744" type="curve" name="hintSet0019"/>
       <point x="252" y="744"/>
       <point x="277" y="767"/>
-      <point type="curve" x="277" y="799"/>
+      <point x="277" y="799" type="curve"/>
       <point x="277" y="831"/>
       <point x="252" y="854"/>
-      <point type="curve" x="220" y="854"/>
+      <point x="220" y="854" type="curve"/>
       <point x="189" y="854"/>
       <point x="162" y="831"/>
-      <point type="curve" x="162" y="799"/>
+      <point x="162" y="799" type="curve"/>
       <point x="162" y="767"/>
       <point x="189" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="443" y="744"/>
+      <point x="443" y="744" type="curve"/>
       <point x="474" y="744"/>
       <point x="501" y="767"/>
-      <point type="curve" x="501" y="799"/>
+      <point x="501" y="799" type="curve"/>
       <point x="501" y="831"/>
       <point x="474" y="854"/>
-      <point type="curve" x="443" y="854"/>
+      <point x="443" y="854" type="curve"/>
       <point x="411" y="854"/>
       <point x="386" y="831"/>
-      <point type="curve" x="386" y="799"/>
+      <point x="386" y="799" type="curve"/>
       <point x="386" y="767"/>
       <point x="411" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/A_tilde.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/A_tilde.glif
@@ -4,53 +4,53 @@
   <unicode hex="00C3"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="151" y="734"/>
-      <point type="line" x="181" y="725"/>
+      <point x="151" y="734" type="curve"/>
+      <point x="181" y="725" type="line"/>
       <point x="196" y="774"/>
       <point x="217" y="804"/>
-      <point type="curve" x="249" y="804"/>
+      <point x="249" y="804" type="curve"/>
       <point x="279" y="804"/>
       <point x="300" y="777"/>
-      <point type="curve" x="325" y="756"/>
+      <point x="325" y="756" type="curve"/>
       <point x="347" y="739" name="hintSet0023"/>
       <point x="370" y="723"/>
-      <point type="curve" x="407" y="723"/>
+      <point x="407" y="723" type="curve"/>
       <point x="468" y="723"/>
       <point x="498" y="774"/>
-      <point type="curve" x="511" y="851"/>
-      <point type="line" x="481" y="861"/>
+      <point x="511" y="851" type="curve"/>
+      <point x="481" y="861" type="line"/>
       <point x="466" y="812"/>
       <point x="446" y="781"/>
-      <point type="curve" x="413" y="781"/>
+      <point x="413" y="781" type="curve"/>
       <point x="383" y="781"/>
       <point x="362" y="809"/>
-      <point type="curve" x="337" y="829"/>
+      <point x="337" y="829" type="curve"/>
       <point x="314" y="847" name="hintSet0028"/>
       <point x="292" y="863"/>
-      <point type="curve" x="256" y="863"/>
+      <point x="256" y="863" type="curve"/>
       <point x="195" y="863" name="hintSet0029"/>
       <point x="163" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/Y_.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/Y_.glif
@@ -6,31 +6,31 @@
   <anchor x="316" y="-22" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/Y_acute.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/Y_acute.glif
@@ -4,47 +4,47 @@
   <unicode hex="00DD"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="305" y="735"/>
-      <point type="line" x="323" y="710"/>
+      <point x="305" y="735" type="curve"/>
+      <point x="323" y="710" type="line"/>
       <point x="365" y="732"/>
       <point x="407" y="755"/>
-      <point type="curve" x="449" y="778"/>
+      <point x="449" y="778" type="curve"/>
       <point x="487" y="799"/>
       <point x="499" y="815"/>
-      <point type="curve" x="499" y="833"/>
+      <point x="499" y="833" type="curve"/>
       <point x="499" y="853"/>
       <point x="482" y="867"/>
-      <point type="curve" x="461" y="867"/>
+      <point x="461" y="867" type="curve"/>
       <point x="444" y="867"/>
       <point x="427" y="857"/>
-      <point type="curve" x="399" y="829"/>
+      <point x="399" y="829" type="curve"/>
       <point x="367" y="799"/>
       <point x="336" y="768"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/Y_dieresis.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/Y_dieresis.glif
@@ -4,57 +4,57 @@
   <unicode hex="0178"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="235" y="744"/>
+      <point x="235" y="744" type="curve"/>
       <point x="267" y="744"/>
       <point x="292" y="767"/>
-      <point type="curve" x="292" y="799"/>
+      <point x="292" y="799" type="curve"/>
       <point x="292" y="831"/>
       <point x="267" y="854"/>
-      <point type="curve" x="235" y="854"/>
+      <point x="235" y="854" type="curve"/>
       <point x="204" y="854"/>
       <point x="177" y="831"/>
-      <point type="curve" x="177" y="799"/>
+      <point x="177" y="799" type="curve"/>
       <point x="177" y="767"/>
       <point x="204" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="458" y="744" name="hintSet0026"/>
+      <point x="458" y="744" type="curve" name="hintSet0026"/>
       <point x="489" y="744"/>
       <point x="516" y="767"/>
-      <point type="curve" x="516" y="799"/>
+      <point x="516" y="799" type="curve"/>
       <point x="516" y="831"/>
       <point x="489" y="854"/>
-      <point type="curve" x="458" y="854"/>
+      <point x="458" y="854" type="curve"/>
       <point x="426" y="854"/>
       <point x="401" y="831"/>
-      <point type="curve" x="401" y="799"/>
+      <point x="401" y="799" type="curve"/>
       <point x="401" y="767"/>
       <point x="426" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/Y_tilde.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/Y_tilde.glif
@@ -4,57 +4,57 @@
   <unicode hex="1EF8"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="166" y="734"/>
-      <point type="line" x="196" y="725"/>
+      <point x="166" y="734" type="curve"/>
+      <point x="196" y="725" type="line"/>
       <point x="211" y="774"/>
       <point x="232" y="804"/>
-      <point type="curve" x="264" y="804"/>
+      <point x="264" y="804" type="curve"/>
       <point x="294" y="804"/>
       <point x="315" y="777"/>
-      <point type="curve" x="340" y="756"/>
+      <point x="340" y="756" type="curve"/>
       <point x="362" y="739" name="hintSet0025"/>
       <point x="385" y="723"/>
-      <point type="curve" x="422" y="723"/>
+      <point x="422" y="723" type="curve"/>
       <point x="483" y="723"/>
       <point x="513" y="774"/>
-      <point type="curve" x="526" y="851"/>
-      <point type="line" x="496" y="861"/>
+      <point x="526" y="851" type="curve"/>
+      <point x="496" y="861" type="line"/>
       <point x="481" y="812"/>
       <point x="461" y="781"/>
-      <point type="curve" x="428" y="781"/>
+      <point x="428" y="781" type="curve"/>
       <point x="398" y="781"/>
       <point x="377" y="809"/>
-      <point type="curve" x="352" y="829"/>
+      <point x="352" y="829" type="curve"/>
       <point x="329" y="847" name="hintSet0030"/>
       <point x="307" y="863"/>
-      <point type="curve" x="271" y="863"/>
+      <point x="271" y="863" type="curve"/>
       <point x="210" y="863" name="hintSet0031"/>
       <point x="178" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/a.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/a.glif
@@ -7,65 +7,65 @@
   <anchor x="244" y="-22" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/aacute.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/aacute.glif
@@ -4,83 +4,83 @@
   <unicode hex="00E1"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="219" y="576"/>
-      <point type="line" x="245" y="557"/>
+      <point x="219" y="576" type="curve"/>
+      <point x="245" y="557" type="line"/>
       <point x="286" y="593"/>
       <point x="325" y="628"/>
-      <point type="curve" x="366" y="665"/>
+      <point x="366" y="665" type="curve"/>
       <point x="394" y="691"/>
       <point x="400" y="706"/>
-      <point type="curve" x="400" y="720"/>
+      <point x="400" y="720" type="curve"/>
       <point x="400" y="746"/>
       <point x="381" y="758"/>
-      <point type="curve" x="362" y="758"/>
+      <point x="362" y="758" type="curve"/>
       <point x="344" y="758"/>
       <point x="327" y="748"/>
-      <point type="curve" x="308" y="717"/>
+      <point x="308" y="717" type="curve"/>
       <point x="276" y="669"/>
       <point x="247" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/acutecmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/acutecmb.cap.glif
@@ -3,20 +3,20 @@
   <anchor x="0" y="691" name="_aboveUC"/>
   <outline>
     <contour>
-      <point type="curve" x="-67" y="745" name="hintSet0000"/>
-      <point type="line" x="-49" y="720"/>
+      <point x="-67" y="745" type="curve" name="hintSet0000"/>
+      <point x="-49" y="720" type="line"/>
       <point x="-7" y="742"/>
       <point x="35" y="765"/>
-      <point type="curve" x="77" y="788"/>
+      <point x="77" y="788" type="curve"/>
       <point x="115" y="809"/>
       <point x="127" y="825"/>
-      <point type="curve" x="127" y="843"/>
+      <point x="127" y="843" type="curve"/>
       <point x="127" y="863"/>
       <point x="110" y="877"/>
-      <point type="curve" x="89" y="877"/>
+      <point x="89" y="877" type="curve"/>
       <point x="72" y="877"/>
       <point x="55" y="867"/>
-      <point type="curve" x="27" y="839"/>
+      <point x="27" y="839" type="curve"/>
       <point x="-5" y="809"/>
       <point x="-36" y="778"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/acutecmb.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/acutecmb.glif
@@ -4,20 +4,20 @@
   <anchor x="0" y="507" name="_aboveLC"/>
   <outline>
     <contour>
-      <point type="curve" x="-59" y="576" name="hintSet0000"/>
-      <point type="line" x="-33" y="557"/>
+      <point x="-59" y="576" type="curve" name="hintSet0000"/>
+      <point x="-33" y="557" type="line"/>
       <point x="8" y="593"/>
       <point x="47" y="628"/>
-      <point type="curve" x="88" y="665"/>
+      <point x="88" y="665" type="curve"/>
       <point x="116" y="691"/>
       <point x="122" y="706"/>
-      <point type="curve" x="122" y="720"/>
+      <point x="122" y="720" type="curve"/>
       <point x="122" y="746"/>
       <point x="103" y="758"/>
-      <point type="curve" x="84" y="758"/>
+      <point x="84" y="758" type="curve"/>
       <point x="66" y="758"/>
       <point x="49" y="748"/>
-      <point type="curve" x="30" y="717"/>
+      <point x="30" y="717" type="curve"/>
       <point x="-2" y="669"/>
       <point x="-31" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/adieresis.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/adieresis.glif
@@ -4,93 +4,93 @@
   <unicode hex="00E4"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="355" y="596" name="hintSet0025"/>
+      <point x="355" y="596" type="curve" name="hintSet0025"/>
       <point x="387" y="596"/>
       <point x="414" y="620"/>
-      <point type="curve" x="414" y="653"/>
+      <point x="414" y="653" type="curve"/>
       <point x="414" y="685"/>
       <point x="387" y="710"/>
-      <point type="curve" x="355" y="710"/>
+      <point x="355" y="710" type="curve"/>
       <point x="322" y="710"/>
       <point x="295" y="685"/>
-      <point type="curve" x="295" y="653"/>
+      <point x="295" y="653" type="curve"/>
       <point x="295" y="620"/>
       <point x="322" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="145" y="596"/>
+      <point x="145" y="596" type="curve"/>
       <point x="178" y="596"/>
       <point x="205" y="620"/>
-      <point type="curve" x="205" y="653"/>
+      <point x="205" y="653" type="curve"/>
       <point x="205" y="685"/>
       <point x="178" y="710"/>
-      <point type="curve" x="145" y="710"/>
+      <point x="145" y="710" type="curve"/>
       <point x="113" y="710"/>
       <point x="86" y="685"/>
-      <point type="curve" x="86" y="653"/>
+      <point x="86" y="653" type="curve"/>
       <point x="86" y="620"/>
       <point x="113" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/atilde.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/atilde.glif
@@ -4,93 +4,93 @@
   <unicode hex="00E3"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="80" y="586" name="hintSet0025"/>
-      <point type="line" x="107" y="577"/>
+      <point x="80" y="586" type="curve" name="hintSet0025"/>
+      <point x="107" y="577" type="line"/>
       <point x="121" y="626"/>
       <point x="139" y="656"/>
-      <point type="curve" x="169" y="656"/>
+      <point x="169" y="656" type="curve"/>
       <point x="196" y="656"/>
       <point x="215" y="629"/>
-      <point type="curve" x="238" y="608"/>
+      <point x="238" y="608" type="curve"/>
       <point x="257" y="591" name="hintSet0029"/>
       <point x="278" y="575"/>
-      <point type="curve" x="311" y="575"/>
+      <point x="311" y="575" type="curve"/>
       <point x="367" y="575"/>
       <point x="394" y="626"/>
-      <point type="curve" x="406" y="703"/>
-      <point type="line" x="379" y="713"/>
+      <point x="406" y="703" type="curve"/>
+      <point x="379" y="713" type="line"/>
       <point x="365" y="664"/>
       <point x="347" y="633"/>
-      <point type="curve" x="317" y="633"/>
+      <point x="317" y="633" type="curve"/>
       <point x="290" y="633"/>
       <point x="271" y="661"/>
-      <point type="curve" x="248" y="681"/>
+      <point x="248" y="681" type="curve"/>
       <point x="228" y="699" name="hintSet0034"/>
       <point x="208" y="715"/>
-      <point type="curve" x="175" y="715"/>
+      <point x="175" y="715" type="curve"/>
       <point x="120" y="715"/>
       <point x="91" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/dieresiscmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/dieresiscmb.cap.glif
@@ -3,30 +3,30 @@
   <anchor x="0" y="691" name="_aboveUC"/>
   <outline>
     <contour>
-      <point type="curve" x="-112" y="744" name="hintSet0000"/>
+      <point x="-112" y="744" type="curve" name="hintSet0000"/>
       <point x="-80" y="744"/>
       <point x="-55" y="767"/>
-      <point type="curve" x="-55" y="799"/>
+      <point x="-55" y="799" type="curve"/>
       <point x="-55" y="831"/>
       <point x="-80" y="854"/>
-      <point type="curve" x="-112" y="854"/>
+      <point x="-112" y="854" type="curve"/>
       <point x="-143" y="854"/>
       <point x="-170" y="831"/>
-      <point type="curve" x="-170" y="799"/>
+      <point x="-170" y="799" type="curve"/>
       <point x="-170" y="767"/>
       <point x="-143" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="111" y="744"/>
+      <point x="111" y="744" type="curve"/>
       <point x="142" y="744"/>
       <point x="169" y="767"/>
-      <point type="curve" x="169" y="799"/>
+      <point x="169" y="799" type="curve"/>
       <point x="169" y="831"/>
       <point x="142" y="854"/>
-      <point type="curve" x="111" y="854"/>
+      <point x="111" y="854" type="curve"/>
       <point x="79" y="854"/>
       <point x="54" y="831"/>
-      <point type="curve" x="54" y="799"/>
+      <point x="54" y="799" type="curve"/>
       <point x="54" y="767"/>
       <point x="79" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/dieresiscmb.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/dieresiscmb.glif
@@ -5,30 +5,30 @@
   <anchor x="0" y="682" name="aboveLC"/>
   <outline>
     <contour>
-      <point type="curve" x="105" y="596" name="hintSet0000"/>
+      <point x="105" y="596" type="curve" name="hintSet0000"/>
       <point x="137" y="596"/>
       <point x="164" y="620"/>
-      <point type="curve" x="164" y="653"/>
+      <point x="164" y="653" type="curve"/>
       <point x="164" y="685"/>
       <point x="137" y="710"/>
-      <point type="curve" x="105" y="710"/>
+      <point x="105" y="710" type="curve"/>
       <point x="72" y="710"/>
       <point x="45" y="685"/>
-      <point type="curve" x="45" y="653"/>
+      <point x="45" y="653" type="curve"/>
       <point x="45" y="620"/>
       <point x="72" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="-105" y="596"/>
+      <point x="-105" y="596" type="curve"/>
       <point x="-72" y="596"/>
       <point x="-45" y="620"/>
-      <point type="curve" x="-45" y="653"/>
+      <point x="-45" y="653" type="curve"/>
       <point x="-45" y="685"/>
       <point x="-72" y="710"/>
-      <point type="curve" x="-105" y="710"/>
+      <point x="-105" y="710" type="curve"/>
       <point x="-137" y="710"/>
       <point x="-164" y="685"/>
-      <point type="curve" x="-164" y="653"/>
+      <point x="-164" y="653" type="curve"/>
       <point x="-164" y="620"/>
       <point x="-137" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/tildecmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/tildecmb.cap.glif
@@ -3,30 +3,30 @@
   <anchor x="0" y="691" name="_aboveUC"/>
   <outline>
     <contour>
-      <point type="curve" x="-180" y="734" name="hintSet0000"/>
-      <point type="line" x="-150" y="725"/>
+      <point x="-180" y="734" type="curve" name="hintSet0000"/>
+      <point x="-150" y="725" type="line"/>
       <point x="-135" y="774"/>
       <point x="-114" y="804"/>
-      <point type="curve" x="-82" y="804"/>
+      <point x="-82" y="804" type="curve"/>
       <point x="-52" y="804"/>
       <point x="-31" y="777"/>
-      <point type="curve" x="-6" y="756"/>
+      <point x="-6" y="756" type="curve"/>
       <point x="16" y="739" name="hintSet0004"/>
       <point x="39" y="723"/>
-      <point type="curve" x="76" y="723"/>
+      <point x="76" y="723" type="curve"/>
       <point x="137" y="723"/>
       <point x="167" y="774"/>
-      <point type="curve" x="180" y="851"/>
-      <point type="line" x="150" y="861"/>
+      <point x="180" y="851" type="curve"/>
+      <point x="150" y="861" type="line"/>
       <point x="135" y="812"/>
       <point x="115" y="781"/>
-      <point type="curve" x="82" y="781"/>
+      <point x="82" y="781" type="curve"/>
       <point x="52" y="781"/>
       <point x="31" y="809"/>
-      <point type="curve" x="6" y="829"/>
+      <point x="6" y="829" type="curve"/>
       <point x="-17" y="847" name="hintSet0009"/>
       <point x="-39" y="863"/>
-      <point type="curve" x="-75" y="863"/>
+      <point x="-75" y="863" type="curve"/>
       <point x="-136" y="863"/>
       <point x="-168" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/tildecmb.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/tildecmb.glif
@@ -4,30 +4,30 @@
   <anchor x="0" y="507" name="_aboveLC"/>
   <outline>
     <contour>
-      <point type="curve" x="-163" y="586" name="hintSet0000"/>
-      <point type="line" x="-136" y="577"/>
+      <point x="-163" y="586" type="curve" name="hintSet0000"/>
+      <point x="-136" y="577" type="line"/>
       <point x="-122" y="626"/>
       <point x="-104" y="656"/>
-      <point type="curve" x="-74" y="656"/>
+      <point x="-74" y="656" type="curve"/>
       <point x="-47" y="656"/>
       <point x="-28" y="629"/>
-      <point type="curve" x="-5" y="608"/>
+      <point x="-5" y="608" type="curve"/>
       <point x="14" y="591" name="hintSet0004"/>
       <point x="35" y="575"/>
-      <point type="curve" x="68" y="575"/>
+      <point x="68" y="575" type="curve"/>
       <point x="124" y="575"/>
       <point x="151" y="626"/>
-      <point type="curve" x="163" y="703"/>
-      <point type="line" x="136" y="713"/>
+      <point x="163" y="703" type="curve"/>
+      <point x="136" y="713" type="line"/>
       <point x="122" y="664"/>
       <point x="104" y="633"/>
-      <point type="curve" x="74" y="633"/>
+      <point x="74" y="633" type="curve"/>
       <point x="47" y="633"/>
       <point x="28" y="661"/>
-      <point type="curve" x="5" y="681"/>
+      <point x="5" y="681" type="curve"/>
       <point x="-15" y="699" name="hintSet0009"/>
       <point x="-35" y="715"/>
-      <point type="curve" x="-68" y="715"/>
+      <point x="-68" y="715" type="curve"/>
       <point x="-123" y="715"/>
       <point x="-152" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/y.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/y.glif
@@ -6,35 +6,35 @@
   <anchor x="124" y="-254" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/yacute.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/yacute.glif
@@ -4,53 +4,53 @@
   <unicode hex="00FD"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="247" y="576"/>
-      <point type="line" x="273" y="557"/>
+      <point x="247" y="576" type="curve"/>
+      <point x="273" y="557" type="line"/>
       <point x="314" y="593"/>
       <point x="353" y="628"/>
-      <point type="curve" x="394" y="665"/>
+      <point x="394" y="665" type="curve"/>
       <point x="422" y="691"/>
       <point x="428" y="706"/>
-      <point type="curve" x="428" y="720"/>
+      <point x="428" y="720" type="curve"/>
       <point x="428" y="746"/>
       <point x="409" y="758"/>
-      <point type="curve" x="390" y="758"/>
+      <point x="390" y="758" type="curve"/>
       <point x="372" y="758"/>
       <point x="355" y="748"/>
-      <point type="curve" x="336" y="717"/>
+      <point x="336" y="717" type="curve"/>
       <point x="304" y="669"/>
       <point x="275" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/ydieresis.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/ydieresis.glif
@@ -4,63 +4,63 @@
   <unicode hex="00FF"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="389" y="596"/>
+      <point x="389" y="596" type="curve"/>
       <point x="421" y="596"/>
       <point x="448" y="620"/>
-      <point type="curve" x="448" y="653"/>
+      <point x="448" y="653" type="curve"/>
       <point x="448" y="685"/>
       <point x="421" y="710"/>
-      <point type="curve" x="389" y="710"/>
+      <point x="389" y="710" type="curve"/>
       <point x="356" y="710"/>
       <point x="329" y="685"/>
-      <point type="curve" x="329" y="653"/>
+      <point x="329" y="653" type="curve"/>
       <point x="329" y="620"/>
       <point x="356" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="179" y="596"/>
+      <point x="179" y="596" type="curve"/>
       <point x="212" y="596"/>
       <point x="239" y="620"/>
-      <point type="curve" x="239" y="653"/>
+      <point x="239" y="653" type="curve"/>
       <point x="239" y="685"/>
       <point x="212" y="710"/>
-      <point type="curve" x="179" y="710"/>
+      <point x="179" y="710" type="curve"/>
       <point x="147" y="710"/>
       <point x="120" y="685"/>
-      <point type="curve" x="120" y="653"/>
+      <point x="120" y="653" type="curve"/>
       <point x="120" y="620"/>
       <point x="147" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/ytilde.glif
+++ b/tests/autohint_data/expected_output/ufo3-wd.ufo/glyphs/ytilde.glif
@@ -4,63 +4,63 @@
   <unicode hex="1EF9"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="111" y="586" name="hintSet0022"/>
-      <point type="line" x="138" y="577"/>
+      <point x="111" y="586" type="curve" name="hintSet0022"/>
+      <point x="138" y="577" type="line"/>
       <point x="152" y="626"/>
       <point x="170" y="656"/>
-      <point type="curve" x="200" y="656"/>
+      <point x="200" y="656" type="curve"/>
       <point x="227" y="656"/>
       <point x="246" y="629"/>
-      <point type="curve" x="269" y="608"/>
+      <point x="269" y="608" type="curve"/>
       <point x="288" y="591" name="hintSet0026"/>
       <point x="309" y="575"/>
-      <point type="curve" x="342" y="575"/>
+      <point x="342" y="575" type="curve"/>
       <point x="398" y="575"/>
       <point x="425" y="626"/>
-      <point type="curve" x="437" y="703"/>
-      <point type="line" x="410" y="713"/>
+      <point x="437" y="703" type="curve"/>
+      <point x="410" y="713" type="line"/>
       <point x="396" y="664"/>
       <point x="378" y="633"/>
-      <point type="curve" x="348" y="633"/>
+      <point x="348" y="633" type="curve"/>
       <point x="321" y="633"/>
       <point x="302" y="661"/>
-      <point type="curve" x="279" y="681"/>
+      <point x="279" y="681" type="curve"/>
       <point x="259" y="699" name="hintSet0031"/>
       <point x="239" y="715"/>
-      <point type="curve" x="206" y="715"/>
+      <point x="206" y="715" type="curve"/>
       <point x="151" y="715"/>
       <point x="122" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/A_.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/A_.glif
@@ -7,27 +7,27 @@
   <anchor x="312" y="-22" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/A_acute.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/A_acute.glif
@@ -4,43 +4,43 @@
   <unicode hex="00C1"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="266" y="745"/>
-      <point type="line" x="284" y="720"/>
+      <point x="266" y="745" type="curve"/>
+      <point x="284" y="720" type="line"/>
       <point x="326" y="742"/>
       <point x="368" y="765"/>
-      <point type="curve" x="410" y="788"/>
+      <point x="410" y="788" type="curve"/>
       <point x="448" y="809"/>
       <point x="460" y="825"/>
-      <point type="curve" x="460" y="843"/>
+      <point x="460" y="843" type="curve"/>
       <point x="460" y="863"/>
       <point x="443" y="877"/>
-      <point type="curve" x="422" y="877"/>
+      <point x="422" y="877" type="curve"/>
       <point x="405" y="877"/>
       <point x="388" y="867"/>
-      <point type="curve" x="360" y="839"/>
+      <point x="360" y="839" type="curve"/>
       <point x="328" y="809"/>
       <point x="297" y="778"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/A_dieresis.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/A_dieresis.glif
@@ -4,53 +4,53 @@
   <unicode hex="00C4"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="220" y="744" name="hintSet0019"/>
+      <point x="220" y="744" type="curve" name="hintSet0019"/>
       <point x="252" y="744"/>
       <point x="277" y="767"/>
-      <point type="curve" x="277" y="799"/>
+      <point x="277" y="799" type="curve"/>
       <point x="277" y="831"/>
       <point x="252" y="854"/>
-      <point type="curve" x="220" y="854"/>
+      <point x="220" y="854" type="curve"/>
       <point x="189" y="854"/>
       <point x="162" y="831"/>
-      <point type="curve" x="162" y="799"/>
+      <point x="162" y="799" type="curve"/>
       <point x="162" y="767"/>
       <point x="189" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="443" y="744"/>
+      <point x="443" y="744" type="curve"/>
       <point x="474" y="744"/>
       <point x="501" y="767"/>
-      <point type="curve" x="501" y="799"/>
+      <point x="501" y="799" type="curve"/>
       <point x="501" y="831"/>
       <point x="474" y="854"/>
-      <point type="curve" x="443" y="854"/>
+      <point x="443" y="854" type="curve"/>
       <point x="411" y="854"/>
       <point x="386" y="831"/>
-      <point type="curve" x="386" y="799"/>
+      <point x="386" y="799" type="curve"/>
       <point x="386" y="767"/>
       <point x="411" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/A_tilde.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/A_tilde.glif
@@ -4,53 +4,53 @@
   <unicode hex="00C3"/>
   <outline>
     <contour>
-      <point type="line" x="5" y="0" name="hintSet0000"/>
-      <point type="line" x="234" y="0" name="hintSet0001"/>
-      <point type="line" x="234" y="41"/>
-      <point type="line" x="137" y="54"/>
-      <point type="line" x="192" y="217"/>
-      <point type="line" x="424" y="217"/>
-      <point type="line" x="480" y="52"/>
-      <point type="line" x="381" y="41"/>
-      <point type="line" x="381" y="0"/>
-      <point type="line" x="653" y="0"/>
-      <point type="line" x="653" y="41" name="hintSet0010"/>
-      <point type="line" x="578" y="50"/>
-      <point type="line" x="365" y="674"/>
-      <point type="line" x="302" y="674"/>
-      <point type="line" x="89" y="53" name="hintSet0014"/>
-      <point type="line" x="5" y="41"/>
+      <point x="5" y="0" type="line" name="hintSet0000"/>
+      <point x="234" y="0" type="line" name="hintSet0001"/>
+      <point x="234" y="41" type="line"/>
+      <point x="137" y="54" type="line"/>
+      <point x="192" y="217" type="line"/>
+      <point x="424" y="217" type="line"/>
+      <point x="480" y="52" type="line"/>
+      <point x="381" y="41" type="line"/>
+      <point x="381" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="41" type="line" name="hintSet0010"/>
+      <point x="578" y="50" type="line"/>
+      <point x="365" y="674" type="line"/>
+      <point x="302" y="674" type="line"/>
+      <point x="89" y="53" type="line" name="hintSet0014"/>
+      <point x="5" y="41" type="line"/>
     </contour>
     <contour>
-      <point type="line" x="208" y="264"/>
-      <point type="line" x="309" y="562"/>
-      <point type="line" x="409" y="264"/>
+      <point x="208" y="264" type="line"/>
+      <point x="309" y="562" type="line"/>
+      <point x="409" y="264" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="151" y="734"/>
-      <point type="line" x="181" y="725"/>
+      <point x="151" y="734" type="curve"/>
+      <point x="181" y="725" type="line"/>
       <point x="196" y="774"/>
       <point x="217" y="804"/>
-      <point type="curve" x="249" y="804"/>
+      <point x="249" y="804" type="curve"/>
       <point x="279" y="804"/>
       <point x="300" y="777"/>
-      <point type="curve" x="325" y="756"/>
+      <point x="325" y="756" type="curve"/>
       <point x="347" y="739" name="hintSet0023"/>
       <point x="370" y="723"/>
-      <point type="curve" x="407" y="723"/>
+      <point x="407" y="723" type="curve"/>
       <point x="468" y="723"/>
       <point x="498" y="774"/>
-      <point type="curve" x="511" y="851"/>
-      <point type="line" x="481" y="861"/>
+      <point x="511" y="851" type="curve"/>
+      <point x="481" y="861" type="line"/>
       <point x="466" y="812"/>
       <point x="446" y="781"/>
-      <point type="curve" x="413" y="781"/>
+      <point x="413" y="781" type="curve"/>
       <point x="383" y="781"/>
       <point x="362" y="809"/>
-      <point type="curve" x="337" y="829"/>
+      <point x="337" y="829" type="curve"/>
       <point x="314" y="847" name="hintSet0028"/>
       <point x="292" y="863"/>
-      <point type="curve" x="256" y="863"/>
+      <point x="256" y="863" type="curve"/>
       <point x="195" y="863" name="hintSet0029"/>
       <point x="163" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/Y_.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/Y_.glif
@@ -6,31 +6,31 @@
   <anchor x="316" y="-22" name="belowLC"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/Y_acute.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/Y_acute.glif
@@ -4,47 +4,47 @@
   <unicode hex="00DD"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="305" y="735"/>
-      <point type="line" x="323" y="710"/>
+      <point x="305" y="735" type="curve"/>
+      <point x="323" y="710" type="line"/>
       <point x="365" y="732"/>
       <point x="407" y="755"/>
-      <point type="curve" x="449" y="778"/>
+      <point x="449" y="778" type="curve"/>
       <point x="487" y="799"/>
       <point x="499" y="815"/>
-      <point type="curve" x="499" y="833"/>
+      <point x="499" y="833" type="curve"/>
       <point x="499" y="853"/>
       <point x="482" y="867"/>
-      <point type="curve" x="461" y="867"/>
+      <point x="461" y="867" type="curve"/>
       <point x="444" y="867"/>
       <point x="427" y="857"/>
-      <point type="curve" x="399" y="829"/>
+      <point x="399" y="829" type="curve"/>
       <point x="367" y="799"/>
       <point x="336" y="768"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/Y_dieresis.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/Y_dieresis.glif
@@ -4,57 +4,57 @@
   <unicode hex="0178"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="235" y="744"/>
+      <point x="235" y="744" type="curve"/>
       <point x="267" y="744"/>
       <point x="292" y="767"/>
-      <point type="curve" x="292" y="799"/>
+      <point x="292" y="799" type="curve"/>
       <point x="292" y="831"/>
       <point x="267" y="854"/>
-      <point type="curve" x="235" y="854"/>
+      <point x="235" y="854" type="curve"/>
       <point x="204" y="854"/>
       <point x="177" y="831"/>
-      <point type="curve" x="177" y="799"/>
+      <point x="177" y="799" type="curve"/>
       <point x="177" y="767"/>
       <point x="204" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="458" y="744" name="hintSet0026"/>
+      <point x="458" y="744" type="curve" name="hintSet0026"/>
       <point x="489" y="744"/>
       <point x="516" y="767"/>
-      <point type="curve" x="516" y="799"/>
+      <point x="516" y="799" type="curve"/>
       <point x="516" y="831"/>
       <point x="489" y="854"/>
-      <point type="curve" x="458" y="854"/>
+      <point x="458" y="854" type="curve"/>
       <point x="426" y="854"/>
       <point x="401" y="831"/>
-      <point type="curve" x="401" y="799"/>
+      <point x="401" y="799" type="curve"/>
       <point x="401" y="767"/>
       <point x="426" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/Y_tilde.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/Y_tilde.glif
@@ -4,57 +4,57 @@
   <unicode hex="1EF8"/>
   <outline>
     <contour>
-      <point type="line" x="394" y="628" name="hintSet0000"/>
-      <point type="line" x="484" y="616"/>
-      <point type="line" x="341" y="315"/>
-      <point type="line" x="202" y="617" name="hintSet0003"/>
-      <point type="line" x="297" y="628"/>
-      <point type="line" x="297" y="669"/>
-      <point type="line" x="15" y="669"/>
-      <point type="line" x="15" y="628" name="hintSet0007"/>
-      <point type="line" x="93" y="619"/>
-      <point type="line" x="271" y="259"/>
+      <point x="394" y="628" type="line" name="hintSet0000"/>
+      <point x="484" y="616" type="line"/>
+      <point x="341" y="315" type="line"/>
+      <point x="202" y="617" type="line" name="hintSet0003"/>
+      <point x="297" y="628" type="line"/>
+      <point x="297" y="669" type="line"/>
+      <point x="15" y="669" type="line"/>
+      <point x="15" y="628" type="line" name="hintSet0007"/>
+      <point x="93" y="619" type="line"/>
+      <point x="271" y="259" type="line"/>
       <point x="271" y="182"/>
       <point x="270" y="114"/>
-      <point type="curve" x="269" y="52"/>
-      <point type="line" x="167" y="41"/>
-      <point type="line" x="167" y="0"/>
-      <point type="line" x="469" y="0"/>
-      <point type="line" x="469" y="41"/>
-      <point type="line" x="367" y="52"/>
+      <point x="269" y="52" type="curve"/>
+      <point x="167" y="41" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="469" y="0" type="line"/>
+      <point x="469" y="41" type="line"/>
+      <point x="367" y="52" type="line"/>
       <point x="365" y="116"/>
       <point x="365" y="185"/>
-      <point type="curve" x="365" y="264"/>
-      <point type="line" x="535" y="615" name="hintSet0017"/>
-      <point type="line" x="623" y="628"/>
-      <point type="line" x="623" y="669" name="hintSet0019"/>
-      <point type="line" x="394" y="669"/>
+      <point x="365" y="264" type="curve"/>
+      <point x="535" y="615" type="line" name="hintSet0017"/>
+      <point x="623" y="628" type="line"/>
+      <point x="623" y="669" type="line" name="hintSet0019"/>
+      <point x="394" y="669" type="line"/>
     </contour>
     <contour>
-      <point type="curve" x="166" y="734"/>
-      <point type="line" x="196" y="725"/>
+      <point x="166" y="734" type="curve"/>
+      <point x="196" y="725" type="line"/>
       <point x="211" y="774"/>
       <point x="232" y="804"/>
-      <point type="curve" x="264" y="804"/>
+      <point x="264" y="804" type="curve"/>
       <point x="294" y="804"/>
       <point x="315" y="777"/>
-      <point type="curve" x="340" y="756"/>
+      <point x="340" y="756" type="curve"/>
       <point x="362" y="739" name="hintSet0025"/>
       <point x="385" y="723"/>
-      <point type="curve" x="422" y="723"/>
+      <point x="422" y="723" type="curve"/>
       <point x="483" y="723"/>
       <point x="513" y="774"/>
-      <point type="curve" x="526" y="851"/>
-      <point type="line" x="496" y="861"/>
+      <point x="526" y="851" type="curve"/>
+      <point x="496" y="861" type="line"/>
       <point x="481" y="812"/>
       <point x="461" y="781"/>
-      <point type="curve" x="428" y="781"/>
+      <point x="428" y="781" type="curve"/>
       <point x="398" y="781"/>
       <point x="377" y="809"/>
-      <point type="curve" x="352" y="829"/>
+      <point x="352" y="829" type="curve"/>
       <point x="329" y="847" name="hintSet0030"/>
       <point x="307" y="863"/>
-      <point type="curve" x="271" y="863"/>
+      <point x="271" y="863" type="curve"/>
       <point x="210" y="863" name="hintSet0031"/>
       <point x="178" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/a.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/a.glif
@@ -7,65 +7,65 @@
   <anchor x="244" y="-22" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/aacute.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/aacute.glif
@@ -4,83 +4,83 @@
   <unicode hex="00E1"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="219" y="576"/>
-      <point type="line" x="245" y="557"/>
+      <point x="219" y="576" type="curve"/>
+      <point x="245" y="557" type="line"/>
       <point x="286" y="593"/>
       <point x="325" y="628"/>
-      <point type="curve" x="366" y="665"/>
+      <point x="366" y="665" type="curve"/>
       <point x="394" y="691"/>
       <point x="400" y="706"/>
-      <point type="curve" x="400" y="720"/>
+      <point x="400" y="720" type="curve"/>
       <point x="400" y="746"/>
       <point x="381" y="758"/>
-      <point type="curve" x="362" y="758"/>
+      <point x="362" y="758" type="curve"/>
       <point x="344" y="758"/>
       <point x="327" y="748"/>
-      <point type="curve" x="308" y="717"/>
+      <point x="308" y="717" type="curve"/>
       <point x="276" y="669"/>
       <point x="247" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/acutecmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/acutecmb.cap.glif
@@ -3,20 +3,20 @@
   <anchor x="0" y="691" name="_aboveUC"/>
   <outline>
     <contour>
-      <point type="curve" x="-67" y="745" name="hintSet0000"/>
-      <point type="line" x="-49" y="720"/>
+      <point x="-67" y="745" type="curve" name="hintSet0000"/>
+      <point x="-49" y="720" type="line"/>
       <point x="-7" y="742"/>
       <point x="35" y="765"/>
-      <point type="curve" x="77" y="788"/>
+      <point x="77" y="788" type="curve"/>
       <point x="115" y="809"/>
       <point x="127" y="825"/>
-      <point type="curve" x="127" y="843"/>
+      <point x="127" y="843" type="curve"/>
       <point x="127" y="863"/>
       <point x="110" y="877"/>
-      <point type="curve" x="89" y="877"/>
+      <point x="89" y="877" type="curve"/>
       <point x="72" y="877"/>
       <point x="55" y="867"/>
-      <point type="curve" x="27" y="839"/>
+      <point x="27" y="839" type="curve"/>
       <point x="-5" y="809"/>
       <point x="-36" y="778"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/acutecmb.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/acutecmb.glif
@@ -4,20 +4,20 @@
   <anchor x="0" y="507" name="_aboveLC"/>
   <outline>
     <contour>
-      <point type="curve" x="-59" y="576" name="hintSet0000"/>
-      <point type="line" x="-33" y="557"/>
+      <point x="-59" y="576" type="curve" name="hintSet0000"/>
+      <point x="-33" y="557" type="line"/>
       <point x="8" y="593"/>
       <point x="47" y="628"/>
-      <point type="curve" x="88" y="665"/>
+      <point x="88" y="665" type="curve"/>
       <point x="116" y="691"/>
       <point x="122" y="706"/>
-      <point type="curve" x="122" y="720"/>
+      <point x="122" y="720" type="curve"/>
       <point x="122" y="746"/>
       <point x="103" y="758"/>
-      <point type="curve" x="84" y="758"/>
+      <point x="84" y="758" type="curve"/>
       <point x="66" y="758"/>
       <point x="49" y="748"/>
-      <point type="curve" x="30" y="717"/>
+      <point x="30" y="717" type="curve"/>
       <point x="-2" y="669"/>
       <point x="-31" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/adieresis.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/adieresis.glif
@@ -4,93 +4,93 @@
   <unicode hex="00E4"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="355" y="596" name="hintSet0025"/>
+      <point x="355" y="596" type="curve" name="hintSet0025"/>
       <point x="387" y="596"/>
       <point x="414" y="620"/>
-      <point type="curve" x="414" y="653"/>
+      <point x="414" y="653" type="curve"/>
       <point x="414" y="685"/>
       <point x="387" y="710"/>
-      <point type="curve" x="355" y="710"/>
+      <point x="355" y="710" type="curve"/>
       <point x="322" y="710"/>
       <point x="295" y="685"/>
-      <point type="curve" x="295" y="653"/>
+      <point x="295" y="653" type="curve"/>
       <point x="295" y="620"/>
       <point x="322" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="145" y="596"/>
+      <point x="145" y="596" type="curve"/>
       <point x="178" y="596"/>
       <point x="205" y="620"/>
-      <point type="curve" x="205" y="653"/>
+      <point x="205" y="653" type="curve"/>
       <point x="205" y="685"/>
       <point x="178" y="710"/>
-      <point type="curve" x="145" y="710"/>
+      <point x="145" y="710" type="curve"/>
       <point x="113" y="710"/>
       <point x="86" y="685"/>
-      <point type="curve" x="86" y="653"/>
+      <point x="86" y="653" type="curve"/>
       <point x="86" y="620"/>
       <point x="113" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/atilde.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/atilde.glif
@@ -4,93 +4,93 @@
   <unicode hex="00E3"/>
   <outline>
     <contour>
-      <point type="curve" x="45" y="112" name="hintSet0000"/>
+      <point x="45" y="112" type="curve" name="hintSet0000"/>
       <point x="45" y="29"/>
       <point x="106" y="-13"/>
-      <point type="curve" x="179" y="-13"/>
+      <point x="179" y="-13" type="curve"/>
       <point x="238" y="-13"/>
       <point x="271" y="13"/>
-      <point type="curve" x="326" y="67"/>
+      <point x="326" y="67" type="curve"/>
       <point x="335" y="19" name="hintSet0003"/>
       <point x="368" y="-10"/>
-      <point type="curve" x="416" y="-10"/>
+      <point x="416" y="-10" type="curve"/>
       <point x="451" y="-10"/>
       <point x="479" y="3"/>
-      <point type="curve" x="503" y="42"/>
-      <point type="line" x="483" y="64"/>
+      <point x="503" y="42" type="curve"/>
+      <point x="483" y="64" type="line"/>
       <point x="472" y="51"/>
       <point x="461" y="42"/>
-      <point type="curve" x="444" y="42"/>
+      <point x="444" y="42" type="curve"/>
       <point x="422" y="42"/>
       <point x="408" y="58"/>
-      <point type="curve" x="408" y="101"/>
-      <point type="line" x="408" y="314"/>
+      <point x="408" y="101" type="curve"/>
+      <point x="408" y="314" type="line"/>
       <point x="408" y="440"/>
       <point x="358" y="488"/>
-      <point type="curve" x="253" y="488"/>
+      <point x="253" y="488" type="curve"/>
       <point x="151" y="488"/>
       <point x="77" y="440"/>
-      <point type="curve" x="58" y="364"/>
+      <point x="58" y="364" type="curve"/>
       <point x="61" y="338"/>
       <point x="77" y="323"/>
-      <point type="curve" x="105" y="323"/>
+      <point x="105" y="323" type="curve"/>
       <point x="132" y="323"/>
       <point x="148" y="340"/>
-      <point type="curve" x="157" y="371"/>
-      <point type="line" x="176" y="436"/>
+      <point x="157" y="371" type="curve"/>
+      <point x="176" y="436" type="line"/>
       <point x="197" y="441"/>
       <point x="215" y="442"/>
-      <point type="curve" x="230" y="442"/>
+      <point x="230" y="442" type="curve"/>
       <point x="296" y="442"/>
       <point x="324" y="418"/>
-      <point type="curve" x="324" y="321"/>
-      <point type="line" x="324" y="296"/>
+      <point x="324" y="321" type="curve"/>
+      <point x="324" y="296" type="line"/>
       <point x="284" y="286"/>
       <point x="242" y="274"/>
-      <point type="curve" x="211" y="263"/>
+      <point x="211" y="263" type="curve"/>
       <point x="76" y="214" name="hintSet0018"/>
       <point x="45" y="169"/>
     </contour>
     <contour>
-      <point type="curve" x="134" y="127"/>
+      <point x="134" y="127" type="curve"/>
       <point x="134" y="157"/>
       <point x="145" y="195"/>
-      <point type="curve" x="232" y="229"/>
+      <point x="232" y="229" type="curve"/>
       <point x="253" y="237"/>
       <point x="289" y="249"/>
-      <point type="curve" x="324" y="258"/>
-      <point type="line" x="324" y="106"/>
+      <point x="324" y="258" type="curve"/>
+      <point x="324" y="106" type="line"/>
       <point x="267" y="65"/>
       <point x="248" y="53"/>
-      <point type="curve" x="214" y="53"/>
+      <point x="214" y="53" type="curve"/>
       <point x="168" y="53"/>
       <point x="134" y="74"/>
     </contour>
     <contour>
-      <point type="curve" x="80" y="586" name="hintSet0025"/>
-      <point type="line" x="107" y="577"/>
+      <point x="80" y="586" type="curve" name="hintSet0025"/>
+      <point x="107" y="577" type="line"/>
       <point x="121" y="626"/>
       <point x="139" y="656"/>
-      <point type="curve" x="169" y="656"/>
+      <point x="169" y="656" type="curve"/>
       <point x="196" y="656"/>
       <point x="215" y="629"/>
-      <point type="curve" x="238" y="608"/>
+      <point x="238" y="608" type="curve"/>
       <point x="257" y="591" name="hintSet0029"/>
       <point x="278" y="575"/>
-      <point type="curve" x="311" y="575"/>
+      <point x="311" y="575" type="curve"/>
       <point x="367" y="575"/>
       <point x="394" y="626"/>
-      <point type="curve" x="406" y="703"/>
-      <point type="line" x="379" y="713"/>
+      <point x="406" y="703" type="curve"/>
+      <point x="379" y="713" type="line"/>
       <point x="365" y="664"/>
       <point x="347" y="633"/>
-      <point type="curve" x="317" y="633"/>
+      <point x="317" y="633" type="curve"/>
       <point x="290" y="633"/>
       <point x="271" y="661"/>
-      <point type="curve" x="248" y="681"/>
+      <point x="248" y="681" type="curve"/>
       <point x="228" y="699" name="hintSet0034"/>
       <point x="208" y="715"/>
-      <point type="curve" x="175" y="715"/>
+      <point x="175" y="715" type="curve"/>
       <point x="120" y="715"/>
       <point x="91" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/dieresiscmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/dieresiscmb.cap.glif
@@ -3,30 +3,30 @@
   <anchor x="0" y="691" name="_aboveUC"/>
   <outline>
     <contour>
-      <point type="curve" x="-112" y="744" name="hintSet0000"/>
+      <point x="-112" y="744" type="curve" name="hintSet0000"/>
       <point x="-80" y="744"/>
       <point x="-55" y="767"/>
-      <point type="curve" x="-55" y="799"/>
+      <point x="-55" y="799" type="curve"/>
       <point x="-55" y="831"/>
       <point x="-80" y="854"/>
-      <point type="curve" x="-112" y="854"/>
+      <point x="-112" y="854" type="curve"/>
       <point x="-143" y="854"/>
       <point x="-170" y="831"/>
-      <point type="curve" x="-170" y="799"/>
+      <point x="-170" y="799" type="curve"/>
       <point x="-170" y="767"/>
       <point x="-143" y="744"/>
     </contour>
     <contour>
-      <point type="curve" x="111" y="744"/>
+      <point x="111" y="744" type="curve"/>
       <point x="142" y="744"/>
       <point x="169" y="767"/>
-      <point type="curve" x="169" y="799"/>
+      <point x="169" y="799" type="curve"/>
       <point x="169" y="831"/>
       <point x="142" y="854"/>
-      <point type="curve" x="111" y="854"/>
+      <point x="111" y="854" type="curve"/>
       <point x="79" y="854"/>
       <point x="54" y="831"/>
-      <point type="curve" x="54" y="799"/>
+      <point x="54" y="799" type="curve"/>
       <point x="54" y="767"/>
       <point x="79" y="744"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/dieresiscmb.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/dieresiscmb.glif
@@ -5,30 +5,30 @@
   <anchor x="0" y="682" name="aboveLC"/>
   <outline>
     <contour>
-      <point type="curve" x="105" y="596" name="hintSet0000"/>
+      <point x="105" y="596" type="curve" name="hintSet0000"/>
       <point x="137" y="596"/>
       <point x="164" y="620"/>
-      <point type="curve" x="164" y="653"/>
+      <point x="164" y="653" type="curve"/>
       <point x="164" y="685"/>
       <point x="137" y="710"/>
-      <point type="curve" x="105" y="710"/>
+      <point x="105" y="710" type="curve"/>
       <point x="72" y="710"/>
       <point x="45" y="685"/>
-      <point type="curve" x="45" y="653"/>
+      <point x="45" y="653" type="curve"/>
       <point x="45" y="620"/>
       <point x="72" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="-105" y="596"/>
+      <point x="-105" y="596" type="curve"/>
       <point x="-72" y="596"/>
       <point x="-45" y="620"/>
-      <point type="curve" x="-45" y="653"/>
+      <point x="-45" y="653" type="curve"/>
       <point x="-45" y="685"/>
       <point x="-72" y="710"/>
-      <point type="curve" x="-105" y="710"/>
+      <point x="-105" y="710" type="curve"/>
       <point x="-137" y="710"/>
       <point x="-164" y="685"/>
-      <point type="curve" x="-164" y="653"/>
+      <point x="-164" y="653" type="curve"/>
       <point x="-164" y="620"/>
       <point x="-137" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/tildecmb.cap.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/tildecmb.cap.glif
@@ -3,30 +3,30 @@
   <anchor x="0" y="691" name="_aboveUC"/>
   <outline>
     <contour>
-      <point type="curve" x="-180" y="734" name="hintSet0000"/>
-      <point type="line" x="-150" y="725"/>
+      <point x="-180" y="734" type="curve" name="hintSet0000"/>
+      <point x="-150" y="725" type="line"/>
       <point x="-135" y="774"/>
       <point x="-114" y="804"/>
-      <point type="curve" x="-82" y="804"/>
+      <point x="-82" y="804" type="curve"/>
       <point x="-52" y="804"/>
       <point x="-31" y="777"/>
-      <point type="curve" x="-6" y="756"/>
+      <point x="-6" y="756" type="curve"/>
       <point x="16" y="739" name="hintSet0004"/>
       <point x="39" y="723"/>
-      <point type="curve" x="76" y="723"/>
+      <point x="76" y="723" type="curve"/>
       <point x="137" y="723"/>
       <point x="167" y="774"/>
-      <point type="curve" x="180" y="851"/>
-      <point type="line" x="150" y="861"/>
+      <point x="180" y="851" type="curve"/>
+      <point x="150" y="861" type="line"/>
       <point x="135" y="812"/>
       <point x="115" y="781"/>
-      <point type="curve" x="82" y="781"/>
+      <point x="82" y="781" type="curve"/>
       <point x="52" y="781"/>
       <point x="31" y="809"/>
-      <point type="curve" x="6" y="829"/>
+      <point x="6" y="829" type="curve"/>
       <point x="-17" y="847" name="hintSet0009"/>
       <point x="-39" y="863"/>
-      <point type="curve" x="-75" y="863"/>
+      <point x="-75" y="863" type="curve"/>
       <point x="-136" y="863"/>
       <point x="-168" y="812"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/tildecmb.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/tildecmb.glif
@@ -4,30 +4,30 @@
   <anchor x="0" y="507" name="_aboveLC"/>
   <outline>
     <contour>
-      <point type="curve" x="-163" y="586" name="hintSet0000"/>
-      <point type="line" x="-136" y="577"/>
+      <point x="-163" y="586" type="curve" name="hintSet0000"/>
+      <point x="-136" y="577" type="line"/>
       <point x="-122" y="626"/>
       <point x="-104" y="656"/>
-      <point type="curve" x="-74" y="656"/>
+      <point x="-74" y="656" type="curve"/>
       <point x="-47" y="656"/>
       <point x="-28" y="629"/>
-      <point type="curve" x="-5" y="608"/>
+      <point x="-5" y="608" type="curve"/>
       <point x="14" y="591" name="hintSet0004"/>
       <point x="35" y="575"/>
-      <point type="curve" x="68" y="575"/>
+      <point x="68" y="575" type="curve"/>
       <point x="124" y="575"/>
       <point x="151" y="626"/>
-      <point type="curve" x="163" y="703"/>
-      <point type="line" x="136" y="713"/>
+      <point x="163" y="703" type="curve"/>
+      <point x="136" y="713" type="line"/>
       <point x="122" y="664"/>
       <point x="104" y="633"/>
-      <point type="curve" x="74" y="633"/>
+      <point x="74" y="633" type="curve"/>
       <point x="47" y="633"/>
       <point x="28" y="661"/>
-      <point type="curve" x="5" y="681"/>
+      <point x="5" y="681" type="curve"/>
       <point x="-15" y="699" name="hintSet0009"/>
       <point x="-35" y="715"/>
-      <point type="curve" x="-68" y="715"/>
+      <point x="-68" y="715" type="curve"/>
       <point x="-123" y="715"/>
       <point x="-152" y="664"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/y.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/y.glif
@@ -6,35 +6,35 @@
   <anchor x="124" y="-254" name="belowLC"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/yacute.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/yacute.glif
@@ -4,53 +4,53 @@
   <unicode hex="00FD"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="247" y="576"/>
-      <point type="line" x="273" y="557"/>
+      <point x="247" y="576" type="curve"/>
+      <point x="273" y="557" type="line"/>
       <point x="314" y="593"/>
       <point x="353" y="628"/>
-      <point type="curve" x="394" y="665"/>
+      <point x="394" y="665" type="curve"/>
       <point x="422" y="691"/>
       <point x="428" y="706"/>
-      <point type="curve" x="428" y="720"/>
+      <point x="428" y="720" type="curve"/>
       <point x="428" y="746"/>
       <point x="409" y="758"/>
-      <point type="curve" x="390" y="758"/>
+      <point x="390" y="758" type="curve"/>
       <point x="372" y="758"/>
       <point x="355" y="748"/>
-      <point type="curve" x="336" y="717"/>
+      <point x="336" y="717" type="curve"/>
       <point x="304" y="669"/>
       <point x="275" y="623"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/ydieresis.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/ydieresis.glif
@@ -4,63 +4,63 @@
   <unicode hex="00FF"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="389" y="596"/>
+      <point x="389" y="596" type="curve"/>
       <point x="421" y="596"/>
       <point x="448" y="620"/>
-      <point type="curve" x="448" y="653"/>
+      <point x="448" y="653" type="curve"/>
       <point x="448" y="685"/>
       <point x="421" y="710"/>
-      <point type="curve" x="389" y="710"/>
+      <point x="389" y="710" type="curve"/>
       <point x="356" y="710"/>
       <point x="329" y="685"/>
-      <point type="curve" x="329" y="653"/>
+      <point x="329" y="653" type="curve"/>
       <point x="329" y="620"/>
       <point x="356" y="596"/>
     </contour>
     <contour>
-      <point type="curve" x="179" y="596"/>
+      <point x="179" y="596" type="curve"/>
       <point x="212" y="596"/>
       <point x="239" y="620"/>
-      <point type="curve" x="239" y="653"/>
+      <point x="239" y="653" type="curve"/>
       <point x="239" y="685"/>
       <point x="212" y="710"/>
-      <point type="curve" x="179" y="710"/>
+      <point x="179" y="710" type="curve"/>
       <point x="147" y="710"/>
       <point x="120" y="685"/>
-      <point type="curve" x="120" y="653"/>
+      <point x="120" y="653" type="curve"/>
       <point x="120" y="620"/>
       <point x="147" y="596"/>
     </contour>

--- a/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/ytilde.glif
+++ b/tests/autohint_data/expected_output/ufo3.ufo/glyphs.com.adobe.type.processedglyphs/ytilde.glif
@@ -4,63 +4,63 @@
   <unicode hex="1EF9"/>
   <outline>
     <contour>
-      <point type="curve" x="92" y="-249" name="hintSet0000"/>
+      <point x="92" y="-249" type="curve" name="hintSet0000"/>
       <point x="174" y="-249"/>
       <point x="230" y="-174"/>
-      <point type="curve" x="297" y="3"/>
-      <point type="line" x="458" y="428" name="hintSet0002"/>
-      <point type="line" x="512" y="439"/>
-      <point type="line" x="512" y="475" name="hintSet0004"/>
-      <point type="line" x="317" y="475"/>
-      <point type="line" x="317" y="439" name="hintSet0006"/>
-      <point type="line" x="404" y="427"/>
-      <point type="line" x="281" y="87"/>
-      <point type="line" x="156" y="428" name="hintSet0009"/>
-      <point type="line" x="244" y="438"/>
-      <point type="line" x="244" y="475"/>
-      <point type="line" x="4" y="475"/>
-      <point type="line" x="4" y="439" name="hintSet0013"/>
-      <point type="line" x="58" y="431"/>
-      <point type="line" x="241" y="-26"/>
-      <point type="line" x="236" y="-38"/>
+      <point x="297" y="3" type="curve"/>
+      <point x="458" y="428" type="line" name="hintSet0002"/>
+      <point x="512" y="439" type="line"/>
+      <point x="512" y="475" type="line" name="hintSet0004"/>
+      <point x="317" y="475" type="line"/>
+      <point x="317" y="439" type="line" name="hintSet0006"/>
+      <point x="404" y="427" type="line"/>
+      <point x="281" y="87" type="line"/>
+      <point x="156" y="428" type="line" name="hintSet0009"/>
+      <point x="244" y="438" type="line"/>
+      <point x="244" y="475" type="line"/>
+      <point x="4" y="475" type="line"/>
+      <point x="4" y="439" type="line" name="hintSet0013"/>
+      <point x="58" y="431" type="line"/>
+      <point x="241" y="-26" type="line"/>
+      <point x="236" y="-38" type="line"/>
       <point x="217" y="-92"/>
       <point x="189" y="-146"/>
-      <point type="curve" x="146" y="-182"/>
-      <point type="line" x="141" y="-177"/>
+      <point x="146" y="-182" type="curve"/>
+      <point x="141" y="-177" type="line"/>
       <point x="114" y="-149"/>
       <point x="93" y="-139"/>
-      <point type="curve" x="67" y="-139"/>
+      <point x="67" y="-139" type="curve"/>
       <point x="36" y="-139"/>
       <point x="7" y="-154"/>
-      <point type="curve" x="0" y="-183"/>
+      <point x="0" y="-183" type="curve"/>
       <point x="0" y="-222" name="hintSet0021"/>
       <point x="42" y="-249"/>
     </contour>
     <contour>
-      <point type="curve" x="111" y="586" name="hintSet0022"/>
-      <point type="line" x="138" y="577"/>
+      <point x="111" y="586" type="curve" name="hintSet0022"/>
+      <point x="138" y="577" type="line"/>
       <point x="152" y="626"/>
       <point x="170" y="656"/>
-      <point type="curve" x="200" y="656"/>
+      <point x="200" y="656" type="curve"/>
       <point x="227" y="656"/>
       <point x="246" y="629"/>
-      <point type="curve" x="269" y="608"/>
+      <point x="269" y="608" type="curve"/>
       <point x="288" y="591" name="hintSet0026"/>
       <point x="309" y="575"/>
-      <point type="curve" x="342" y="575"/>
+      <point x="342" y="575" type="curve"/>
       <point x="398" y="575"/>
       <point x="425" y="626"/>
-      <point type="curve" x="437" y="703"/>
-      <point type="line" x="410" y="713"/>
+      <point x="437" y="703" type="curve"/>
+      <point x="410" y="713" type="line"/>
       <point x="396" y="664"/>
       <point x="378" y="633"/>
-      <point type="curve" x="348" y="633"/>
+      <point x="348" y="633" type="curve"/>
       <point x="321" y="633"/>
       <point x="302" y="661"/>
-      <point type="curve" x="279" y="681"/>
+      <point x="279" y="681" type="curve"/>
       <point x="259" y="699" name="hintSet0031"/>
       <point x="239" y="715"/>
-      <point type="curve" x="206" y="715"/>
+      <point x="206" y="715" type="curve"/>
       <point x="151" y="715"/>
       <point x="122" y="664"/>
     </contour>


### PR DESCRIPTION
recent `lxml` release (4.4.0) caused changes in .glif file output that broke a bunch of tests. This PR pins `lxml` to v4.4.0 (the latest) and also updates all of the tests that were broken. The hope is that by stabilizing `lxml` we can avoid their releases breaking our tests unexpectedly.