### PR TITLE
[mergefonts] allow use of camelCase "mergeFonts" in glyph alias files

### DIFF
--- a/c/mergefonts/source/mergeFonts.c
+++ b/c/mergefonts/source/mergeFonts.c
@@ -1569,6 +1569,7 @@ static bool readGlyphAliasFile(txCtx h, int fileIndex, char *filePath) {
     unsigned short lineno = 0;
     GAFileInfo *gaf = NULL;
     MergeInfo *mergeInfo = (MergeInfo *)h->appSpecificInfo;
+    char *p;
 
     /* Always make a  glyphAliasSet entry - even if we are skipping a GA file
        and the current file turns out to be a font. we still need an empty
@@ -1601,6 +1602,10 @@ static bool readGlyphAliasFile(txCtx h, int fileIndex, char *filePath) {
         fclose(ga_fp);
         return isGA;
     }
+
+    /* convert to lower case to allow for old uses of "mergeFonts" */
+    for (p = progName; *p != 0; p++)
+        *p = tolower(*p);
 
     if (strcmp(progName, "mergefonts")) {
         fclose(ga_fp);

--- a/tests/mergefonts_data/input/camelCase/alias1.txt
+++ b/tests/mergefonts_data/input/camelCase/alias1.txt
@@ -1,0 +1,2 @@
+mergeFonts SourceSans-Test_No Alignment Zones 0
+0	.notdef

--- a/tests/mergefonts_data/input/camelCase/alias2.txt
+++ b/tests/mergefonts_data/input/camelCase/alias2.txt
@@ -1,0 +1,2 @@
+mergeFonts SourceSans-Test_OTHER 0
+2	negative

--- a/tests/mergefonts_data/input/camelCase/alias3.txt
+++ b/tests/mergefonts_data/input/camelCase/alias3.txt
@@ -1,0 +1,2 @@
+mergeFonts SourceSans-Test_LOWERCASE 0
+1	a

--- a/tests/mergefonts_test.py
+++ b/tests/mergefonts_test.py
@@ -59,3 +59,27 @@ def test_warnings_bug635():
     with open(warnings_path, 'wb') as f:
         f.write(warnings)
     assert differ([expected_path, warnings_path, '-l', '1,5-7,11-12'])
+
+
+def test_camel_case():
+    # confirm old 'mergeFonts' name in glyph alias files still works
+    # (as opposed to the new 'mergefonts' name)
+    font1_filename = 'font1.pfa'
+    font2_filename = 'font2.pfa'
+    font3_filename = 'font3.pfa'
+    alias1_filename = 'camelCase/alias1.txt'
+    alias2_filename = 'camelCase/alias2.txt'
+    alias3_filename = 'camelCase/alias3.txt'
+    fontinfo_filename = 'cidfontinfo.txt'
+    actual_path = get_temp_file_path()
+
+    expected_path = get_expected_path('cidfont.ps')
+    runner(CMD + ['-o', 'cid', '-f', fontinfo_filename, actual_path,
+                  alias1_filename, font1_filename,
+                  alias2_filename, font2_filename,
+                  alias3_filename, font3_filename])
+
+    actual_path = generate_ps_dump(actual_path)
+    expected_path = generate_ps_dump(expected_path)
+
+    assert differ([expected_path, actual_path, '-s', r'%ADOt1write:'])


### PR DESCRIPTION
(for use with old glyph alias files that predate the name change)

fixes #1002 
