### PR TITLE
[fea-spec] fix example n.4 in chapter 6.h.iii

### DIFF
--- a/docs/OpenTypeFeatureFileSpecification.md
+++ b/docs/OpenTypeFeatureFileSpecification.md
@@ -2460,7 +2460,7 @@ context, you need to put the mark and kern rules in different lookups.
 mark sukun <anchor 0 0> @TOP_CLASS;
 
 lookup MARK_POS {
-    position lam_meem_jeem' <anchor 625 1800> mark @TOP_CLASS alef;
+    position base lam_meem_jeem' <anchor 625 1800> mark @TOP_CLASS alef;
 } MARK_POS;
 
 lookup MARK_KERN {


### PR DESCRIPTION
the wording preceding this example refers to positioning a mark over a base glyph, so the keyword shoud be `position base` not just `position`.