### PR TITLE
[tx] allocate byte for null terminator when copying PostScript strings

### DIFF
--- a/c/public/lib/source/cffwrite/cffwrite_dict.c
+++ b/c/public/lib/source/cffwrite/cffwrite_dict.c
@@ -75,7 +75,7 @@ static void saveFSType(cfwCtx g, abfTopDict *dst) {
         }
         /* Copy string to tmp buf */
         /* 64-bit warning fixed by cast here */
-        postscriptLen = strlen(dst->PostScript.ptr);
+        postscriptLen = strlen(dst->PostScript.ptr) + 1;
         STRCPY_S(dnaEXTEND(h->tmp, (long)postscriptLen),
                  postscriptLen,
                  dst->PostScript.ptr);
@@ -159,7 +159,7 @@ static void saveOrigFontType(cfwCtx g, abfTopDict *dst) {
         }
         /* Copy string to tmp buf */
         /* 64-bit warning fixed by cast here */
-        postscriptLen = strlen(dst->PostScript.ptr);
+        postscriptLen = strlen(dst->PostScript.ptr) + 1;
         STRCPY_S(dnaEXTEND(h->tmp, (long)postscriptLen),
                  postscriptLen,
                  dst->PostScript.ptr);


### PR DESCRIPTION
(Note that `STRCPY_S` is currently mapped to `strcpy` on mac, so the size parameter is not used there.)