### PR TITLE
Replace dependency on standalone cu2qu package

### DIFF
--- a/python/afdko/otf2ttf.py
+++ b/python/afdko/otf2ttf.py
@@ -7,9 +7,9 @@ from functools import partial, singledispatch
 from itertools import chain
 from multiprocessing import Pool
 
-from cu2qu.pens import Cu2QuPen
 from fontTools import configLogger
 from fontTools.misc.cliTools import makeOutputFileName
+from fontTools.pens.cu2quPen import Cu2QuPen
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.ttLib import TTCollection, TTFont, TTLibError, newTable
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 # NOTE: hard-pinning (==) here gets relaxed to >= in setup.py
 lxml==4.5.1
 booleanOperations==0.9.0
-cu2qu[cli]==1.6.7
 defcon[pens,lxml]==0.7.2
 fontMath==0.6.0
 fontTools[woff,ufo,lxml,unicode]==4.11.0


### PR DESCRIPTION
The code was integrated into FontTools in version 4.7.0
https://github.com/fonttools/fonttools/releases/tag/4.7.0