### PR TITLE
[sfntedit] more fixes for issues found in static analysis

### DIFF
--- a/c/sfntedit/build/osx/xcode/sfntedit.xcodeproj/project.pbxproj
+++ b/c/sfntedit/build/osx/xcode/sfntedit.xcodeproj/project.pbxproj
@@ -120,14 +120,15 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 			};
 			buildConfigurationList = 1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "sfntedit" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* sfntedit */;
 			projectDirPath = "";
@@ -177,6 +178,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BDB5C7570DAEC139003A4375 /* debug.xcconfig */;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -210,6 +212,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BDB5C7580DAEC139003A4375 /* release.xcconfig */;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;

--- a/c/sfntedit/source/Efile.c
+++ b/c/sfntedit/source/Efile.c
@@ -62,7 +62,7 @@ void fileOpenWrite(char *filename, File *fyl) {
         } else {
             /* make certain that "filename" is unique */
             int try = 0;
-            strcpy(Wfnam, filename);
+            STRLCPY(Wfnam, filename, sizeof(Wfnam));
             while (fileExists(Wfnam)) {
                 sprintf(Wfnam, "%s%d", filename, try ++);
             }
@@ -113,7 +113,7 @@ long fileLength(File *fyl) {
 }
 
 /* Read N bytes from file */
-int fileReadN(File *file, size_t count, void *ptr) {
+size_t fileReadN(File *file, size_t count, void *ptr) {
     size_t n = fread(ptr, 1, count, file->fp);
 
     if (n == 0 && ferror(file->fp))
@@ -159,7 +159,7 @@ void fileReadObject(File *fyl, IntX size, void *obj) {
 }
 
 /* Write N bytes to file */
-int fileWriteN(File *file, size_t count, void *ptr) {
+size_t fileWriteN(File *file, size_t count, void *ptr) {
     size_t n = fwrite(ptr, 1, count, file->fp);
     if (n != count)
         fileError(file);

--- a/c/sfntedit/source/Efile.h
+++ b/c/sfntedit/source/Efile.h
@@ -21,10 +21,13 @@ extern int fileExists(char *filename);
 extern void fileClose(File *fyl);
 extern Card32 fileTell(File *fyl);
 extern void fileSeek(File *file, long offset, int wherefrom);
-extern int fileReadN(File *file, size_t count, void *ptr);
-extern int fileWriteN(File *file, size_t count, void *ptr);
+extern size_t fileReadN(File *file, size_t count, void *ptr);
+extern size_t fileWriteN(File *file, size_t count, void *ptr);
 extern void fileReadObject(File *fyl, IntX size, void *obj);
 extern void fileWriteObject(File *fyl, IntX size, Card32 value);
 extern void fileCopy(File *src, File *dst, size_t count);
+
+/* using a macro for this since strlcpy() is not portable */
+#define STRLCPY(dst, src, dstsize) strncpy(dst, src, dstsize); dst[dstsize - 1] = 0
 
 #endif /* FILE_H */

--- a/c/sfntedit/source/Esys.c
+++ b/c/sfntedit/source/Esys.c
@@ -40,14 +40,20 @@ int sysFileExists(char *filename) {
 long sysFileLen(FILE *f) {
     long at, cur;
     if (f == NULL)
-        return (-1);
+        return -1;
     cur = ftell(f);
+    if (cur == -1)
+        return -1;
     at = fseek(f, 0, SEEK_END);
     if (at == -1)
-        return (-1);
+        return -1;
     at = ftell(f);
-    fseek(f, cur, SEEK_SET);
-    return (at);
+    if (at == -1)
+        return -1;
+    if (fseek(f, cur, SEEK_SET) == -1)
+        return -1;
+    else
+        return at;
 }
 
 FILE *sysOpenRead(char *filename) {
@@ -83,14 +89,15 @@ FILE *sysOpenSearchpath(char *filename) {
         file[0] = '\0';
         sprintf(file, *p, filename);
         f = fopen(file, "rb");
-        if (f == NULL) continue;
-        fd = fileno(f);
-        if (fd < 0) continue;
-        if ((f == NULL) ||
-            (fstat(fd, &st) == (-1)) || ((st.st_mode & S_IFMT) == S_IFDIR))
+        if (f == NULL)
             continue;
-        else
+        fd = fileno(f);
+        if ((fd < 0) || (fstat(fd, &st) == (-1)) || ((st.st_mode & S_IFMT) == S_IFDIR)) {
+            fclose(f);
+            continue;
+        } else {
             return f;
+        }
     }
 
     return (NULL);

--- a/c/sfntedit/source/main.c
+++ b/c/sfntedit/source/main.c
@@ -397,8 +397,8 @@ static Table *insertTable(Tag tag) {
 static void parseTagList(char *arg, int option, int flag) {
     char *p = arg;
     for (p = strtok(arg, ","); p != NULL; p = strtok(NULL, ",")) {
-        int i;
-        int taglen;
+        size_t i;
+        size_t taglen;
         Tag tag;
         char *filename;
         Table *tbl;
@@ -479,7 +479,7 @@ static int parseArgs(int argc, char *argv[]) {
                     case 'X': /* script file to execute */
                         foundXswitch = 1;
                         if ((argsleft > 0) && argv[i + 1][0] != '-') {
-                            strcpy(scriptfilename, argv[++i]);
+                            STRLCPY(scriptfilename, argv[++i], sizeof(scriptfilename));
                             if (doingScripting) /* disallow nesting */
                             {
                                 foundXswitch = 0;
@@ -905,7 +905,7 @@ static boolean sfntCopy(void) {
     FILE *f;
     boolean changed = (options & OPT_FIX) ? 1: 0; /* write file only if we change it */
 
-    strcpy(outputfilename, dstfile.name);
+    STRLCPY(outputfilename, dstfile.name, sizeof(outputfilename));
     f = freopen(outputfilename, "r+b", dstfile.fp);
     if (f == NULL) {
         fatal(SFED_MSG_sysFERRORSTR, strerror(errno), dstfile.name);
@@ -1052,7 +1052,7 @@ int main(int argc, char *argv[]) {
     for (i = 0; i < argc; i++) {
         if (strcmp(argv[i], "-X") == 0) {
             if ((argv[i + 1] != NULL) && (argv[i + 1][0] != '\0')) {
-                strcpy(scriptfilename, argv[i + 1]);
+                STRLCPY(scriptfilename, argv[i + 1], sizeof(scriptfilename));
                 foundXswitch = 1;
             }
             break;
@@ -1118,7 +1118,7 @@ int main(int argc, char *argv[]) {
                 char *scurr = srcfile.name;
                 char *dcurr;
 
-                sourcepath = (char *)malloc(strlen(srcfile.name));
+                sourcepath = (char *)malloc(strlen(srcfile.name) + 1);
                 dcurr = sourcepath;
                 while (scurr != end) {
                     *dcurr++ = *scurr++;


### PR DESCRIPTION
`project.pbxproj`:
* updated automatically per Xcode's recommendations

`Efile.c`/`Efile.h`:
* `fileOpenWrite()` -- use `STRLCPY` instead of `strcpy`
* `fileReadN()` -- changed return type to `size_t`
* `fileWriteN()` -- changed return type to `size_t`

`Esys.c`:
* `sysFileLen()` -- check return values of `ftell` and `fseek`
* `sysOpenSearchpath()` -- close current file before opening a new one

`main.c`:
* `parseTagList()` -- changed `i` and `taglen` to `size_t`
* `parseArgs()`, `sfntCopy()`, & `main()` -- use `STRLCPY` instead of `strcpy`

Note:
* Added a macro `STRLCPY` that emulates `strlcpy` (since `strlcpy` is not portable).
