### PR TITLE
fix Xcode paths to header files in tx_shared

### DIFF
--- a/c/mergefonts/build/osx/xcode/mergeFonts.xcodeproj/project.pbxproj
+++ b/c/mergefonts/build/osx/xcode/mergeFonts.xcodeproj/project.pbxproj
@@ -597,15 +597,6 @@
 		BD55C9280DAD569C00CA71B7 /* mergeFonts.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = mergeFonts.c; path = ../../../source/mergeFonts.c; sourceTree = SOURCE_ROOT; };
 		BD8A5AD90D6F915300301916 /* absfont.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = absfont.xcodeproj; path = ../../../../public/lib/build/absfont/osx/xcode/absfont.xcodeproj; sourceTree = SOURCE_ROOT; };
 		BDA33EA811AC30D2000A747B /* common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = common.xcconfig; path = ../../../../public/config/xcconfig/common.xcconfig; sourceTree = SOURCE_ROOT; };
-		BDA34AF20D6F3F690009FF85 /* afm.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = afm.h; path = ../../../source/afm.h; sourceTree = SOURCE_ROOT; };
-		BDA34AF90D6F3F690009FF85 /* cef.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = cef.h; path = ../../../source/cef.h; sourceTree = SOURCE_ROOT; };
-		BDA34AFB0D6F3F690009FF85 /* cff.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = cff.h; path = ../../../source/cff.h; sourceTree = SOURCE_ROOT; };
-		BDA34B020D6F3F690009FF85 /* ps.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = ps.h; path = ../../../source/ps.h; sourceTree = SOURCE_ROOT; };
-		BDA34B030D6F3F690009FF85 /* dump.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = dump.h; path = ../../../source/dump.h; sourceTree = SOURCE_ROOT; };
-		BDA34B060D6F3F690009FF85 /* mtx.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = mtx.h; path = ../../../source/mtx.h; sourceTree = SOURCE_ROOT; };
-		BDA34B070D6F3F690009FF85 /* pdf.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = pdf.h; path = ../../../source/pdf.h; sourceTree = SOURCE_ROOT; };
-		BDA34B120D6F3F690009FF85 /* t1.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = t1.h; path = ../../../source/t1.h; sourceTree = SOURCE_ROOT; };
-		BDA34B130D6F3F690009FF85 /* path.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = path.h; path = ../../../source/path.h; sourceTree = SOURCE_ROOT; };
 		BDA34B140D6F3F690009FF85 /* help.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = help.h; path = ../../../source/help.h; sourceTree = SOURCE_ROOT; };
 		BDA34B170D6F3F690009FF85 /* usage.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = usage.h; path = ../../../source/usage.h; sourceTree = SOURCE_ROOT; };
 		BDA34B5B0D6F3FDB0009FF85 /* release_tx.xcconfig */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text.xcconfig; name = release_tx.xcconfig; path = ../../../../public/config/xcconfig/release_tx.xcconfig; sourceTree = SOURCE_ROOT; };
