### PR TITLE
Travis (macOS) setup updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,12 @@ script:
       $PIP --version
       $PIP list
       $PYTHON setup.py bdist_wheel
-      $PIP install dist/*.whl
-      $PYTHON -m pytest
-      $PIP uninstall --yes afdko
+      if [[ -z $TRAVIS_TAG ]]; then
+        # run the tests only on untagged commits
+        $PIP install dist/*.whl
+        $PYTHON -m pytest
+        $PIP uninstall --yes afdko
+      fi
     else
       $PIP install --disable-pip-version-check -U -q pip
       $PIP install cibuildwheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
         - CIBW_TEST_COMMAND="cd {project} && pytest && pip uninstall --yes afdko"
 
     - os: osx
+      osx_image: xcode8
       language: generic
       env:
         - NAME=OSX
@@ -31,6 +32,7 @@ matrix:
 script:
   - |
     if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+      brew install python3
       $PIP install --disable-pip-version-check -U -q pip setuptools wheel pytest
       $PYTHON --version
       $PIP --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ python: 3.6
 
 env:
   global:
-    - CIBW_BUILD="cp36-macosx_10_6_intel cp36-manylinux1_x86_64"
-    - CIBW_BEFORE_BUILD_LINUX="pip install --disable-pip-version-check -U -q pip"
-    - CIBW_TEST_REQUIRES="pytest"
-    - CIBW_TEST_COMMAND="cd {project} && pytest && pip uninstall --yes afdko"
     - TWINE_USERNAME="adobe-type-tools-ci"
     # Note: TWINE_PASSWORD is set in Travis settings
 
@@ -20,6 +16,10 @@ matrix:
         - NAME=Linux
         - PIP=pip
         - PYTHON=python
+        - CIBW_BUILD="cp36-manylinux1_x86_64"
+        - CIBW_BEFORE_BUILD="pip install --disable-pip-version-check -U -q pip"
+        - CIBW_TEST_REQUIRES="pytest"
+        - CIBW_TEST_COMMAND="cd {project} && pytest && pip uninstall --yes afdko"
 
     - os: osx
       language: generic
@@ -29,10 +29,21 @@ matrix:
         - PYTHON=python3
 
 script:
-  - $PIP install --upgrade pip
-  # - $PIP install cibuildwheel
-  - $PIP install git+https://github.com/adobe-type-tools/cibuildwheel
-  - cibuildwheel --output-dir wheelhouse
+  - |
+    if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+      $PIP install --disable-pip-version-check -U -q pip setuptools wheel pytest
+      $PYTHON --version
+      $PIP --version
+      $PIP list
+      $PYTHON setup.py bdist_wheel
+      $PIP install dist/*.whl
+      $PYTHON -m pytest
+      $PIP uninstall --yes afdko
+    else
+      $PIP install --disable-pip-version-check -U -q pip
+      $PIP install cibuildwheel
+      cibuildwheel --output-dir dist
+    fi
 
 after_success:
   # create source distribution
@@ -40,7 +51,7 @@ after_success:
   - |
     if [[ $TRAVIS_TAG ]]; then
       $PYTHON -m pip install twine
-      $PYTHON -m twine upload wheelhouse/*.whl
+      $PYTHON -m twine upload dist/*.whl
       if [[ $TRAVIS_OS_NAME == "osx" ]]; then
         $PYTHON setup.py sdist
         $PYTHON -m twine upload dist/*.tar.gz
@@ -55,7 +66,7 @@ deploy:
     skip_cleanup: true
     file_glob: true
     file:
-      - wheelhouse/*.whl
+      - dist/*.whl
       - dist/*.tar.gz
     prerelease: true
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - CIBW_TEST_COMMAND="cd {project} && pytest && pip uninstall --yes afdko"
 
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode9.4
       language: generic
       env:
         - NAME=OSX
@@ -32,7 +32,6 @@ matrix:
 script:
   - |
     if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-      brew install python3
       $PIP install --disable-pip-version-check -U -q pip setuptools wheel pytest
       $PYTHON --version
       $PIP --version


### PR DESCRIPTION
* Drops the dependency on **cibuildwheel**
* The tests now only run on untagged commits