### PR TITLE
Fix bug in fontpdf.py (map/list discrepancy)

### DIFF
--- a/python/afdko/pdflib/fontpdf.py
+++ b/python/afdko/pdflib/fontpdf.py
@@ -1,5 +1,5 @@
 """
-fontpdf v1.28 Jul 12 2019. This module is not run stand-alone; it requires
+fontpdf v1.29 Nov 25 2019. This module is not run stand-alone; it requires
 another module, such as proofpdf, in order to collect the options, and call
 the MakePDF function.
 
@@ -32,7 +32,7 @@ from afdko import fdkutils
 from afdko.pdflib import pdfgen, pdfmetrics
 from afdko.pdflib.pdfutils import LINEEND
 
-__version__ = "1.28"
+__version__ = "1.29"
 
 __copyright__ = """Copyright 2014 Adobe Systems Incorporated (http://www.adobe.com/). All Rights Reserved.
 """
@@ -2014,9 +2014,8 @@ def makeFontSetPDF(pdfFontList, params, doProgressBar=True):
 	An entry in the pdfFontList is [glyphList, pdfFont, tempCFFPath]
 	"""
 	# Sort fonts with same charsets together. Sort by: len charset, charset, ps name.
-	sortList = map(lambda entry: [ len(entry[0]), entry[0], entry[1].getPSName(), entry[1]], pdfFontList)
-	sortList.sort()
-	pdfFontList = map(lambda entry: [entry[1], entry[3]], sortList)
+	sortList = sorted(map(lambda entry: [ len(entry[0]), entry[0], entry[1].getPSName(), entry[1]], pdfFontList))
+	pdfFontList = list(map(lambda entry: [entry[1], entry[3]], sortList))
 
 	if params.rt_pdfFileName:
 		pdfPath = params.rt_pdfFileName

--- a/python/afdko/pdflib/otfpdf.py
+++ b/python/afdko/pdflib/otfpdf.py
@@ -1,6 +1,6 @@
 # Copyright 2014 Adobe. All rights reserved.
 """
-otfpdf v1.6.3 Jul 15 2019
+otfpdf v1.6.4 Nov 25 2019
 provides support for the proofpdf script, for working with OpenType/CFF
 fonts. Provides an implementation of the fontpdf font object. Cannot be
 run alone.
@@ -10,7 +10,7 @@ from fontTools.misc.psCharStrings import T2OutlineExtractor
 
 from afdko.pdflib.fontpdf import FontPDFGlyph, FontPDFFont, FontPDFPen
 
-__version__ = "1.6.3"
+__version__ = "1.6.4"
 
 
 class txPDFFont(FontPDFFont):
@@ -35,6 +35,9 @@ class txPDFFont(FontPDFFont):
         self.getBBox()
         self.GetBlueZones()
         self.AscentDescent()
+
+    def __lt__(self, other):
+        return self.clientGetPSName() < other.clientGetPSName()
 
     def clientGetPSName(self):
         psName = self.clientFont['CFF '].cff.fontNames[0]

--- a/tests/proofpdf_test.py
+++ b/tests/proofpdf_test.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from runner import main as runner
@@ -97,6 +99,30 @@ def test_fontplot2_lf_option(font_filename, glyphs):
     assert differ([expected_path, save_path,
                    '-s', '/CreationDate', '-e', 'macroman'])
 
+
+def test_fontsetplot():
+    f1 = 'SourceSansPro-Black.otf'
+    f2 = 'SourceSansPro-BlackIt.otf'
+    # pdf_filename = "fontsetplot_otf_glyphs_2-7.pdf"
+    fp1 = get_input_path(f1)
+    fp2 = get_input_path(f2)
+    save_path = get_temp_file_path()
+    runner(['-t', 'fontsetplot', '-o', 'o', f'_{save_path}', 'dno',
+            'g', '_2-7', f'_{fp1}', f'_{fp2}'])
+    # expected_path = get_expected_path(pdf_filename)
+
+    # It would be nice to compare the output PDF here, but it seems there
+    # are some minor variations in the binary section from run to run.
+    # Visual comparison of the output suggests that they are the same
+    # (apart from the CreationDate).
+    #
+    # For now, we're just checking that we: 1) don't get any errors
+    # while running, and 2) that an output file gets generated.
+    #
+    # assert(differ([expected_path, save_path,
+    #                '-s', '/CreationDate', '-e', 'macroman']))
+
+    assert os.path.exists(save_path)
 
 @pytest.mark.parametrize('filename', ['SourceSansPro-Black',
                                       'SourceSansPro-BlackIt'])


### PR DESCRIPTION
 - explicitly convert `map` results to `list` in `fontpdf.makeFontSetPDF`
 - add `__lt__` method to `otfpdf.txPDFFont` to make it sortable in ^^
 - add simple test case for `fontsetplot`

closes #1034 
