### PR TITLE
[sfntedit, sfntdiff] fix long path failures

### DIFF
--- a/c/sfntdiff/source/Dmain.c
+++ b/c/sfntdiff/source/Dmain.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <stdbool.h>
 
-Byte8 *version = "3.0.0"; /* Program version */
+Byte8 *version = "3.0.1"; /* Program version */
 
 static char *sourcepath = "";
 #include "setjmp.h"

--- a/c/sfntdiff/source/Dsys.c
+++ b/c/sfntdiff/source/Dsys.c
@@ -50,6 +50,8 @@
 #include <sys/stat.h>
 #endif
 
+#define FILESTR_BUF_SIZE 1024
+
 static void error(Byte8 *filename) {
 #ifdef __MWERKS__
     switch (errno) {
@@ -141,13 +143,13 @@ IntX sysOpenSearchpath(Byte8 *filename) {
         "c:/psfonts/%s",
         "c:/temp/%s",
         NULL};
+    static char file[FILESTR_BUF_SIZE];
 
     for (p = path; *p != NULL; p++) {
         struct stat st;
-        char file[256];
 
         file[0] = '\0';
-        sprintf(file, *p, filename);
+        snprintf(file, FILESTR_BUF_SIZE, *p, filename);
         fd = OPEN(file, OMODE);
         if ((fd == (-1)) ||
             (fstat(fd, &st) == (-1)) || ((st.st_mode & S_IFMT) == S_IFDIR))

--- a/c/sfntedit/source/Esys.c
+++ b/c/sfntedit/source/Esys.c
@@ -15,6 +15,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#define FILESTR_BUF_SIZE 1024
+
 static void error(char *filename) {
     fatal(SFED_MSG_sysFERRORSTR, strerror(errno), filename);
 }
@@ -79,15 +81,15 @@ FILE *sysOpenSearchpath(char *filename) {
         "c:/psfonts/%s",
         "c:/temp/%s",
         NULL};
+    static char file[FILESTR_BUF_SIZE];
 
     for (p = path; *p != NULL; p++) {
         struct stat st;
-        char file[256];
         short fd;
         FILE *f;
 
         file[0] = '\0';
-        sprintf(file, *p, filename);
+        snprintf(file, FILESTR_BUF_SIZE, *p, filename);
         f = fopen(file, "rb");
         if (f == NULL)
             continue;

--- a/c/sfntedit/source/main.c
+++ b/c/sfntedit/source/main.c
@@ -39,7 +39,7 @@ jmp_buf mark;
 
 #endif /* SUNOS */
 
-#define VERSION "1.4.1"
+#define VERSION "1.4.2"
 
 /* Data type sizes (bytes) */
 #define uint16_ 2


### PR DESCRIPTION
- use larger buffer for `file` in `sysOpenSearchpath` in *sys.c
- move declaration of `file` out of loop
- use `snprintf` instead of `sprintf`

Closes #1139 
