### PR TITLE
bumped versions to reflect recent changes

### DIFF
--- a/c/mergefonts/source/mergeFonts.c
+++ b/c/mergefonts/source/mergeFonts.c
@@ -8,7 +8,7 @@
 
 #include "tx_shared.h"
 
-#define MERGEFONTS_VERSION CTL_MAKE_VERSION(1, 2, 0) /* derived from tx */
+#define MERGEFONTS_VERSION CTL_MAKE_VERSION(1, 2, 2) /* derived from tx */
 
 #ifdef __cplusplus
 extern "C" {

--- a/c/public/lib/api/absfont.h
+++ b/c/public/lib/api/absfont.h
@@ -9,7 +9,7 @@
 #include "dynarr.h"
 #include "txops.h"
 
-#define ABF_VERSION CTL_MAKE_VERSION(1, 0, 53)
+#define ABF_VERSION CTL_MAKE_VERSION(1, 0, 54)
 
 #include <stdint.h>
 #include <stdio.h>

--- a/c/public/lib/api/cffread.h
+++ b/c/public/lib/api/cffread.h
@@ -7,7 +7,7 @@
 
 #include "ctlshare.h"
 
-#define CFR_VERSION CTL_MAKE_VERSION(2, 1, 0)
+#define CFR_VERSION CTL_MAKE_VERSION(2, 1, 1)
 
 #include "absfont.h"
 

--- a/c/public/lib/api/cffwrite.h
+++ b/c/public/lib/api/cffwrite.h
@@ -8,7 +8,7 @@
 
 #include "ctlshare.h"
 
-#define CFW_VERSION CTL_MAKE_VERSION(1, 0, 54)
+#define CFW_VERSION CTL_MAKE_VERSION(1, 0, 55)
 
 #include "absfont.h"
 

--- a/c/public/lib/api/dynarr.h
+++ b/c/public/lib/api/dynarr.h
@@ -7,7 +7,7 @@
 
 #include "ctlshare.h"
 
-#define DNA_VERSION CTL_MAKE_VERSION(2, 0, 3)
+#define DNA_VERSION CTL_MAKE_VERSION(2, 0, 4)
 
 #ifdef __cplusplus
 extern "C" {

--- a/c/public/lib/api/pstoken.h
+++ b/c/public/lib/api/pstoken.h
@@ -7,7 +7,7 @@
 
 #include "ctlshare.h"
 
-#define PST_VERSION CTL_MAKE_VERSION(2, 0, 9)
+#define PST_VERSION CTL_MAKE_VERSION(2, 0, 10)
 
 #ifdef __cplusplus
 extern "C" {

--- a/c/public/lib/api/sfntread.h
+++ b/c/public/lib/api/sfntread.h
@@ -7,7 +7,7 @@
 
 #include "ctlshare.h"
 
-#define SFR_VERSION CTL_MAKE_VERSION(1, 0, 5)
+#define SFR_VERSION CTL_MAKE_VERSION(1, 0, 6)
 
 #ifdef __cplusplus
 extern "C" {

--- a/c/public/lib/api/svgwrite.h
+++ b/c/public/lib/api/svgwrite.h
@@ -7,7 +7,7 @@
 
 #include "ctlshare.h"
 
-#define SVW_VERSION CTL_MAKE_VERSION(1, 1, 10)
+#define SVW_VERSION CTL_MAKE_VERSION(1, 1, 11)
 
 #include "absfont.h"
 

--- a/c/public/lib/api/svread.h
+++ b/c/public/lib/api/svread.h
@@ -7,7 +7,7 @@
 
 #include "ctlshare.h"
 
-#define SVR_VERSION CTL_MAKE_VERSION(1, 0, 6)
+#define SVR_VERSION CTL_MAKE_VERSION(1, 0, 7)
 
 #include "absfont.h"
 

--- a/c/public/lib/api/t1cstr.h
+++ b/c/public/lib/api/t1cstr.h
@@ -11,7 +11,7 @@
 
 #include "ctlshare.h"
 
-#define T1C_VERSION CTL_MAKE_VERSION(1, 0, 19)
+#define T1C_VERSION CTL_MAKE_VERSION(1, 0, 20)
 
 #include "absfont.h"
 

--- a/c/public/lib/api/t1read.h
+++ b/c/public/lib/api/t1read.h
@@ -7,7 +7,7 @@
 
 #include "ctlshare.h"
 
-#define T1R_VERSION CTL_MAKE_VERSION(1, 0, 42)
+#define T1R_VERSION CTL_MAKE_VERSION(1, 0, 43)
 
 #include "absfont.h"
 

--- a/c/public/lib/api/t1write.h
+++ b/c/public/lib/api/t1write.h
@@ -7,7 +7,7 @@
 
 #include "ctlshare.h"
 
-#define T1W_VERSION CTL_MAKE_VERSION(1, 0, 34)
+#define T1W_VERSION CTL_MAKE_VERSION(1, 0, 35)
 
 #include "absfont.h"
 

--- a/c/public/lib/api/t2cstr.h
+++ b/c/public/lib/api/t2cstr.h
@@ -11,7 +11,7 @@
 
 #include "ctlshare.h"
 
-#define T2C_VERSION CTL_MAKE_VERSION(1, 0, 21)
+#define T2C_VERSION CTL_MAKE_VERSION(1, 0, 22)
 
 #include "absfont.h"
 

--- a/c/public/lib/api/uforead.h
+++ b/c/public/lib/api/uforead.h
@@ -2,12 +2,12 @@
    This software is licensed as OpenSource, under the Apache License, Version 2.0.
    This license is available at: http://opensource.org/licenses/Apache-2.0. */
 
-#ifndef UFOEAD_H
-#define UFOEAD_H
+#ifndef UFOREAD_H
+#define UFOREAD_H
 
 #include "ctlshare.h"
 
-#define UFO_VERSION CTL_MAKE_VERSION(1, 1, 0)
+#define UFO_VERSION CTL_MAKE_VERSION(1, 1, 1)
 
 #include "absfont.h"
 
@@ -150,4 +150,4 @@ void ufoGetVersion(ctlVersionCallbacks *cb);
 }
 #endif
 
-#endif /* UFOEAD_H */
+#endif /* UFOREAD_H */

--- a/c/public/lib/api/varread.h
+++ b/c/public/lib/api/varread.h
@@ -19,7 +19,7 @@ extern "C" {
    This library parses tables common tables used by variable OpenType fonts.
 */
 
-#define VARREAD_VERSION CTL_MAKE_VERSION(1, 0, 5)
+#define VARREAD_VERSION CTL_MAKE_VERSION(1, 0, 6)
 #define F2DOT14_TO_FIXED(v) (((Fixed)(v)) << 2)
 #define FIXED_TO_F2DOT14(v) ((var_F2dot14)(((Fixed)(v) + 0x00000002) >> 2))
 

--- a/c/rotatefont/source/rotateFont.c
+++ b/c/rotatefont/source/rotateFont.c
@@ -8,7 +8,7 @@
 
 #include "tx_shared.h"
 
-#define ROTATE_VERSION CTL_MAKE_VERSION(1, 2, 0)
+#define ROTATE_VERSION CTL_MAKE_VERSION(1, 2, 2)
 
 #define kHADV_NOT_SPECIFIED 11111.0 /* If the value is this, we don't overwrite the glyphs original advance width*/
 #define kkHADV_NOT_SPECIFIED_NAME "None"

--- a/c/tx/source/tx.c
+++ b/c/tx/source/tx.c
@@ -8,7 +8,7 @@
 
 #include "tx_shared.h"
 
-#define TX_VERSION CTL_MAKE_VERSION(1, 2, 1)
+#define TX_VERSION CTL_MAKE_VERSION(1, 2, 2)
 
 #include "varread.h"
 


### PR DESCRIPTION
* incremented versions on changed C modules
* set `tx`, `mergefonts`, & `rotatefont` versions to have same version as each other due to shared code changes
* also fixed typo in `uforead.h`