### PR TITLE
Initialize variables before use

### DIFF
--- a/c/public/lib/source/absfont/absfont.c
+++ b/c/public/lib/source/absfont/absfont.c
@@ -100,6 +100,8 @@ static void initPrivateDict(abfPrivateDict *priv) {
     priv->LanguageGroup = cff_DFLT_LanguageGroup;
     priv->ExpansionFactor = (float)cff_DFLT_ExpansionFactor;
     priv->initialRandomSeed = cff_DFLT_initialRandomSeed;
+    priv->vsindex = ABF_UNSET_INT;
+    priv->numRegions = ABF_UNSET_INT;
     memset(&priv->blendValues, 0, sizeof(priv->blendValues));
 }
 

--- a/c/public/lib/source/ttread/ttread.c
+++ b/c/public/lib/source/ttread/ttread.c
@@ -534,6 +534,14 @@ ttrCtx ttrNew(ctlMemoryCallbacks *mem_cb, ctlStreamCallbacks *stm_cb,
     h->strings.buf.size = 0;
     h->glyf.ranges.size = 0;
     h->glyf.coords.size = 0;
+    h->gvar.tableLength = 0;
+    h->gvar.tableOffset = 0;
+    h->gvar.version = 0;
+    h->gvar.sharedTupleCount = 0;
+    h->gvar.sharedTuplesOffset = 0;
+    h->gvar.glyphCount = 0;
+    h->gvar.flags = 0;
+    h->gvar.dataArrayOffset = 0;
     h->gvar.dataOffsets.size = 0;
     h->gvar.sharedTuples.size = 0;
     h->tmp0.size = 0;
@@ -541,6 +549,12 @@ ttrCtx ttrNew(ctlMemoryCallbacks *mem_cb, ctlStreamCallbacks *stm_cb,
     h->stm.dbg = NULL;
     h->ctx.dna = NULL;
     h->ctx.sfr = NULL;
+    h->vf.axisCount = 0;
+    h->vf.flags = 0;
+    h->vf.axes = 0;
+    h->vf.hmtx = 0;
+    h->vf.mvar = 0;
+    h->vf.varStore = 0;
 
     /* Copy callbacks */
     h->cb.mem = *mem_cb;


### PR DESCRIPTION
When building an afdko package on the openSUSE build service
many tests failed. After some investigation I compared the workflow
in parallel debugging sessions inside the build service and a
regular system (where they didn't fail). I noticed the reason
of the failing is that afdko uses some variables that were not
initialized so on systems where memory is automatically set to 0
they work fine, but this is not safe in general (and cannot
be guaranteed), so it's better to initialize the variables.