@@ -626,6 +617,19 @@
 		BDE02A17190F19940013858F /* ufowrite.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ufowrite.xcodeproj; path = ../../../../public/lib/build/ufowrite/osx/xcode/ufowrite.xcodeproj; sourceTree = "<group>"; };
 		BDEA9B4F1E499AF300EFF385 /* varread.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = varread.xcodeproj; path = ../../../../public/lib/build/varread/osx/xcode/varread.xcodeproj; sourceTree = "<group>"; };
 		BDEA9B551E499AFE00EFF385 /* nameread.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = nameread.xcodeproj; path = ../../../../public/lib/build/nameread/osx/xcode/nameread.xcodeproj; sourceTree = "<group>"; };
+		DE9917CA2319C7F7000DEEFA /* mtx.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = mtx.h; path = ../../../../public/lib/source/tx_shared/mtx.h; sourceTree = "<group>"; };
+		DE9917CB2319C7F7000DEEFA /* path.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = path.h; path = ../../../../public/lib/source/tx_shared/path.h; sourceTree = "<group>"; };
+		DE9917CC2319C7F7000DEEFA /* t1.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = t1.h; path = ../../../../public/lib/source/tx_shared/t1.h; sourceTree = "<group>"; };
+		DE9917CD2319C7F7000DEEFA /* ps.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ps.h; path = ../../../../public/lib/source/tx_shared/ps.h; sourceTree = "<group>"; };
+		DE9917CE2319C7F7000DEEFA /* cff.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = cff.h; path = ../../../../public/lib/source/tx_shared/cff.h; sourceTree = "<group>"; };
+		DE9917CF2319C7F7000DEEFA /* pdf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pdf.h; path = ../../../../public/lib/source/tx_shared/pdf.h; sourceTree = "<group>"; };
+		DE9917D02319C7F7000DEEFA /* dump.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = dump.h; path = ../../../../public/lib/source/tx_shared/dump.h; sourceTree = "<group>"; };
+		DE9917D12319C7F7000DEEFA /* afm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = afm.h; path = ../../../../public/lib/source/tx_shared/afm.h; sourceTree = "<group>"; };
+		DE9917D22319C7F7000DEEFA /* cef.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = cef.h; path = ../../../../public/lib/source/tx_shared/cef.h; sourceTree = "<group>"; };
+		DE9917D32319C806000DEEFA /* options.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = options.h; path = ../../../source/options.h; sourceTree = "<group>"; };
+		DE9917D42319C82F000DEEFA /* dcf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = dcf.h; path = ../../../../public/lib/source/tx_shared/dcf.h; sourceTree = "<group>"; };
+		DE9917D52319C843000DEEFA /* svg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = svg.h; path = ../../../../public/lib/source/tx_shared/svg.h; sourceTree = "<group>"; };
+		DE9917D62319C851000DEEFA /* ufo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ufo.h; path = ../../../../public/lib/source/tx_shared/ufo.h; sourceTree = "<group>"; };
 		DEE09B5A21935AD900B474B9 /* tx_shared.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = tx_shared.xcodeproj; path = ../../../../public/lib/build/tx_shared/osx/xcode/tx_shared.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -752,16 +756,20 @@
 		BDA34AEC0D6F3F530009FF85 /* Headers */ = {
 			isa = PBXGroup;
 			children = (
-				BDA34AF20D6F3F690009FF85 /* afm.h */,
-				BDA34AF90D6F3F690009FF85 /* cef.h */,
-				BDA34AFB0D6F3F690009FF85 /* cff.h */,
-				BDA34B020D6F3F690009FF85 /* ps.h */,
-				BDA34B030D6F3F690009FF85 /* dump.h */,
-				BDA34B060D6F3F690009FF85 /* mtx.h */,
-				BDA34B070D6F3F690009FF85 /* pdf.h */,
-				BDA34B120D6F3F690009FF85 /* t1.h */,
-				BDA34B130D6F3F690009FF85 /* path.h */,
+				DE9917D12319C7F7000DEEFA /* afm.h */,
+				DE9917D22319C7F7000DEEFA /* cef.h */,
+				DE9917CE2319C7F7000DEEFA /* cff.h */,
+				DE9917D42319C82F000DEEFA /* dcf.h */,
+				DE9917D02319C7F7000DEEFA /* dump.h */,
 				BDA34B140D6F3F690009FF85 /* help.h */,
+				DE9917CA2319C7F7000DEEFA /* mtx.h */,
+				DE9917D32319C806000DEEFA /* options.h */,
+				DE9917CB2319C7F7000DEEFA /* path.h */,
+				DE9917CF2319C7F7000DEEFA /* pdf.h */,
+				DE9917CD2319C7F7000DEEFA /* ps.h */,
+				DE9917D52319C843000DEEFA /* svg.h */,
+				DE9917CC2319C7F7000DEEFA /* t1.h */,
+				DE9917D62319C851000DEEFA /* ufo.h */,
 				BDA34B170D6F3F690009FF85 /* usage.h */,
 			);
 			name = Headers;

--- a/c/rotatefont/build/osx/xcode/rotateFont.xcodeproj/project.pbxproj
+++ b/c/rotatefont/build/osx/xcode/rotateFont.xcodeproj/project.pbxproj
@@ -582,15 +582,6 @@
 		BD8A5AD90D6F915300301916 /* absfont.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = absfont.xcodeproj; path = ../../../../public/lib/build/absfont/osx/xcode/absfont.xcodeproj; sourceTree = SOURCE_ROOT; };
 		BDA148B618FF432B00788518 /* uforead.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = uforead.xcodeproj; path = ../../../../public/lib/build/uforead/osx/xcode/uforead.xcodeproj; sourceTree = "<group>"; };
 		BDA148C218FF437900788518 /* ufowrite.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ufowrite.xcodeproj; path = ../../../../public/lib/build/ufowrite/osx/xcode/ufowrite.xcodeproj; sourceTree = "<group>"; };
-		BDA34AF20D6F3F690009FF85 /* afm.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = afm.h; path = ../../../source/afm.h; sourceTree = SOURCE_ROOT; };
-		BDA34AF90D6F3F690009FF85 /* cef.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = cef.h; path = ../../../source/cef.h; sourceTree = SOURCE_ROOT; };
-		BDA34AFB0D6F3F690009FF85 /* cff.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = cff.h; path = ../../../source/cff.h; sourceTree = SOURCE_ROOT; };
-		BDA34B020D6F3F690009FF85 /* ps.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = ps.h; path = ../../../source/ps.h; sourceTree = SOURCE_ROOT; };
-		BDA34B030D6F3F690009FF85 /* dump.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = dump.h; path = ../../../source/dump.h; sourceTree = SOURCE_ROOT; };
-		BDA34B060D6F3F690009FF85 /* mtx.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = mtx.h; path = ../../../source/mtx.h; sourceTree = SOURCE_ROOT; };
-		BDA34B070D6F3F690009FF85 /* pdf.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = pdf.h; path = ../../../source/pdf.h; sourceTree = SOURCE_ROOT; };
-		BDA34B120D6F3F690009FF85 /* t1.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = t1.h; path = ../../../source/t1.h; sourceTree = SOURCE_ROOT; };
-		BDA34B130D6F3F690009FF85 /* path.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = path.h; path = ../../../source/path.h; sourceTree = SOURCE_ROOT; };
 		BDA34B140D6F3F690009FF85 /* help.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = help.h; path = ../../../source/help.h; sourceTree = SOURCE_ROOT; };
 		BDA34B170D6F3F690009FF85 /* usage.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = usage.h; path = ../../../source/usage.h; sourceTree = SOURCE_ROOT; };
 		BDA34B5B0D6F3FDB0009FF85 /* release_tx.xcconfig */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text.xcconfig; name = release_tx.xcconfig; path = ../../../../public/config/xcconfig/release_tx.xcconfig; sourceTree = SOURCE_ROOT; };
