### PR TITLE
[makeotf] avoid potential issue in recode.c

### DIFF
--- a/c/makeotf/makeotf_lib/api/hotconv.h
+++ b/c/makeotf/makeotf_lib/api/hotconv.h
@@ -12,7 +12,7 @@ This software is licensed as OpenSource, under the Apache License, Version 2.0. 
 extern "C" {
 #endif
 
-#define HOT_VERSION 0x010070 /* Library version (1.0.112) */
+#define HOT_VERSION 0x010071 /* Library version (1.0.113) */
 /* Major, minor, build = (HOT_VERSION >> 16) & 0xff, (HOT_VERSION >> 8) & 0xff, HOT_VERSION & 0xff) */
 /* Warning: this string is now part of heuristic used by CoolType to identify the
 first round of CoolType fonts which had the backtrack sequence of a chaining

--- a/c/makeotf/makeotf_lib/source/typecomp/recode.c
+++ b/c/makeotf/makeotf_lib/source/typecomp/recode.c
@@ -984,7 +984,7 @@ static long sizeFDWidths(recodeCtx h, int fd) {
         }
 
         /* Find best combination of nominal and default widths */
-        minsize = SHRT_MAX;
+        minsize = INT_MAX;
         for (i = 0; i < wfd->total.cnt; i++) {
             int j;
             int nomsize;


### PR DESCRIPTION
- in `sizeFDWidths`, initialize `minsize` (int) to `INT_MAX` instead of `SHRT_MAX` to avoid potential undesired behavior in the case of `totsize` being larger than `SHRT_MAX` (which can apparently happen, see #1108)
- increment `HOT_VERSION` to 1.0.113

Closes #1108 
