### PR TITLE
[requirements] relax pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,14 @@
 # 'lxml' is not a primary requirement of afdko but it's listed here because
 # we want to have control over the version and guarantee that the XML output
 # of our tools is stable
-lxml>=4.4.1
-booleanOperations>=0.8.2
-cu2qu[cli]>=1.6.6
-defcon[lxml,pens]>=0.6.0
-fontMath>=0.5.0
-fontTools[ufo,unicode,lxml,woff]>=4.0.1
-mutatorMath>=2.1.2
-psautohint>=2.0.0a1
-ufonormalizer>=0.3.6
-ufoProcessor>=1.0.6
+# NOTE: hard-pinning (==) here gets relaxed to >= in setup.py
+lxml==4.4.1
+booleanOperations==0.8.2
+cu2qu[cli]==1.6.6
+defcon[lxml,pens]==0.6.0
+fontMath==0.5.0
+fontTools[ufo,unicode,lxml,woff]==4.0.1
+mutatorMath==2.1.2
+psautohint==2.0.0a1
+ufonormalizer==0.3.6
+ufoProcessor==1.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 # 'lxml' is not a primary requirement of afdko but it's listed here because
 # we want to have control over the version and guarantee that the XML output
 # of our tools is stable
-lxml==4.4.1
-booleanOperations==0.8.2
-cu2qu[cli]==1.6.6
-defcon[lxml,pens]==0.6.0
-fontMath==0.5.0
-fontTools[ufo,unicode,lxml,woff]==4.0.1
-mutatorMath==2.1.2
-psautohint==2.0.0a1
-ufonormalizer==0.3.6
-ufoProcessor==1.0.6
+lxml>=4.4.1
+booleanOperations>=0.8.2
+cu2qu[cli]>=1.6.6
+defcon[lxml,pens]>=0.6.0
+fontMath>=0.5.0
+fontTools[ufo,unicode,lxml,woff]>=4.0.1
+mutatorMath>=2.1.2
+psautohint>=2.0.0a1
+ufonormalizer>=0.3.6
+ufoProcessor>=1.0.6

--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,7 @@ def _get_console_scripts():
 
 def _get_requirements():
     with io.open("requirements.txt", encoding="utf-8") as requirements:
-        return requirements.read().splitlines()
+        return [l.replace("==", ">=") for l in requirements.readlines()]
 
 
 def main():


### PR DESCRIPTION
Strict pinning with `==` in AFDKO's `requirements.txt` can result in downgrades to packages that are shared by other co-installed projects. Use of `>=` enforces only the minimum version specified and allows later versions.

Closes #408 .