### PR TITLE
Appveyor setup updates

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,13 +25,13 @@ install:
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:
-  - python setup.py bdist_wheel
+  - python setup.py bdist_wheel || EXIT /B 1
   - for %%f in (dist\*.whl) do (set "WHEEL=%%f")
-  - python -m pip install %WHEEL%
+  - python -m pip install %WHEEL% || EXIT /B 1
 
 test_script:
-  - python -m pytest
-  - python -m pip uninstall --yes afdko
+  - python -m pytest || EXIT /B 1
+  - python -m pip uninstall --yes afdko || EXIT /B 1
 
 artifacts:
   # archive the generated packages in the ci.appveyor.com build report

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,9 +2,6 @@ image: Visual Studio 2017
 
 environment:
   global:
-    CIBW_BUILD: cp36-win_amd64
-    CIBW_TEST_REQUIRES: pytest
-    CIBW_TEST_COMMAND: cd {project} && pytest && pip uninstall --yes afdko
     TWINE_USERNAME: adobe-type-tools-ci
     # Note: TWINE_PASSWORD is set in AppVeyor settings
     PYTHON_HOME: C:\Python36-x64
@@ -15,22 +12,30 @@ matrix:
 # Do not build feature branch with open Pull Requests
 skip_branch_with_pr: true
 
+# scripts that run after cloning repository
 install:
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
   - SET PATH=%PYTHON_HOME%;%PYTHON_HOME%\Scripts;%PATH%
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
-  - python -m pip install --disable-pip-version-check --upgrade pip
+  - python -m pip install --disable-pip-version-check -U -q pip setuptools wheel
+  - python -m pip install pytest
   - python -m pip --version
+  - python -m pip list
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:
-  # our setup.py requires 'wheel', which may not be already installed
-  - python -m pip install cibuildwheel wheel
-  - cibuildwheel --output-dir wheelhouse
+  - python setup.py bdist_wheel
+  - for %%f in (dist\*.whl) do (set "WHEEL=%%f")
+  - python -m pip install %WHEEL%
+
+test_script:
+  - python -m pytest
+  - python -m pip uninstall --yes afdko
 
 artifacts:
   # archive the generated packages in the ci.appveyor.com build report
-  - path: wheelhouse\*.whl
+  - path: dist\*.whl
     name: Wheels
 
 on_success:
@@ -39,7 +44,7 @@ on_success:
       if ($env:APPVEYOR_REPO_TAG -eq "true") {
         Write-Output ("Deploying " + $env:APPVEYOR_REPO_TAG_NAME + " to PyPI...")
         python -m pip install twine
-        python -m twine upload wheelhouse/*.whl
+        python -m twine upload dist/*.whl
       }
 
 deploy:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,20 +18,23 @@ install:
   - SET PATH=%PYTHON_HOME%;%PYTHON_HOME%\Scripts;%PATH%
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
-  - python -m pip install --disable-pip-version-check -U -q pip setuptools wheel
-  - python -m pip install pytest
+  - python -m pip install --disable-pip-version-check -U -q pip setuptools wheel pytest
   - python -m pip --version
   - python -m pip list
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:
   - python setup.py bdist_wheel || EXIT /B 1
-  - for %%f in (dist\*.whl) do (set "WHEEL=%%f")
-  - python -m pip install %WHEEL% || EXIT /B 1
 
 test_script:
-  - python -m pytest || EXIT /B 1
-  - python -m pip uninstall --yes afdko || EXIT /B 1
+  # run the tests only on untagged commits
+  - ps: >-
+      if ($env:APPVEYOR_REPO_TAG -ne "true") {
+        $WHEEL = Resolve-Path "dist\*.whl" | Select -ExpandProperty Path
+        python -m pip install $WHEEL
+        python -m pytest
+        python -m pip uninstall --yes afdko
+      }
 
 artifacts:
   # archive the generated packages in the ci.appveyor.com build report


### PR DESCRIPTION
* Drops the dependency on **cibuildwheel**
* The tests now only run on untagged commits