### PR TITLE
[makeotfexe] Bad font built when feature file has feature parameters, issue 1080

### DIFF
--- a/c/makeotf/makeotf_lib/source/hotconv/otl.c
+++ b/c/makeotf/makeotf_lib/source/hotconv/otl.c
@@ -2033,22 +2033,18 @@ void otlSubtableAdd(hotCtx g, otlTbl t, Tag script, Tag language, Tag feature,
         sub->seenInFeature = 1;
     }
 
-    if (isFeatParam) {
-        t->nFeatParams++;
+    if (script == TAG_UNDEF) {
+         t->nAnonSubtables++;
+     }
+     if (feature == (Tag)TAG_STAND_ALONE) {
+         t->nStandAloneSubtables++;
+     }
 
-        if (IS_REF_LAB(label)) {
-          t->nRefLookups++;
-        }
-    } else {
-        if (script == TAG_UNDEF) {
-          t->nAnonSubtables++;
-        }
-        if (feature == (Tag)TAG_STAND_ALONE) {
-          t->nStandAloneSubtables++;
-        }
-
-        if (IS_REF_LAB(label)) {
-          t->nRefLookups++;
-        }
-    }
+     /* FeatParam subtables may be labeled, but should NOT be added */
+     /* to the list of real look ups.                               */
+     if (IS_REF_LAB(label)) {
+         t->nRefLookups++;
+     } else if (isFeatParam) {
+         t->nFeatParams++;
+     }
 }

--- a/tests/makeotfexe_data/expected_output/bug1017.GSUB.txt
+++ b/tests/makeotfexe_data/expected_output/bug1017.GSUB.txt
@@ -1,13 +1,13 @@
 ### [GSUB] (00000544)
 Version    =1.0 (00010000)
 ScriptList =000a
-FeatureList=001e
-LookupList =0030
+FeatureList=0042
+LookupList =006c
 --- ScriptList (000a)
-ScriptCount=1
+ScriptCount=3
 --- ScriptRecord[index]={ScriptTag,Script}
-[0]={DFLT,0008} 
---- Script [0] (0008)
+[0]={DFLT,0014} [1]={grek,0020} [2]={latn,002c} 
+--- Script [0] (0014)
 DefaultLangSys=0004
 LangSysCount  =0
 
@@ -17,19 +17,53 @@ ReqFeatureIndex=65535
 FeatureCount   =1
 --- FeatureIndex[index]=value
 [0]=0 
+--- Script [1] (0020)
+DefaultLangSys=0004
+LangSysCount  =0
 
---- FeatureList (001e)
-FeatureCount=1
+--- LangSys [-1] (0004)
+LookupOrder    =0000
+ReqFeatureIndex=65535
+FeatureCount   =1
+--- FeatureIndex[index]=value
+[0]=1 
+--- Script [2] (002c)
+DefaultLangSys=0004
+LangSysCount  =0
+
+--- LangSys [-1] (0004)
+LookupOrder    =0000
+ReqFeatureIndex=65535
+FeatureCount   =1
+--- FeatureIndex[index]=value
+[0]=2 
+
+--- FeatureList (0042)
+FeatureCount=3
 --- FeatureRecord[index]={FeatureTag,Feature}
-[0]={'ss05',0008} 
---- FeatureTable (0008)
-FeatureParam=0006
+[0]={'ss05',0014} [1]={'ss05',001a} [2]={'ss05',0020} 
+--- FeatureTable (0014)
+FeatureParam=0012
    Stylistic Alternate name parameter version: 0
    Stylistic Alternate name parameter name table name ID: 256
 LookupCount =1
 --- LookupListIndex[index]=value
 [0]=0 
---- LookupList (0030)
+--- FeatureTable (001a)
+FeatureParam=000c
+
+# Skipping stylistic alternate parameter block in feature 'ss05' offset 001a. It was previously reported for feature 'ss05' offset 0014.
+LookupCount =1
+--- LookupListIndex[index]=value
+[0]=0 
+--- FeatureTable (0020)
+FeatureParam=0006
+
+# Skipping stylistic alternate parameter block in feature 'ss05' offset 0020. It was previously reported for feature 'ss05' offset 0014.
+LookupCount =1
+--- LookupListIndex[index]=value
+[0]=0 
+--- LookupList (006c)
 LookupCount=2
 --- Lookup[index]=offset
 [0]=0006 [1]=000e 

--- a/tests/makeotfexe_data/input/bug1017/feat.fea
+++ b/tests/makeotfexe_data/input/bug1017/feat.fea
@@ -1,4 +1,6 @@
 languagesystem DFLT dflt;
+languagesystem latn dflt;
+languagesystem grek dflt;
 
 
 feature ss05 {


### PR DESCRIPTION
Fixed bug where a bad font built when feature file has multiple languagesystems and feature parameters #1080

Updated test file to fail the build tests with in versions of makeotf with this bug, and to pass in versions without this bug, by changing from one to three language system statements, and updating the expected ttx file.

