### PR TITLE
[checkoutlinesufo, ufotools] improve overlap removal, error messages

### DIFF
--- a/python/afdko/checkoutlinesufo.py
+++ b/python/afdko/checkoutlinesufo.py
@@ -4,7 +4,7 @@
 Tool that performs outline quality checks and can remove path overlaps.
 """
 
-__version__ = '2.4.2'
+__version__ = '2.4.3'
 
 import argparse
 from functools import cmp_to_key
@@ -923,7 +923,7 @@ def restore_contour_order(fixed_glyph, original_contours):
     # Check each extreme for a match.
     if num_contours > 0:
         # ctr_starts tracks start points per contour
-        ctr_starts = {n: [] for n in range(num_contours)}
+        ctr_starts = {n: [] for n in range(len(fixed_glyph))}
         for i in range(num_contours):
             ci, contour = new_list[i]
             max_p = contour.maxP

--- a/python/afdko/ufotools.py
+++ b/python/afdko/ufotools.py
@@ -16,10 +16,10 @@ from psautohint.ufoFont import norm_float
 
 from afdko import fdkutils
 
-__version__ = '1.35.0'
+__version__ = '1.35.1'
 
 __doc__ = """
-ufotools.py v1.35.0 Mar 03 2020
+ufotools.py v1.35.1 Jun 11 2020
 
 Originally developed to work with 'bez' files and UFO fonts in support of
 the autohint tool, ufotools.py is now only used in checkoutlinesufo (since
@@ -1085,7 +1085,7 @@ def makeUFOFMNDB(srcFontPath):
     return fmndbPath
 
 
-def thresholdAttrGlyph(aGlyph, threshold=0):
+def thresholdAttrGlyph(aGlyph, threshold=0.5):
     """
     Like fontPens.thresholdPen.thresholdGlyph, but preserves some glyph- and
     point-level attributes that are not preserved by that method.
@@ -1094,20 +1094,12 @@ def thresholdAttrGlyph(aGlyph, threshold=0):
     attrnames = ['anchors']
     attrs = {k: getattr(aGlyph, k, None) for k in attrnames if hasattr(aGlyph, k)}  # noqa: E501
 
-    # preserve Point.smooth attributes
-    smoothed = {(ci, (p.x, p.y)): p for ci, p in PointIterator(aGlyph) if p.smooth}  # noqa: E501
-
     # filter with ThresholdPen into recording pen
     recorder = RecordingPen()
     filterpen = ThresholdPen(recorder, threshold)
     aGlyph.draw(filterpen)
     aGlyph.clear()
     recorder.replay(aGlyph.getPen())
-
-    # restore Point.smooth attributes
-    for ci, p in PointIterator(aGlyph):
-        if (ci, (p.x, p.y)) in smoothed:
-            p.smooth = True
 
     # restore glyph-level attributes
     for k, v in attrs.items():

--- a/python/afdko/ufotools.py
+++ b/python/afdko/ufotools.py
@@ -1106,13 +1106,3 @@ def thresholdAttrGlyph(aGlyph, threshold=0.5):
         setattr(aGlyph, k, v)
 
     return aGlyph
-
-
-class PointIterator(object):
-    def __init__(self, aGlyph):
-        self.glyph = aGlyph
-
-    def __iter__(self):
-        for ci, c in enumerate(self.glyph._contours):
-            for p in c._points:
-                yield (ci, p)

--- a/tests/checkoutlinesufo_data/expected_output/bug790.ufo/glyphs.com.adobe.type.processedglyphs/scedilla.glif
+++ b/tests/checkoutlinesufo_data/expected_output/bug790.ufo/glyphs.com.adobe.type.processedglyphs/scedilla.glif
@@ -4,7 +4,7 @@
   <unicode hex="015F"/>
   <outline>
     <contour>
-      <point x="230" y="-14" type="line" smooth="yes"/>
+      <point x="230" y="-14" type="line"/>
       <point x="377" y="-14"/>
       <point x="444" y="57"/>
       <point x="444" y="135" type="curve" smooth="yes"/>

--- a/tests/makeinstancesufo_data/expected_output/light.ufo/glyphs.com.adobe.type.processedglyphs/y.glif
+++ b/tests/makeinstancesufo_data/expected_output/light.ufo/glyphs.com.adobe.type.processedglyphs/y.glif
@@ -26,7 +26,7 @@
 			<point x="194" y="-133"/>
 			<point x="154" y="-190"/>
 			<point x="103" y="-215" type="curve"/>
-			<point x="95" y="-207" type="line" smooth="yes"/>
+			<point x="95" y="-207" type="line"/>
 			<point x="73" y="-189"/>
 			<point x="55" y="-179"/>
 			<point x="35" y="-179" type="curve" smooth="yes"/>

--- a/tests/makeinstancesufo_data/expected_output/light.ufo/glyphs.com.adobe.type.processedglyphs/yacute.glif
+++ b/tests/makeinstancesufo_data/expected_output/light.ufo/glyphs.com.adobe.type.processedglyphs/yacute.glif
@@ -26,7 +26,7 @@
 			<point x="194" y="-133"/>
 			<point x="154" y="-190"/>
 			<point x="103" y="-215" type="curve"/>
-			<point x="95" y="-207" type="line" smooth="yes"/>
+			<point x="95" y="-207" type="line"/>
 			<point x="73" y="-189"/>
 			<point x="55" y="-179"/>
 			<point x="35" y="-179" type="curve" smooth="yes"/>

--- a/tests/makeinstancesufo_data/expected_output/light.ufo/glyphs.com.adobe.type.processedglyphs/ydieresis.glif
+++ b/tests/makeinstancesufo_data/expected_output/light.ufo/glyphs.com.adobe.type.processedglyphs/ydieresis.glif
@@ -26,7 +26,7 @@
 			<point x="194" y="-133"/>
 			<point x="154" y="-190"/>
 			<point x="103" y="-215" type="curve"/>
-			<point x="95" y="-207" type="line" smooth="yes"/>
+			<point x="95" y="-207" type="line"/>
 			<point x="73" y="-189"/>
 			<point x="55" y="-179"/>
 			<point x="35" y="-179" type="curve" smooth="yes"/>

--- a/tests/makeinstancesufo_data/expected_output/light.ufo/glyphs.com.adobe.type.processedglyphs/ytilde.glif
+++ b/tests/makeinstancesufo_data/expected_output/light.ufo/glyphs.com.adobe.type.processedglyphs/ytilde.glif
@@ -26,7 +26,7 @@
 			<point x="194" y="-133"/>
 			<point x="154" y="-190"/>
 			<point x="103" y="-215" type="curve"/>
-			<point x="95" y="-207" type="line" smooth="yes"/>
+			<point x="95" y="-207" type="line"/>
 			<point x="73" y="-189"/>
 			<point x="55" y="-179"/>
 			<point x="35" y="-179" type="curve" smooth="yes"/>

--- a/tests/makeinstancesufo_data/expected_output/ufo3semibold.ufo/glyphs.com.adobe.type.processedglyphs/a.glif
+++ b/tests/makeinstancesufo_data/expected_output/ufo3semibold.ufo/glyphs.com.adobe.type.processedglyphs/a.glif
@@ -27,7 +27,7 @@
       <point x="107" y="322" type="curve" smooth="yes"/>
       <point x="138" y="322"/>
       <point x="164" y="343"/>
-      <point x="166" y="398" type="curve" smooth="yes"/>
+      <point x="166" y="398" type="curve"/>
       <point x="171" y="448" type="line"/>
       <point x="189" y="453"/>
       <point x="206" y="455"/>

--- a/tests/makeinstancesufo_data/expected_output/ufo3semibold.ufo/glyphs.com.adobe.type.processedglyphs/aacute.glif
+++ b/tests/makeinstancesufo_data/expected_output/ufo3semibold.ufo/glyphs.com.adobe.type.processedglyphs/aacute.glif
@@ -27,7 +27,7 @@
       <point x="107" y="322" type="curve" smooth="yes"/>
       <point x="138" y="322"/>
       <point x="164" y="343"/>
-      <point x="166" y="398" type="curve" smooth="yes"/>
+      <point x="166" y="398" type="curve"/>
       <point x="171" y="448" type="line"/>
       <point x="189" y="453"/>
       <point x="206" y="455"/>

--- a/tests/makeinstancesufo_data/expected_output/ufo3semibold.ufo/glyphs.com.adobe.type.processedglyphs/adieresis.glif
+++ b/tests/makeinstancesufo_data/expected_output/ufo3semibold.ufo/glyphs.com.adobe.type.processedglyphs/adieresis.glif
@@ -27,7 +27,7 @@
       <point x="107" y="322" type="curve" smooth="yes"/>
       <point x="138" y="322"/>
       <point x="164" y="343"/>
-      <point x="166" y="398" type="curve" smooth="yes"/>
+      <point x="166" y="398" type="curve"/>
       <point x="171" y="448" type="line"/>
       <point x="189" y="453"/>
       <point x="206" y="455"/>

--- a/tests/makeinstancesufo_data/expected_output/ufo3semibold.ufo/glyphs.com.adobe.type.processedglyphs/atilde.glif
+++ b/tests/makeinstancesufo_data/expected_output/ufo3semibold.ufo/glyphs.com.adobe.type.processedglyphs/atilde.glif
@@ -27,7 +27,7 @@
       <point x="107" y="322" type="curve" smooth="yes"/>
       <point x="138" y="322"/>
       <point x="164" y="343"/>
-      <point x="166" y="398" type="curve" smooth="yes"/>
+      <point x="166" y="398" type="curve"/>
       <point x="171" y="448" type="line"/>
       <point x="189" y="453"/>
       <point x="206" y="455"/>


### PR DESCRIPTION
- modify check for contour starts (base contour indices on original glyph, not fixed glyph)
- update `thresholdAttrGlyph` method: don't try to "fix" smooth points, use threshold of 0.5 **N.B. this change causes changes to test data** w/r/t smoothed points
- update to use `ufoVersionFormatTuple` consistently throughout module
- improve messaging for KeyError and failed assertion in overlap removal/contour renumbering scheme
