### PR TITLE
makeotfexe STAT/name table fixes

### DIFF
--- a/c/makeotf/makeotf_lib/api/hotconv.h
+++ b/c/makeotf/makeotf_lib/api/hotconv.h
@@ -12,7 +12,7 @@ This software is licensed as OpenSource, under the Apache License, Version 2.0. 
 extern "C" {
 #endif
 
-#define HOT_VERSION 0x010072 /* Library version (1.0.114) */
+#define HOT_VERSION 0x010073 /* Library version (1.0.115) */
 /* Major, minor, build = (HOT_VERSION >> 16) & 0xff, (HOT_VERSION >> 8) & 0xff, HOT_VERSION & 0xff) */
 /* Warning: this string is now part of heuristic used by CoolType to identify the
 first round of CoolType fonts which had the backtrack sequence of a chaining

--- a/c/makeotf/makeotf_lib/source/hotconv/STAT.c
+++ b/c/makeotf/makeotf_lib/source/hotconv/STAT.c
@@ -425,38 +425,37 @@ void STATAddAxisValueTable(hotCtx g, uint16_t format, Tag *axisTags,
         case 4:
             for (i = 0; i < h->axisValues.cnt; i++) {
                 AxisValueTable *refav = &h->axisValues.array[i];
-				bool dupeAVT[99];
-				bool isDupe = true;
-				if (refav->format4.axisCount == count) {
-					for (j = 0; j < count; j++) {
-						if (refav->format4.axisValues[j].axisTag == axisTags[j]
-							&& refav->format4.axisValues[j].value == values[j]) {
-							dupeAVT[j] = true;
-						}
-						else {
-							dupeAVT[j] = false;
-						}
-					}
-					for (j = 0; j < count; j++) {
-						if (!dupeAVT[j]) {
-							isDupe = false;
-							break;
-						}
-					}
-					if (isDupe) {
-						// message + number of axes * 14 (wght ddddd.dd)
-						char dupeMsg[2048];
-						dupeMsg[0] = '\0';
-						sprintf(dupeMsg, "[STAT] AxisValueTable already defined with locations: ");
-						for (j = 0; j < count; j++) {
-							char axisMsg[20];
-							axisMsg[0] = '\0';
-							sprintf(axisMsg, "%c%c%c%c %.2f ", TAG_ARG(axisTags[j]), FIX2DBL(values[j]));
-							strcat(dupeMsg, axisMsg);
-						}
-						hotMsg(g, hotFATAL, dupeMsg);
-					}
-				}
+                bool dupeAVT[99];
+                bool isDupe = true;
+                if (refav->format4.axisCount == count) {
+                    for (j = 0; j < count; j++) {
+                        if (refav->format4.axisValues[j].axisTag == axisTags[j]
+                            && refav->format4.axisValues[j].value == values[j]) {
+                            dupeAVT[j] = true;
+                        } else {
+                            dupeAVT[j] = false;
+                        }
+                    }
+                    for (j = 0; j < count; j++) {
+                        if (!dupeAVT[j]) {
+                            isDupe = false;
+                            break;
+                        }
+                    }
+                    if (isDupe) {
+                        // message + number of axes * 14 (wght ddddd.dd)
+                        char dupeMsg[2048];
+                        dupeMsg[0] = '\0';
+                        sprintf(dupeMsg, "[STAT] AxisValueTable already defined with locations: ");
+                        for (j = 0; j < count; j++) {
+                            char axisMsg[20];
+                            axisMsg[0] = '\0';
+                            sprintf(axisMsg, "%c%c%c%c %.2f ", TAG_ARG(axisTags[j]), FIX2DBL(values[j]));
+                            strcat(dupeMsg, axisMsg);
+                        }
+                        hotMsg(g, hotFATAL, dupeMsg);
+                    }
+                }
             }
             av->size = AXIS_VALUE_TABLE4_SIZE(count);
             av->format4.axisCount = count;

--- a/c/makeotf/makeotf_lib/source/hotconv/STAT.c
+++ b/c/makeotf/makeotf_lib/source/hotconv/STAT.c
@@ -302,9 +302,11 @@ void STATAddDesignAxis(hotCtx g, Tag tag, uint16_t nameID, uint16_t ordering) {
     // Currently registered tags are 'wght', 'wdth', 'opsz', 'ital', 'slnt'
     char tagString[4] = {TAG_ARG(tag)};
     const uint32_t *regTags[5] = {
-                                  TAG('i','t','a','l'), TAG('o','p','s','z'), 
-                                  TAG('s','l','n','t'), TAG('w','d','t','h'), 
-                                  TAG('w','g','h','t'), 
+                                  TAG('i', 't', 'a', 'l'),
+                                  TAG('o', 'p', 's', 'z'),
+                                  TAG('s', 'l', 'n', 't'),
+                                  TAG('w', 'd', 't', 'h'),
+                                  TAG('w', 'g', 'h', 't'),
                                   };
 
     // Unregistered tags should be all uppercase

--- a/c/makeotf/makeotf_lib/source/hotconv/STAT.c
+++ b/c/makeotf/makeotf_lib/source/hotconv/STAT.c
@@ -302,9 +302,9 @@ void STATAddDesignAxis(hotCtx g, Tag tag, uint16_t nameID, uint16_t ordering) {
     // Currently registered tags are 'wght', 'wdth', 'opsz', 'ital', 'slnt'
     char tagString[4] = {TAG_ARG(tag)};
     const uint32_t *regTags[5] = {
-                                  TAG('i','t','a','l'), TAG('o','p','s','z'),
-                                  TAG('s','l','n','t'), TAG('w','d','t','h'),
-                                  TAG('w','g','h','t'),
+                                  TAG('i','t','a','l'), TAG('o','p','s','z'), 
+                                  TAG('s','l','n','t'), TAG('w','d','t','h'), 
+                                  TAG('w','g','h','t'), 
                                   };
 
     // Unregistered tags should be all uppercase

--- a/c/makeotf/makeotf_lib/source/hotconv/STAT.c
+++ b/c/makeotf/makeotf_lib/source/hotconv/STAT.c
@@ -425,38 +425,38 @@ void STATAddAxisValueTable(hotCtx g, uint16_t format, Tag *axisTags,
         case 4:
             for (i = 0; i < h->axisValues.cnt; i++) {
                 AxisValueTable *refav = &h->axisValues.array[i];
-				bool dupeAVT[count];
+				bool dupeAVT[99];
 				bool isDupe = true;
-                if (refav->format4.axisCount == count) {
+				if (refav->format4.axisCount == count) {
 					for (j = 0; j < count; j++) {
-		                if (refav->format4.axisValues[j].axisTag == axisTags[j]
-        		        	&& refav->format4.axisValues[j].value == values[j]) {
-        		        	dupeAVT[j] = true;
+						if (refav->format4.axisValues[j].axisTag == axisTags[j]
+							&& refav->format4.axisValues[j].value == values[j]) {
+							dupeAVT[j] = true;
 						}
 						else {
-        		        	dupeAVT[j] = false;
+							dupeAVT[j] = false;
 						}
 					}
+					for (j = 0; j < count; j++) {
+						if (!dupeAVT[j]) {
+							isDupe = false;
+							break;
+						}
+					}
+					if (isDupe) {
+						// message + number of axes * 14 (wght ddddd.dd)
+						char dupeMsg[2048];
+						dupeMsg[0] = '\0';
+						sprintf(dupeMsg, "[STAT] AxisValueTable already defined with locations: ");
 						for (j = 0; j < count; j++) {
-							if (!dupeAVT[j]) {
-								isDupe = false;
-//								break;
-							}
+							char axisMsg[20];
+							axisMsg[0] = '\0';
+							sprintf(axisMsg, "%c%c%c%c %.2f ", TAG_ARG(axisTags[j]), FIX2DBL(values[j]));
+							strcat(dupeMsg, axisMsg);
 						}
-						if (isDupe) {
-							// message + number of axes * 14 (wght ddddd.dd)
-							char dupeMsg[54 + count * 14];
-							dupeMsg[0] = '\0';
-							sprintf(dupeMsg, "[STAT] AxisValueTable already defined with locations: ");
-							for (j = 0; j < count; j++) {
-								char axisMsg[20];
-								axisMsg[0] = '\0';
-								sprintf(axisMsg, "%c%c%c%c %.2f ", TAG_ARG(axisTags[j]), FIX2DBL(values[j]));
-								strcat(dupeMsg, axisMsg);
-							}
-							hotMsg(g, hotFATAL, dupeMsg);
-						}
+						hotMsg(g, hotFATAL, dupeMsg);
 					}
+				}
             }
             av->size = AXIS_VALUE_TABLE4_SIZE(count);
             av->format4.axisCount = count;

--- a/c/makeotf/makeotf_lib/source/hotconv/STAT.c
+++ b/c/makeotf/makeotf_lib/source/hotconv/STAT.c
@@ -320,7 +320,7 @@ void STATAddDesignAxis(hotCtx g, Tag tag, uint16_t nameID, uint16_t ordering) {
     }
     if (!regTag) {
         int hasLC = false;
-        for (j = 0; j <= 4; j++) {
+        for (j = 0; j < 4; j++) {
             if (tagString[j] >= 'a' && tagString[j] <= 'z') {
                 hasLC = true;
                 break;

--- a/c/makeotf/makeotf_lib/source/hotconv/name.c
+++ b/c/makeotf/makeotf_lib/source/hotconv/name.c
@@ -437,7 +437,7 @@ static char *translate2MacDflt(nameCtx h, char *src) {
         if (uv) {
             char macChar = mapUV2MacRoman(uv);
             if (macChar == 0) {
-                hotMsg(h->g, hotFATAL, "Could not translate UTF8 glyph code into Mac Roman in name table name %s", begin);
+                hotMsg(h->g, hotFATAL, "[name] Could not translate UTF8 glyph code into Mac Roman in name table name %s", begin);
             }
             *dst++ = macChar;
         }
@@ -477,7 +477,7 @@ static void fillNames(nameCtx h) {
                              HOT_NAME_FAMILY);
 
         if (tempString == NULL) {
-            hotMsg(h->g, hotFATAL, "I can't find a Family name for this font !");
+            hotMsg(h->g, hotFATAL, "[name] I can't find a Family name for this font !");
         }
         addWinDfltName(h, HOT_NAME_FAMILY, strlen(tempString), tempString);
     }
@@ -525,7 +525,7 @@ static void fillNames(nameCtx h) {
                     rec->languageId,
                     HOT_NAME_FAMILY, strlen(Family), Family);
             if (doWarning) {
-                hotMsg(h->g, hotWARNING, "The Font Menu Name DB entry for this font is missing an MS Platform Compatible Family Name entry to match the MS Platform Preferred Family Name for language ID %d. Using the Preferred Name only.", rec->languageId);
+                hotMsg(h->g, hotWARNING, "[name] The Font Menu Name DB entry for this font is missing an MS Platform Compatible Family Name entry to match the MS Platform Preferred Family Name for language ID %d. Using the Preferred Name only.", rec->languageId);
             }
         }
 
@@ -681,7 +681,7 @@ static void fillNames(nameCtx h) {
                         rec->languageId,
                         HOT_NAME_FAMILY, strlen(Family), Family);
                 if (doWarning && (!doV1Names)) {
-                    hotMsg(h->g, hotWARNING, "The Font Menu Name DB entry for this font is missing a Mac Platform Compatible Family Name entry to match the Mac Platform Preferred Family Name for language ID %d. Using the Preferred Name only.", rec->languageId);
+                    hotMsg(h->g, hotWARNING, "[name] The Font Menu Name DB entry for this font is missing a Mac Platform Compatible Family Name entry to match the Mac Platform Preferred Family Name for language ID %d. Using the Preferred Name only.", rec->languageId);
                 }
             }
             index++;
@@ -817,7 +817,7 @@ static void fillNames(nameCtx h) {
                 }
 
                 if (Subfamily == NULL) {
-                    hotMsg(h->g, hotFATAL, "no Mac subfamily name specified");
+                    hotMsg(h->g, hotFATAL, "[name] no Mac subfamily name specified");
                 } else if (strcmp(Subfamily, "Regular") == 0) {
                     addName(h,
                             HOT_NAME_MAC_PLATFORM,
@@ -873,7 +873,7 @@ static void fillNames(nameCtx h) {
                 }
 
                 if (Subfamily == NULL) {
-                    hotMsg(h->g, hotFATAL, "no Mac subfamily name specified");
+                    hotMsg(h->g, hotFATAL, "[name] no Mac subfamily name specified");
                 } else if (strcmp(Subfamily, "Regular") == 0) {
                     addName(h,
                             HOT_NAME_MAC_PLATFORM,
@@ -1119,6 +1119,12 @@ void nameAddReg(hotCtx g,
                 unsigned short languageId,
                 unsigned short nameId, char *str) {
     nameCtx h = g->ctx.name;
+    if (nameVerifyIDExists(g, nameId)) {
+        char *foundstr = getName(h, platformId, platspecId, languageId, nameId);
+        if (foundstr != NULL) {
+            hotMsg(h->g, hotWARNING, "[name] Overwriting existing nameid %d %s with %s", nameId, foundstr, str);
+        }
+    }
     addName(h, platformId, platspecId, languageId, nameId, strlen(str), str);
 }
 
@@ -1134,6 +1140,11 @@ unsigned short nameAddUser(hotCtx g, char *str) {
 unsigned short nameReserveUserID(hotCtx g) {
     nameCtx h = g->ctx.name;
     unsigned short nameId = h->userNameId++;
+    if (nameVerifyIDExists(g, nameId) && nameId > 255) {
+        while (nameVerifyIDExists(g, nameId)) {
+            nameId++;
+        }
+    }
     return nameId;
 }
 

--- a/c/makeotf/source/main.c
+++ b/c/makeotf/source/main.c
@@ -30,7 +30,7 @@
 
 jmp_buf mark;
 
-#define MAKEOTF_VERSION "2.5.65599"
+#define MAKEOTF_VERSION "2.5.65600"
 /* Warning: this string is now part of heuristic used by CoolType to identify the
    first round of CoolType fonts which had the backtrack sequence of a chaining
    contextual substitution ordered incorrectly.  Fonts with the old ordering MUST match

--- a/docs/MakeOTFUserGuide.md
+++ b/docs/MakeOTFUserGuide.md
@@ -236,7 +236,22 @@ Versions of MakeOTF prior to FDK 2.5 used a similar syntax in the FontMenuNameDB
 If the key `c=` is used, then MakeOTF will build the older style name table. If the keys `l=` or `m=` are present, it will build the newer style name table . If none of these are present, then there is no difference in how the name table is built.
 
 ## **GlyphOrderAndAliasDB** (GOADB)
-The GOADB file is used to rename and to establish an order for the glyphs in a font. It is a simple text file with one line per glyph name. Each line contains at least two fields, and optionally three fields. The first field is the final glyph name to be used in the output font. The second field is the ‘friendly’ name used in the source font data. The third field is a Unicode value, specified in the form `uniXXXX` or `uXXXX`, where `XXXX` is a Unicode value (hexadecimal). One may specify more than one Unicode value for a glyph by giving a comma separated list of values, for example: `uni0020,uni00A0`. The `XXXX` hexadecimal values *must* be either numerals (0-9) or uppercase letters. Values containing lowercase letters will be ignored. The source font is not required to have any glyphs that are named in the `GlyphOrderAndAliasDB` file.
+The GOADB file is used to rename and to establish an order for the glyphs in a font. 
+It is a simple text file with one line per glyph name. Each line contains at least two fields, 
+and optionally three fields. The first field is the final glyph name to be used in the output font. 
+The second field is the ‘friendly’ name used in the source font data. 
+The third field is a Unicode value, specified in the form `uniXXXX` or `uXXXX[XX]` (see [note](#unicode_note)). 
+One may specify more than one Unicode value for a glyph by giving a comma separated list of values, for example: `uni0020,uni00A0`. 
+The `XXXX` hexadecimal values *must* be either numerals (0-9) or uppercase letters. Values containing lowercase letters will be ignored. 
+The source font is not required to have any glyphs that are named in the `GlyphOrderAndAliasDB` file.
+
+<a name="unicode_note"></a>
+Note: Unicode values can be used in the form `uniXXXX` or `uXXXX[XX]` where `XXXX[XX]` is a hexadecimal Unicode value.
+The number of `X` is determined by the codepoint. For example, `U+0903` can be written as either 
+`uni0903` or `u0903`. If the codepoint requires 5 or 6 digits, for example `U+F0002` or `U+F00041`, 
+then the format must contain the same number of digits: `uF0002` or `uF00041`. This only applies when 
+assigning Unicode values using column 3.
+
 
 It should be noted that the ordering, renaming, and Unicode override operations are applied only if the `–r` option or the `-ga` option is specified. These operations work as follows:
 
@@ -246,11 +261,11 @@ It should be noted that the ordering, renaming, and Unicode override operations 
 
   3) Override the default Unicode encoding by MakeOTF. MakeOTF will assign Unicode values to glyphs in a non-CID font when possible. (For a CID font, the Unicode values are provided by the Adobe CMap files.) The rules used are as follows:
 
-      a) If the third field of the GOADB record for a glyph contains a Unicode value in the form uniXXXX or uXXXX (where XXXX stands for a Unicode value), assign that Unicode value to the glyph. Else b);
+      a) If the third field of the GOADB record for a glyph contains a Unicode value in the form uniXXXX or uXXXX\[XX\] (see [note](#unicode_note)), assign that Unicode value to the glyph. Else b);
       
       b) If a glyph name is in the [Adobe Glyph List For New Fonts](https://github.com/adobe-type-tools/agl-aglfn/blob/master/aglfn.txt), use the assigned Unicode value. Else c);
       
-      c) If the glyph name is in the form uniXXXX or uXXXX (where XXXX stands for a Unicode value), assign the Unicode value. Else d);
+      c) If the glyph name is in the form uniXXXX or uXXXX\[XX\] (see [note](#unicode_note)), assign the Unicode value. Else d);
 
       d) Do not assign any Unicode value.
 

--- a/python/afdko/makeotf.py
+++ b/python/afdko/makeotf.py
@@ -26,7 +26,7 @@ if needed.
 """
 
 __version__ = """\
-makeotf.py v2.8.0 June 21 2020
+makeotf.py v2.8.1 July 8 2020
 """
 
 __methods__ = """

--- a/tests/makeotfexe_data/expected_output/fealib/bug1178.ttx
+++ b/tests/makeotfexe_data/expected_output/fealib/bug1178.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.12">
 
   <name>
     <namerecord nameID="1" platformID="1" platEncID="0" langID="0x0" unicode="True">
@@ -15,10 +15,13 @@
       Untitled1
     </namerecord>
     <namerecord nameID="5" platformID="1" platEncID="0" langID="0x0" unicode="True">
-
+      Version 1.000;hotconv 1.0.114;makeotfexe 2.5.65599 DEVELOPMENT
     </namerecord>
     <namerecord nameID="6" platformID="1" platEncID="0" langID="0x0" unicode="True">
       Untitled1
+    </namerecord>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      © 2014 - 2020 Adobe Systems Incorporated (http://www.adobe.com/), with Reserved Font Name ‘Source’.
     </namerecord>
     <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
       Untitled1
@@ -33,18 +36,39 @@
       Untitled1
     </namerecord>
     <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
-
+      Version 1.000;hotconv 1.0.114;makeotfexe 2.5.65599 DEVELOPMENT
     </namerecord>
     <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
       Untitled1
     </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Source is a trademark of Adobe Systems Incorporated in the United States and/or other countries.
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Adobe Systems Incorporated
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      A Designer
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://www.adobe.com/type
+    </namerecord>
     <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
-      Weight
+      Roman
     </namerecord>
     <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Italic
+    </namerecord>
+    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
       Regular
     </namerecord>
-    <namerecord nameID="300" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+    <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
+      Light
+    </namerecord>
+    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
       Regular
     </namerecord>
   </name>
@@ -56,20 +80,30 @@
     <DesignAxisRecord>
       <Axis index="0">
         <AxisTag value="wght"/>
-        <AxisNameID value="256"/>  <!-- Weight -->
+        <AxisNameID value="259"/>  <!-- Weight -->
         <AxisOrdering value="0"/>
       </Axis>
     </DesignAxisRecord>
-    <!-- AxisValueCount=1 -->
+    <!-- AxisValueCount=2 -->
     <AxisValueArray>
-      <AxisValue index="0" Format="1">
+      <AxisValue index="0" Format="2">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="260"/>  <!-- Light -->
+        <NominalValue value="300.0"/>
+        <RangeMinValue value="250.0"/>
+        <RangeMaxValue value="350.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="2">
         <AxisIndex value="0"/>
         <Flags value="2"/>
-        <ValueNameID value="257"/>  <!-- Regular -->
-        <Value value="400.0"/>
+        <ValueNameID value="261"/>  <!-- Regular -->
+        <NominalValue value="400.0"/>
+        <RangeMinValue value="350.0"/>
+        <RangeMaxValue value="450.0"/>
       </AxisValue>
     </AxisValueArray>
-    <ElidedFallbackNameID value="300"/>  <!-- Regular -->
+    <ElidedFallbackNameID value="258"/>  <!-- Regular -->
   </STAT>
 
 </ttFont>

--- a/tests/makeotfexe_data/expected_output/spec/9i-2.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9i-2.ttx
@@ -2,7 +2,7 @@
 <ttFont>
 
   <STAT>
-    <Version value="0x00010002"/>
+    <Version value="0x00010001"/>
     <DesignAxisRecordSize value="8"/>
     <!-- DesignAxisCount=1 -->
     <DesignAxisRecord>

--- a/tests/makeotfexe_data/expected_output/spec/9i-21.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9i-21.ttx
@@ -50,7 +50,7 @@
   </name>
 
   <STAT>
-    <Version value="0x00010002"/>
+    <Version value="0x00010001"/>
     <DesignAxisRecordSize value="8"/>
     <!-- DesignAxisCount=1 -->
     <DesignAxisRecord>

--- a/tests/makeotfexe_data/expected_output/spec/9i-22.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9i-22.ttx
@@ -2,7 +2,7 @@
 <ttFont>
 
   <STAT>
-    <Version value="0x00010002"/>
+    <Version value="0x00010001"/>
     <DesignAxisRecordSize value="8"/>
     <!-- DesignAxisCount=1 -->
     <DesignAxisRecord>

--- a/tests/makeotfexe_data/expected_output/spec/9i-25.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9i-25.ttx
@@ -2,7 +2,7 @@
 <ttFont>
 
   <STAT>
-    <Version value="0x00010002"/>
+    <Version value="0x00010001"/>
     <DesignAxisRecordSize value="8"/>
     <!-- DesignAxisCount=2 -->
     <DesignAxisRecord>

--- a/tests/makeotfexe_data/expected_output/spec/9i-4.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9i-4.ttx
@@ -2,7 +2,7 @@
 <ttFont>
 
   <STAT>
-    <Version value="0x00010002"/>
+    <Version value="0x00010001"/>
     <DesignAxisRecordSize value="8"/>
     <!-- DesignAxisCount=1 -->
     <DesignAxisRecord>

--- a/tests/makeotfexe_data/expected_output/spec/9i-5.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9i-5.ttx
@@ -2,7 +2,7 @@
 <ttFont>
 
   <STAT>
-    <Version value="0x00010002"/>
+    <Version value="0x00010001"/>
     <DesignAxisRecordSize value="8"/>
     <!-- DesignAxisCount=0 -->
     <!-- AxisValueCount=0 -->

--- a/tests/makeotfexe_data/expected_output/spec/9i-6.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9i-6.ttx
@@ -2,7 +2,7 @@
 <ttFont>
 
   <STAT>
-    <Version value="0x00010002"/>
+    <Version value="0x00010001"/>
     <DesignAxisRecordSize value="8"/>
     <!-- DesignAxisCount=1 -->
     <DesignAxisRecord>

--- a/tests/makeotfexe_data/input/fealib/bug1178.fea
+++ b/tests/makeotfexe_data/input/fealib/bug1178.fea
@@ -1,0 +1,31 @@
+# https://github.com/adobe-type-tools/afdko/issues/1178
+
+table name {
+    nameid 0 "\00a9 2014 - 2020 Adobe Systems Incorporated (http://www.adobe.com/), with Reserved Font Name \2018Source\2019.";
+    nameid 7 "Source is a trademark of Adobe Systems Incorporated in the United States and/or other countries.";
+    nameid 8 "Adobe Systems Incorporated";
+    nameid 9 "A Designer";
+    nameid 11 "http://www.adobe.com/type";
+    nameid 256 "Roman";
+    nameid 257 "Italic";
+} name;
+
+
+table STAT {
+
+   ElidedFallbackName { name "Regular"; };
+
+   DesignAxis wght 0 { name "Weight"; };
+
+   AxisValue {
+      location wght 300 250 - 350;
+      name "Light";
+   };
+
+   AxisValue {
+      location wght 400 350 - 450;
+      name "Regular";
+      flag ElidableAxisValueName;
+   };
+
+} STAT;

--- a/tests/makeotfexe_data/input/fealib/incomplete_glyph_range.bad.fea
+++ b/tests/makeotfexe_data/input/fealib/incomplete_glyph_range.bad.fea
@@ -1,0 +1,2 @@
+
+@incomplete_range = [a- ];

--- a/tests/makeotfexe_data/input/fealib/name_after_STAT.bad.fea
+++ b/tests/makeotfexe_data/input/fealib/name_after_STAT.bad.fea
@@ -1,0 +1,26 @@
+# name table should be defined before STAT to avoid possibly overwriting names
+
+table STAT {
+   ElidedFallbackName { name "Regular"; };
+
+   DesignAxis wght 0 { name "Weight"; };
+   DesignAxis ital 1 { name "Italic"; };
+
+   AxisValue {
+      location wght 400.0 -300.54 - 450.6;
+      name "Regular";
+      flag ElidableAxisValueName;
+   };
+
+   AxisValue {
+      location ital 1;
+      name "Italic";
+      flag ElidableAxisValueName;
+   };
+} STAT;
+
+
+table name {
+    nameid 256 "Roman";
+    nameid 257 "Italic";
+} name;

--- a/tests/makeotfexe_data/input/spec/9i-21.fea
+++ b/tests/makeotfexe_data/input/spec/9i-21.fea
@@ -1,5 +1,9 @@
 # TABLES: name,STAT
 
+table name {
+   nameid 300 "Regular";
+} name;
+
 table STAT {
    ElidedFallbackNameID 300;
 
@@ -11,7 +15,3 @@ table STAT {
       flag ElidableAxisValueName;
    };
 } STAT;
-
-table name {
-   nameid 300 "Regular";
-} name;

--- a/tests/makeotfexe_test.py
+++ b/tests/makeotfexe_test.py
@@ -553,6 +553,24 @@ def test_parameter_offset_overflow_bug1017():
     assert differ([expected_txt, actual_txt])
 
 
+def test_bug1178():
+    input_filename = 'fealib/font.pfa'
+    feat_filename = 'fealib/bug1178.fea'
+    ttx_filename = 'fealib/bug1178.ttx'
+    actual_path = get_temp_file_path()
+    runner(CMD + ['-o', 'f', f'_{get_input_path(input_filename)}',
+                        'ff', f'_{get_input_path(feat_filename)}',
+                        'o', f'_{actual_path}'])
+    actual_ttx = generate_ttx_dump(actual_path, ['name', 'STAT'])
+    expected_ttx = get_expected_path(ttx_filename)
+    assert differ([expected_ttx, actual_ttx,
+                   '-s',
+                   '<ttFont sfntVersion' + SPLIT_MARKER +
+                   '    <checkSumAdjustment value=' + SPLIT_MARKER +
+                   '    <created value=' + SPLIT_MARKER +
+                   '    <modified value='])
+
+
 TEST_FEATURE_FILES = [
     "Attach", "enum", "markClass", "language_required", "GlyphClassDef",
     "LigatureCaretByIndex", "LigatureCaretByPos", "lookup", "lookupflag",
@@ -570,7 +588,8 @@ TEST_FEATURE_FILES = [
     "ZeroValue_SinglePos_horizontal", "ZeroValue_SinglePos_vertical",
     "ZeroValue_PairPos_horizontal", "ZeroValue_PairPos_vertical",
     "ZeroValue_ChainSinglePos_horizontal", "ZeroValue_ChainSinglePos_vertical",
-    "PairPosSubtable", "MultipleLookupsPerGlyph", "MultipleLookupsPerGlyph2"
+    "PairPosSubtable", "MultipleLookupsPerGlyph", "MultipleLookupsPerGlyph2",
+    "name_after_STAT.bad", "incomplete_glyph_range.bad",
 ]
 
 TEST_FEATURE_FILES_XFAIL = [
@@ -580,6 +599,8 @@ TEST_FEATURE_FILES_XFAIL = [
     "language_required",  # required
     "PairPosSubtable",   # https://github.com/adobe-type-tools/afdko/issues/971
     "bug1307",           # https://github.com/adobe-type-tools/afdko/issues/966
+    "name_after_STAT.bad",
+    "incomplete_glyph_range.bad",
 ]
 
 TEST_FEATURE_FILES_TABLES = {

--- a/tests/makeotfexe_test.py
+++ b/tests/makeotfexe_test.py
@@ -568,7 +568,8 @@ def test_bug1178():
                    '<ttFont sfntVersion' + SPLIT_MARKER +
                    '    <checkSumAdjustment value=' + SPLIT_MARKER +
                    '    <created value=' + SPLIT_MARKER +
-                   '    <modified value='])
+                   '    <modified value=',
+                   '-r', r'^\s+Version.*;hotconv.*;makeotfexe'])
 
 
 TEST_FEATURE_FILES = [


### PR DESCRIPTION
Add `[STAT]` to STAT table messages
Update STAT handling to write version 1.2 table only if there are Format 4 Axis value tables
Warn if unregistered axis tags are not uppercase
Warn if Format 2 default value is not in min-max range
Fail if DesignAxis tag has already been defined
Fail if Axis Value Table of the same format has already been defined with the same values

Add `[name]` to name table messages
Warn when overwriting existing nameid
Fail if GSUB or STAT are defined before name table and name table sets nameids above 255. Fixes #1178 

Docs:
Clarify use of Unicode values in column 3 of GlyphOrderAndAliasDB. Fixes #1177 