@@ -610,6 +601,19 @@
 		BDEA9B7A1E499BAE00EFF385 /* nameread.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = nameread.xcodeproj; path = ../../../../public/lib/build/nameread/osx/xcode/nameread.xcodeproj; sourceTree = "<group>"; };
 		BDEA9B801E499BBA00EFF385 /* varread.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = varread.xcodeproj; path = ../../../../public/lib/build/varread/osx/xcode/varread.xcodeproj; sourceTree = "<group>"; };
 		DE4B9A2121935BD100C8BB92 /* tx_shared.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = tx_shared.xcodeproj; path = ../../../../public/lib/build/tx_shared/osx/xcode/tx_shared.xcodeproj; sourceTree = "<group>"; };
+		DE99178D2319C678000DEEFA /* svg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = svg.h; path = ../../../../public/lib/source/tx_shared/svg.h; sourceTree = "<group>"; };
+		DE99178E2319C679000DEEFA /* dcf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = dcf.h; path = ../../../../public/lib/source/tx_shared/dcf.h; sourceTree = "<group>"; };
+		DE99178F2319C679000DEEFA /* ufo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ufo.h; path = ../../../../public/lib/source/tx_shared/ufo.h; sourceTree = "<group>"; };
+		DE9917902319C679000DEEFA /* pdf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pdf.h; path = ../../../../public/lib/source/tx_shared/pdf.h; sourceTree = "<group>"; };
+		DE9917912319C679000DEEFA /* t1.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = t1.h; path = ../../../../public/lib/source/tx_shared/t1.h; sourceTree = "<group>"; };
+		DE9917922319C679000DEEFA /* dump.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = dump.h; path = ../../../../public/lib/source/tx_shared/dump.h; sourceTree = "<group>"; };
+		DE9917932319C679000DEEFA /* path.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = path.h; path = ../../../../public/lib/source/tx_shared/path.h; sourceTree = "<group>"; };
+		DE9917942319C679000DEEFA /* ps.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ps.h; path = ../../../../public/lib/source/tx_shared/ps.h; sourceTree = "<group>"; };
+		DE9917952319C679000DEEFA /* afm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = afm.h; path = ../../../../public/lib/source/tx_shared/afm.h; sourceTree = "<group>"; };
+		DE9917962319C679000DEEFA /* cff.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = cff.h; path = ../../../../public/lib/source/tx_shared/cff.h; sourceTree = "<group>"; };
+		DE9917972319C679000DEEFA /* mtx.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = mtx.h; path = ../../../../public/lib/source/tx_shared/mtx.h; sourceTree = "<group>"; };
+		DE9917982319C679000DEEFA /* cef.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = cef.h; path = ../../../../public/lib/source/tx_shared/cef.h; sourceTree = "<group>"; };
+		DE9917992319C6EC000DEEFA /* options.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = options.h; path = ../../../source/options.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -751,16 +755,20 @@
 		BDA34AEC0D6F3F530009FF85 /* Headers */ = {
 			isa = PBXGroup;
 			children = (
-				BDA34AF20D6F3F690009FF85 /* afm.h */,
-				BDA34AF90D6F3F690009FF85 /* cef.h */,
-				BDA34AFB0D6F3F690009FF85 /* cff.h */,
-				BDA34B020D6F3F690009FF85 /* ps.h */,
-				BDA34B030D6F3F690009FF85 /* dump.h */,
-				BDA34B060D6F3F690009FF85 /* mtx.h */,
-				BDA34B070D6F3F690009FF85 /* pdf.h */,
-				BDA34B120D6F3F690009FF85 /* t1.h */,
-				BDA34B130D6F3F690009FF85 /* path.h */,
+				DE9917952319C679000DEEFA /* afm.h */,
+				DE9917982319C679000DEEFA /* cef.h */,
+				DE9917962319C679000DEEFA /* cff.h */,
+				DE99178E2319C679000DEEFA /* dcf.h */,
+				DE9917922319C679000DEEFA /* dump.h */,
 				BDA34B140D6F3F690009FF85 /* help.h */,
+				DE9917972319C679000DEEFA /* mtx.h */,
+				DE9917992319C6EC000DEEFA /* options.h */,
+				DE9917932319C679000DEEFA /* path.h */,
+				DE9917902319C679000DEEFA /* pdf.h */,
+				DE9917942319C679000DEEFA /* ps.h */,
+				DE99178D2319C678000DEEFA /* svg.h */,
+				DE9917912319C679000DEEFA /* t1.h */,
+				DE99178F2319C679000DEEFA /* ufo.h */,
 				BDA34B170D6F3F690009FF85 /* usage.h */,
 			);
 			name = Headers;

--- a/c/tx/build/osx/xcode/tx.xcodeproj/project.pbxproj
+++ b/c/tx/build/osx/xcode/tx.xcodeproj/project.pbxproj
@@ -568,20 +568,9 @@
 		BD1FAAA71731D2E100472BF0 /* uforead.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = uforead.xcodeproj; path = ../../../../public/lib/build/uforead/osx/xcode/uforead.xcodeproj; sourceTree = "<group>"; };
 		BD49904A0D7DE640005EF88C /* debug_tx.xcconfig */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text.xcconfig; name = debug_tx.xcconfig; path = ../../../../public/config/xcconfig/debug_tx.xcconfig; sourceTree = SOURCE_ROOT; };
 		BD49904B0D7DE640005EF88C /* release_tx.xcconfig */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text.xcconfig; name = release_tx.xcconfig; path = ../../../../public/config/xcconfig/release_tx.xcconfig; sourceTree = SOURCE_ROOT; };
