### PR TITLE
prevent modulo zero when processing roll operator

### DIFF
--- a/c/makeotf/makeotf_lib/source/cffread/cffread.c
+++ b/c/makeotf/makeotf_lib/source/cffread/cffread.c
@@ -1533,7 +1533,7 @@ static void t2Read(cffCtx h, Offset offset, int init) {
                         int iTop = h->stack.cnt - 1;
                         int iBottom = h->stack.cnt - n;
 
-                        if (n < 0 || iBottom < 0) {
+                        if (n <= 0 || iBottom < 0) {
                             fatal(h, "limit check (roll)");
                         }
 

--- a/c/public/lib/source/t1cstr/t1cstr.c
+++ b/c/public/lib/source/t1cstr/t1cstr.c
@@ -1095,7 +1095,7 @@ static int t1Decode(t1cCtx h, long offset) {
                             int iTop = h->stack.cnt - 1;
                             int iBottom = h->stack.cnt - n;
 
-                            if (n < 0 || iBottom < 0)
+                            if (n <= 0 || iBottom < 0)
                                 return t1cErrRollBounds;
 
                             /* Constrain j to [0,n) */

--- a/c/spot/source/t13supp.c
+++ b/c/spot/source/t13supp.c
@@ -518,7 +518,7 @@ static void t13Read(cffCtx h, Offset offset, int init, int csLen) {
                         int iTop = h->stack.cnt - 1;
                         int iBottom = h->stack.cnt - n;
 
-                        if (n < 0 || iBottom < 0)
+                        if (n <= 0 || iBottom < 0)
                             fatal(h, "limit check (roll)");
 
                         /* Constrain j to [0,n) */


### PR DESCRIPTION
fixes a fatal arithmetic exception reported by @hardik05