### PR TITLE
Fix reversed STAT flags

### DIFF
--- a/c/makeotf/makeotf_lib/build/hotpccts/featgram.g
+++ b/c/makeotf/makeotf_lib/build/hotpccts/featgram.g
@@ -1988,9 +1988,9 @@ designAxis
 
 axisValueFlag[uint16_t *flags]
 	:
-		K_ElidableAxisValueName     << *flags |= 0x0001; >>
+		K_OlderSiblingFontAttribute     << *flags |= 0x0001; >>
 		|
-		K_OlderSiblingFontAttribute << *flags |= 0x0002; >>
+		K_ElidableAxisValueName << *flags |= 0x0002; >>
 	;
 
 axisValueFlags>[uint16_t flags]

--- a/c/makeotf/makeotf_lib/source/hotconv/featgram.c
+++ b/c/makeotf/makeotf_lib/source/hotconv/featgram.c
@@ -4723,14 +4723,14 @@ axisValueFlag(uint16_t *flags)
     zzBLOCK(zztasp1);
     zzMake0;
     {
-        if ((LA(1) == K_ElidableAxisValueName)) {
-            zzmatch(K_ElidableAxisValueName);
+        if ((LA(1) == K_OlderSiblingFontAttribute)) {
+            zzmatch(K_OlderSiblingFontAttribute);
             *flags |= 0x0001;
             zzCONSUME;
 
         } else {
-            if ((LA(1) == K_OlderSiblingFontAttribute)) {
-                zzmatch(K_OlderSiblingFontAttribute);
+            if ((LA(1) == K_ElidableAxisValueName)) {
+                zzmatch(K_ElidableAxisValueName);
                 *flags |= 0x0002;
                 zzCONSUME;
 

--- a/tests/makeotfexe_data/expected_output/spec/9i-1.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9i-1.ttx
@@ -87,13 +87,13 @@
     <AxisValueArray>
       <AxisValue index="0" Format="1">
         <AxisIndex value="0"/>
-        <Flags value="1"/>
+        <Flags value="2"/>
         <ValueNameID value="259"/>  <!-- Regular -->
         <Value value="400.0"/>
       </AxisValue>
       <AxisValue index="1" Format="2">
         <AxisIndex value="0"/>
-        <Flags value="1"/>
+        <Flags value="2"/>
         <ValueNameID value="260"/>  <!-- Regular -->
         <NominalValue value="400.0"/>
         <RangeMinValue value="300.0"/>
@@ -101,21 +101,21 @@
       </AxisValue>
       <AxisValue index="2" Format="3">
         <AxisIndex value="0"/>
-        <Flags value="1"/>
+        <Flags value="2"/>
         <ValueNameID value="261"/>  <!-- Regular -->
         <Value value="400.0"/>
         <LinkedValue value="700.0"/>
       </AxisValue>
       <AxisValue index="3" Format="3">
         <AxisIndex value="1"/>
-        <Flags value="1"/>
+        <Flags value="2"/>
         <ValueNameID value="262"/>  <!-- Regular -->
         <Value value="0.0"/>
         <LinkedValue value="1.0"/>
       </AxisValue>
       <AxisValue index="4" Format="4">
         <!-- AxisCount=2 -->
-        <Flags value="1"/>
+        <Flags value="2"/>
         <ValueNameID value="263"/>  <!-- Mediumitalic -->
         <AxisValueRecord index="0">
           <AxisIndex value="0"/>

--- a/tests/makeotfexe_data/expected_output/spec/9i-2.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9i-2.ttx
@@ -16,7 +16,7 @@
     <AxisValueArray>
       <AxisValue index="0" Format="1">
         <AxisIndex value="0"/>
-        <Flags value="1"/>
+        <Flags value="2"/>
         <ValueNameID value="257"/>  <!-- Regular -->
         <Value value="400.0"/>
       </AxisValue>

--- a/tests/makeotfexe_data/expected_output/spec/9i-20.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9i-20.ttx
@@ -64,7 +64,7 @@
     <AxisValueArray>
       <AxisValue index="0" Format="1">
         <AxisIndex value="0"/>
-        <Flags value="1"/>
+        <Flags value="2"/>
         <ValueNameID value="257"/>  <!-- Regular -->
         <Value value="400.0"/>
       </AxisValue>

--- a/tests/makeotfexe_data/expected_output/spec/9i-21.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9i-21.ttx
@@ -64,7 +64,7 @@
     <AxisValueArray>
       <AxisValue index="0" Format="1">
         <AxisIndex value="0"/>
-        <Flags value="1"/>
+        <Flags value="2"/>
         <ValueNameID value="257"/>  <!-- Regular -->
         <Value value="400.0"/>
       </AxisValue>

--- a/tests/makeotfexe_data/expected_output/spec/9i-25.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9i-25.ttx
@@ -21,7 +21,7 @@
     <AxisValueArray>
       <AxisValue index="0" Format="2">
         <AxisIndex value="0"/>
-        <Flags value="1"/>
+        <Flags value="2"/>
         <ValueNameID value="259"/>  <!-- Regular -->
         <NominalValue value="400.0"/>
         <RangeMinValue value="-300.54"/>
@@ -29,7 +29,7 @@
       </AxisValue>
       <AxisValue index="1" Format="1">
         <AxisIndex value="1"/>
-        <Flags value="1"/>
+        <Flags value="2"/>
         <ValueNameID value="260"/>  <!-- Italic -->
         <Value value="1.0"/>
       </AxisValue>

--- a/tests/makeotfexe_data/expected_output/spec/9i-4.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9i-4.ttx
@@ -16,7 +16,7 @@
     <AxisValueArray>
       <AxisValue index="0" Format="1">
         <AxisIndex value="0"/>
-        <Flags value="2"/>
+        <Flags value="1"/>
         <ValueNameID value="258"/>  <!-- Regular -->
         <Value value="400.0"/>
       </AxisValue>


### PR DESCRIPTION
Fixed the flag values for  `OlderSiblingFontAttribute` and `ElidableAxisValueName` because they were reversed.