-		BD49904E0D7DE65D005EF88C /* mtx.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = mtx.h; path = ../../../source/mtx.h; sourceTree = SOURCE_ROOT; };
-		BD49904F0D7DE65D005EF88C /* ps.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = ps.h; path = ../../../source/ps.h; sourceTree = SOURCE_ROOT; };
-		BD4990500D7DE65D005EF88C /* pdf.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = pdf.h; path = ../../../source/pdf.h; sourceTree = SOURCE_ROOT; };
-		BD4990510D7DE65D005EF88C /* t1.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = t1.h; path = ../../../source/t1.h; sourceTree = SOURCE_ROOT; };
-		BD4990520D7DE65D005EF88C /* svg.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = svg.h; path = ../../../source/svg.h; sourceTree = SOURCE_ROOT; };
-		BD4990530D7DE65D005EF88C /* afm.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = afm.h; path = ../../../source/afm.h; sourceTree = SOURCE_ROOT; };
-		BD4990540D7DE65D005EF88C /* cef.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = cef.h; path = ../../../source/cef.h; sourceTree = SOURCE_ROOT; };
-		BD4990550D7DE65D005EF88C /* cff.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = cff.h; path = ../../../source/cff.h; sourceTree = SOURCE_ROOT; };
-		BD4990570D7DE65D005EF88C /* dcf.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = dcf.h; path = ../../../source/dcf.h; sourceTree = SOURCE_ROOT; };
 		BD4990580D7DE65D005EF88C /* help.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = help.h; path = ../../../source/help.h; sourceTree = SOURCE_ROOT; };
 		BD4990590D7DE65D005EF88C /* usage.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = usage.h; path = ../../../source/usage.h; sourceTree = SOURCE_ROOT; };
-		BD49905A0D7DE65D005EF88C /* path.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = path.h; path = ../../../source/path.h; sourceTree = SOURCE_ROOT; };
 		BD49905B0D7DE65D005EF88C /* options.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = options.h; path = ../../../source/options.h; sourceTree = SOURCE_ROOT; };
-		BD49905C0D7DE65D005EF88C /* dump.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = dump.h; path = ../../../source/dump.h; sourceTree = SOURCE_ROOT; };
 		BD49906C0D7DE66E005EF88C /* tx.c */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.c; name = tx.c; path = ../../../source/tx.c; sourceTree = SOURCE_ROOT; };
 		BD49908A0D7DE69A005EF88C /* tx */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = tx; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD4990940D7DE82C005EF88C /* absfont.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = absfont.h; path = ../../../../public/lib/api/absfont.h; sourceTree = SOURCE_ROOT; };
@@ -625,7 +614,19 @@
 		BD5E11E017A7384E007BA047 /* ttread.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ttread.xcodeproj; path = ../../../../public/lib/build/ttread/osx/xcode/ttread.xcodeproj; sourceTree = "<group>"; };
 		BD613CC210F7986500F98996 /* svread.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = svread.xcodeproj; path = ../../../../public/lib/build/svread/osx/xcode/svread.xcodeproj; sourceTree = SOURCE_ROOT; };
 		BDAF345217D6A9AF004B2EA0 /* ufowrite.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ufowrite.xcodeproj; path = ../../../../public/lib/build/ufowrite/osx/xcode/ufowrite.xcodeproj; sourceTree = "<group>"; };
-		BDC28A801808539300053E7D /* ufo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ufo.h; path = ../../../source/ufo.h; sourceTree = "<group>"; };
+		DE9917672319C51D000DEEFA /* afm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = afm.h; path = ../../../../public/lib/source/tx_shared/afm.h; sourceTree = "<group>"; };
+		DE9917682319C528000DEEFA /* svg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = svg.h; path = ../../../../public/lib/source/tx_shared/svg.h; sourceTree = "<group>"; };
+		DE9917692319C528000DEEFA /* t1.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = t1.h; path = ../../../../public/lib/source/tx_shared/t1.h; sourceTree = "<group>"; };
+		DE99176A2319C528000DEEFA /* cff2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = cff2.h; path = ../../../../public/lib/source/tx_shared/cff2.h; sourceTree = "<group>"; };
+		DE99176B2319C528000DEEFA /* cef.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = cef.h; path = ../../../../public/lib/source/tx_shared/cef.h; sourceTree = "<group>"; };
+		DE99176C2319C528000DEEFA /* ps.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ps.h; path = ../../../../public/lib/source/tx_shared/ps.h; sourceTree = "<group>"; };
+		DE99176D2319C528000DEEFA /* mtx.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = mtx.h; path = ../../../../public/lib/source/tx_shared/mtx.h; sourceTree = "<group>"; };
+		DE99176E2319C528000DEEFA /* dump.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = dump.h; path = ../../../../public/lib/source/tx_shared/dump.h; sourceTree = "<group>"; };
+		DE99176F2319C528000DEEFA /* pdf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pdf.h; path = ../../../../public/lib/source/tx_shared/pdf.h; sourceTree = "<group>"; };
+		DE9917702319C528000DEEFA /* path.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = path.h; path = ../../../../public/lib/source/tx_shared/path.h; sourceTree = "<group>"; };
+		DE9917712319C528000DEEFA /* dcf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = dcf.h; path = ../../../../public/lib/source/tx_shared/dcf.h; sourceTree = "<group>"; };
+		DE9917722319C528000DEEFA /* cff.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = cff.h; path = ../../../../public/lib/source/tx_shared/cff.h; sourceTree = "<group>"; };
+		DE9917732319C532000DEEFA /* ufo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ufo.h; path = ../../../../public/lib/source/tx_shared/ufo.h; sourceTree = "<group>"; };
 		DEBF3EFF219259C10022A4C6 /* tx_shared.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = tx_shared.xcodeproj; path = ../../../../public/lib/build/tx_shared/osx/xcode/tx_shared.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -721,21 +722,22 @@
 		BD4990480D7DE60A005EF88C /* Headers */ = {
 			isa = PBXGroup;
 			children = (
-				BDC28A801808539300053E7D /* ufo.h */,
-				BD49904E0D7DE65D005EF88C /* mtx.h */,
-				BD49904F0D7DE65D005EF88C /* ps.h */,
-				BD4990500D7DE65D005EF88C /* pdf.h */,
-				BD4990510D7DE65D005EF88C /* t1.h */,
-				BD4990520D7DE65D005EF88C /* svg.h */,
-				BD4990530D7DE65D005EF88C /* afm.h */,
-				BD4990540D7DE65D005EF88C /* cef.h */,
-				BD4990550D7DE65D005EF88C /* cff.h */,
-				BD4990570D7DE65D005EF88C /* dcf.h */,
+				DE9917672319C51D000DEEFA /* afm.h */,
+				DE99176B2319C528000DEEFA /* cef.h */,
+				DE9917722319C528000DEEFA /* cff.h */,
+				DE99176A2319C528000DEEFA /* cff2.h */,
+				DE9917712319C528000DEEFA /* dcf.h */,
+				DE99176E2319C528000DEEFA /* dump.h */,
 				BD4990580D7DE65D005EF88C /* help.h */,
-				BD4990590D7DE65D005EF88C /* usage.h */,
-				BD49905A0D7DE65D005EF88C /* path.h */,
+				DE99176D2319C528000DEEFA /* mtx.h */,
 				BD49905B0D7DE65D005EF88C /* options.h */,
-				BD49905C0D7DE65D005EF88C /* dump.h */,
+				DE9917702319C528000DEEFA /* path.h */,
+				DE99176F2319C528000DEEFA /* pdf.h */,
+				DE99176C2319C528000DEEFA /* ps.h */,
+				DE9917682319C528000DEEFA /* svg.h */,
+				DE9917692319C528000DEEFA /* t1.h */,
+				DE9917732319C532000DEEFA /* ufo.h */,
+				BD4990590D7DE65D005EF88C /* usage.h */,
 			);
 			name = Headers;
 			sourceTree = "<group>";


### PR DESCRIPTION
The header files were in the header search path, so the build worked, but the file icons in the Xcode IDE sidebar had dead links and were greyed out. This commit fixes that.