### PR TITLE
[makeotf] use absolute path to features file in updateFontRevision

### DIFF
--- a/python/afdko/makeotf.py
+++ b/python/afdko/makeotf.py
@@ -2071,6 +2071,7 @@ def updateFontRevision(featuresPath, fontRevision):
 
     try:
         # get FontRevision from feature file
+        featuresPath = os.path.abspath(featuresPath)
         with open(featuresPath, "r", encoding='utf-8') as fp:
             data = fp.read()
     except (IOError, OSError):


### PR DESCRIPTION
This fixes two test failures in macOS 10.15 (Catalina) due to its prohibition of relative paths to the `/var` folder.

See also #828 and #838.