### PR TITLE
[autohint][stemhist] add FutureWarnings

### DIFF
--- a/python/afdko/autohint.py
+++ b/python/afdko/autohint.py
@@ -443,7 +443,6 @@ import time
 import tempfile
 from fontTools.ttLib import TTFont, getTableModule
 import plistlib
-import warnings
 from afdko import fdkutils, ufotools
 from afdko.beztools import *
 import traceback
@@ -457,10 +456,8 @@ except ImportError:
 
 warnings.warn(
 	"autohint has been deprecated and will be removed from AFDKO soon. "
-	"Please update your code.",
+	"Please update your code to use psautohint.",
 	category=FutureWarning)
-
-# warnings.simplefilter("ignore", RuntimeWarning) # supress waring about use of os.tempnam().
 
 kACIDKey = "AutoHintKey"
 NEWBEZ_SUFFIX = '.new'

--- a/python/afdko/autohint.py
+++ b/python/afdko/autohint.py
@@ -448,11 +448,17 @@ from afdko import fdkutils, ufotools
 from afdko.beztools import *
 import traceback
 import shutil
+import warnings
 
 try:
     from psautohint import AUTOHINTEXE
 except ImportError:
     AUTOHINTEXE = "autohintexe"
+
+warnings.warn(
+	"autohint has been deprecated and will be removed from AFDKO soon. "
+	"Please update your code.",
+	category=FutureWarning)
 
 # warnings.simplefilter("ignore", RuntimeWarning) # supress waring about use of os.tempnam().
 

--- a/python/afdko/stemhist.py
+++ b/python/afdko/stemhist.py
@@ -120,7 +120,7 @@ from afdko import fdkutils, ufotools
 
 warnings.warn(
 	"stemhist has been deprecated and will be removed from AFDKO soon. "
-	"Please update your code.",
+	"Please update your code to use psstemhist.",
 	category=FutureWarning)
 
 

--- a/python/afdko/stemhist.py
+++ b/python/afdko/stemhist.py
@@ -109,6 +109,7 @@ import os
 import sys
 import time
 import traceback
+import warnings
 
 from fontTools.ttLib import TTFont, getTableModule
 from afdko.autohint import (
@@ -116,6 +117,11 @@ from afdko.autohint import (
 	ACOptionParseError, ACFontError, logMsg, ACreport, expandNames,
 	AUTOHINTEXE)
 from afdko import fdkutils, ufotools
+
+warnings.warn(
+	"stemhist has been deprecated and will be removed from AFDKO soon. "
+	"Please update your code.",
+	category=FutureWarning)
 
 
 rawData = []


### PR DESCRIPTION
 - add FutureWarnings to autohint.py and stemhist.py. Settled on using FutureWarning instead of DeprecationWarning so that it is displayed for all use cases (DeprecationWarning is hidden for some cases).