### PR TITLE
[tx] improve robustness of components

### DIFF
--- a/c/public/lib/api/pstoken.h
+++ b/c/public/lib/api/pstoken.h
@@ -7,7 +7,7 @@
 
 #include "ctlshare.h"
 
-#define PST_VERSION CTL_MAKE_VERSION(2, 0, 10)
+#define PST_VERSION CTL_MAKE_VERSION(2, 0, 11)
 
 #ifdef __cplusplus
 extern "C" {

--- a/c/public/lib/api/svread.h
+++ b/c/public/lib/api/svread.h
@@ -7,7 +7,7 @@
 
 #include "ctlshare.h"
 
-#define SVR_VERSION CTL_MAKE_VERSION(1, 0, 7)
+#define SVR_VERSION CTL_MAKE_VERSION(1, 0, 8)
 
 #include "absfont.h"
 

--- a/c/public/lib/api/t1read.h
+++ b/c/public/lib/api/t1read.h
@@ -7,7 +7,7 @@
 
 #include "ctlshare.h"
 
-#define T1R_VERSION CTL_MAKE_VERSION(1, 0, 43)
+#define T1R_VERSION CTL_MAKE_VERSION(1, 0, 44)
 
 #include "absfont.h"
 

--- a/c/public/lib/source/pstoken/pstoken.c
+++ b/c/public/lib/source/pstoken/pstoken.c
@@ -576,7 +576,7 @@ static int skipDictionary(pstCtx h, int call_depth) {
                     return 1;
                 break;
             case '<':
-                if (skipAngle(h, call_depth + 1))
+                if (skipAngle(h, call_depth + 1) == -1)
                     return 1;
                 break;
             case -1:

--- a/c/public/lib/source/svread/svread.c
+++ b/c/public/lib/source/svread/svread.c
@@ -883,7 +883,7 @@ static int parseSVG(svrCtx h) {
         } else if (tokenEqualStr(tk, "unicode=")) {
             char *endPtr;
             tk = getAttribute(h);
-            if ((tk == NULL) || (tk->length > kMaxName)) {
+            if ((tk == NULL) || (tk->length >= kMaxName)) {
                 fatal(h, svrErrParse, "Error parsing Unicode value. Glyph index: %ld.", h->chars.index.cnt);
                 return svrErrParse; /* should not reach this line, but it makes Xcode happy */
             }
@@ -905,10 +905,7 @@ static int parseSVG(svrCtx h) {
                     unicode = '>';
                     sprintf(tempName, "greater");
                 } else {
-                    size_t len = tk->length;
-                    if (len > kMaxName)
-                        len = kMaxName - 1;
-                    strncpy(tempVal, tk->val, len);
+                    strncpy(tempVal, tk->val, tk->length);
                     message(h, "Encountered bad Unicode value: '%s'.", tempVal);
                     continue;
                 }
@@ -923,7 +920,7 @@ static int parseSVG(svrCtx h) {
         } else if (tokenEqualStr(tk, "horiz-adv-x=")) {
             long width;
             tk = getToken(h);
-            if ((tk == NULL) || (tk->length > kMaxName)) {
+            if ((tk == NULL) || (tk->length >= kMaxName)) {
                 fatal(h, svrErrParse, "Error parsing horiz-adv-x value. Glyph index: %ld.", h->chars.index.cnt);
                 return svrErrParse; /* should not reach this line, but it makes Xcode happy */
             }
@@ -1145,7 +1142,7 @@ static STI addString(svrCtx h, size_t length, const char *value) {
         /* A null name (/) is legal in PostScript but could lead to unexpected
            behavior elsewhere in the coretype libraries so it is substituted
            for a name that is very likely to be unique in the font */
-        const char subs_name[] = "_null_name_substitute_";
+        static const char subs_name[] = "_null_name_substitute_";
         value = subs_name;
         length = sizeof(subs_name) - 1;
         message(h, "null charstring name");

--- a/c/public/lib/source/t1read/t1read.c
+++ b/c/public/lib/source/t1read/t1read.c
@@ -1554,7 +1554,7 @@ static void prepMMData(t1rCtx h) {
     /* copy FontName because call to addString() below may make pointer stale */
     strncpy(FontName, pFontName, 128);
     FontName[127] = 0;
-    
+
     if (h->fd->aux.nMasters == 0)
         fatal(h, t1rErrMMParse, "invalid number of masters");
 

--- a/c/public/lib/source/t1read/t1read.c
+++ b/c/public/lib/source/t1read/t1read.c
@@ -319,7 +319,7 @@ static STI addString(t1rCtx h, size_t length, const char *value) {
         /* A null name (/) is legal in PostScript but could lead to unexpected
            behavior elsewhere in the coretype libraries so it is substituted
            for a name that is very likely to be unique in the font */
-        const char subs_name[] = "_null_name_substitute_";
+        static const char subs_name[] = "_null_name_substitute_";
         value = subs_name;
         length = sizeof(subs_name) - 1;
         message(h, "null charstring name");
@@ -1543,13 +1543,18 @@ static void prepMMData(t1rCtx h) {
     char buf[64];
     char coords[64];
     char *p;
-    char *FontName = getString(h, (STI)h->fd->fdict->FontName.impl);
+    char *pFontName = getString(h, (STI)h->fd->fdict->FontName.impl);
+    char FontName[128];
     unsigned int nAxes;
     char *Weight = "SnapShotMM";
 
-    if (FontName == NULL)
+    if (pFontName == NULL)
         fatal(h, t1rErrMMParse, "missing FontName");
 
+    /* copy FontName because call to addString() below may make pointer stale */
+    strncpy(FontName, pFontName, 128);
+    FontName[127] = 0;
+    
     if (h->fd->aux.nMasters == 0)
         fatal(h, t1rErrMMParse, "invalid number of masters");
 


### PR DESCRIPTION
## Description

Updates several components of `tx`:
 - in pstoken.c: fixed an issue that could result in heap use-after-free in a malformed file
 - in svread.c: fixed an issue that could result in stack buffer overflow in a malformed file
 - in t1read.c: fixed an issue that could result in stack use-after-scope in a malformed file

Version numbers are updated for all components.
