### PR TITLE
[absfont] cleaned up some Xcode & cppcheck warnings

### DIFF
--- a/c/public/lib/source/absfont/absfont.c
+++ b/c/public/lib/source/absfont/absfont.c
@@ -419,7 +419,7 @@ void abfCheckAllDicts(abfErrCallbacks *cb, abfTopDict *top) {
     if (top->FDArray.cnt == 1)
         checkFontDict(cb, top, &top->FDArray.array[0], -1);
     else {
-        long i;
+        int i;
         for (i = 0; i < top->FDArray.cnt; i++)
             checkFontDict(cb, top, &top->FDArray.array[i], i);
     }

--- a/c/public/lib/source/absfont/absfont_compare.c
+++ b/c/public/lib/source/absfont/absfont_compare.c
@@ -12,7 +12,6 @@
 
 static int compareOpEntries(abfOpEntry *opEntry1, abfOpEntry *opEntry2) {
     /* return 1 if NOT equal */
-    int i = 0;
     int retVal = 1;
 
     if (opEntry1->numBlends != opEntry2->numBlends)
@@ -24,6 +23,7 @@ static int compareOpEntries(abfOpEntry *opEntry1, abfOpEntry *opEntry2) {
         else
             return 1;
     } else {
+        int i = 0;
         retVal = 0;
         while (i < opEntry1->numBlends) {
             if (opEntry1->blendValues[i] != opEntry2->blendValues[i]) {
@@ -125,7 +125,6 @@ static int comparePrivateDicts(abfPrivateDict *private1,
 /* Compare two top dicts to see if they are similar enough to merge.
    Assume client has assured that they are valid before call. */
 int abfCompareTopDicts(abfTopDict *top1, abfTopDict *top2) {
-    int i;
     int firstIsCID = (top1->sup.flags & ABF_CID_FONT) != 0;
     int secondIsCID = (top2->sup.flags & ABF_CID_FONT) != 0;
 
@@ -149,6 +148,8 @@ int abfCompareTopDicts(abfTopDict *top1, abfTopDict *top2) {
         return 1;
 
     if (firstIsCID) {
+        int i;
+
         if (top1->cid.Registry.ptr && top2->cid.Registry.ptr &&
             strcmp(top1->cid.Registry.ptr, top2->cid.Registry.ptr) != 0)
             return 1;

--- a/c/public/lib/source/absfont/absfont_desc.c
+++ b/c/public/lib/source/absfont/absfont_desc.c
@@ -160,7 +160,7 @@ static void fillFontDescElementValues(abfFontDict *font,
     values = saveValues(values, Private->FamilyOtherBlues.array,
                         elem->FamilyOtherBlues);
     values = saveValues(values, Private->StemSnapH.array, elem->StemSnapH);
-    values = saveValues(values, Private->StemSnapV.array, elem->StemSnapV);
+    saveValues(values, Private->StemSnapV.array, elem->StemSnapV);
 }
 
 /* Create abstract font descriptor. */

--- a/c/public/lib/source/absfont/absfont_draw.c
+++ b/c/public/lib/source/absfont/absfont_draw.c
@@ -637,8 +637,8 @@ static void drawMetrics(abfDrawCtx h, abfGlyphInfo *info) {
             char *p = buf;
             size_t remainingBufferLength = bufLen;
             char *sep = "";
-            size_t printStringLength;
             do {
+                size_t printStringLength;
                 if (info->flags & ABF_GLYPH_UNICODE) {
                     if (enc->code < 0x10000)
                         SPRINTF_S(p, remainingBufferLength, "%sU+%04lX", sep, enc->code);
@@ -662,14 +662,13 @@ static void drawMetrics(abfDrawCtx h, abfGlyphInfo *info) {
         SPRINTF_S(buf, bufLen, "\\\\%hu", info->cid);
     else
         SPRINTF_S(buf, bufLen, "%s", info->gname.ptr);
-    y = drawString(h, y, "glyph", buf);
+    drawString(h, y, "glyph", buf);
 }
 
 /* Draw glyph end. */
 static void glyphEnd(abfGlyphCallbacks *cb) {
     abfDrawCtx h = (abfDrawCtx)cb->direct_ctx;
     char gname[50];
-    const size_t gnameLen = sizeof(gname);
     abfGlyphInfo *info = cb->info;
 
     if (!h->showglyph)
@@ -685,15 +684,14 @@ static void glyphEnd(abfGlyphCallbacks *cb) {
 
     /* Set glyph name */
     if (info->flags & ABF_GLYPH_CID)
-        SPRINTF_S(gname, gnameLen, "\\\\%hu", info->cid);
+        SPRINTF_S(gname, sizeof(gname), "\\\\%hu", info->cid);
     else
-        SPRINTF_S(gname, gnameLen, "%s", info->gname.ptr);
+        SPRINTF_S(gname, sizeof(gname), "%s", info->gname.ptr);
 
     if (h->level == 0) {
         char tag[20];
         const size_t tagLen = sizeof(tag);
         char hAdv[20];
-        const size_t hAdvLen = sizeof(hAdv);
 
         if (info->flags & ABF_GLYPH_CID)
             SPRINTF_S(tag, tagLen, "%hu,%u", info->tag, info->iFD);
@@ -727,7 +725,7 @@ static void glyphEnd(abfGlyphCallbacks *cb) {
                 }
             }
         }
-        SPRINTF_S(hAdv, hAdvLen, "%g", h->glyph.hAdv);
+        SPRINTF_S(hAdv, sizeof(hAdv), "%g", h->glyph.hAdv);
         drawTile(h, (float)h->tile.h, (float)h->tile.v, tag, hAdv, gname);
 
         if (!(h->flags & ABF_SHOW_BY_ENC)) {

--- a/c/public/lib/source/absfont/absfont_dump.c
+++ b/c/public/lib/source/absfont/absfont_dump.c
@@ -456,17 +456,16 @@ static void glyphWidth(abfGlyphCallbacks *cb, float hAdv) {
 /*In Xcode, FLT_EPSILON is 1.192..x10-7, but the diff between value-roundf(value) can be 3.05x10-5, when the input value is an integer. */
 static void writeReal(char *buf, const size_t bufLen, float value) {
     char tmp[50];
-    const size_t tmpLen = sizeof(tmp);
-    int l;
 
     /* if no decimal component, perform a faster to string conversion */
     if ((fabs(value - roundf(value)) < TX_EPSILON) && (value > LONG_MIN) && (value < LONG_MAX))
-        SPRINTF_S(tmp, tmpLen, " %ld", (long int)roundf(value));
+        SPRINTF_S(tmp, sizeof(tmp), " %ld", (long int)roundf(value));
     else {
+        int l;
         float value2 = (float)RND_ON_WRITE(value);  // to avoid getting -0 from 0.0004.
         if ((value2 == 0) && (value < 0))
             value2 = 0;
-        SPRINTF_S(tmp, tmpLen, " %.2f", value2);
+        SPRINTF_S(tmp, sizeof(tmp), " %.2f", value2);
         l = (int)strlen(tmp) - 1;
         if ((tmp[l] == '0') && (tmp[l - 1] == '0')) {
             tmp[l - 2] = 0;


### PR DESCRIPTION
absfont.c:
* changed a variable type for consistency

absfont_compare.c:
* reduced the scope of a couple of variables

absfont_desc.c:
* removed superfluous code

absfont_draw.c:
* reduced the scope of a variable
* removed superfluous code
* moved `sizeof()` into `SPRINTF_S` calls to prevent unused variable warnings

absfont_dump.c:
* reduced the scope of a variable
* moved `sizeof()` into `SPRINTF_S` calls to prevent unused variable warnings

absfont_path.c:
* reduced the scope of several variables
* removed superfluous code