### PR TITLE
[makeotfexe] fix stack-buffer-overflow and heap-use-after-free

### DIFF
--- a/c/makeotf/makeotf_lib/build/hotpccts/featgram.g
+++ b/c/makeotf/makeotf_lib/build/hotpccts/featgram.g
@@ -1934,7 +1934,7 @@ table_OS_2
 			  (
 				<<for (arrayIndex = 0; arrayIndex < kLenUnicodeList; arrayIndex++) unicodeRangeList[arrayIndex] = kCodePageUnSet; arrayIndex = 0; >>
 				(
-				numUInt16>[valUInt16] <<if ((arrayIndex) < kLenUnicodeList) unicodeRangeList[arrayIndex] = valUInt16; arrayIndex++;>>
+				numUInt16>[valUInt16] <<if (arrayIndex < kLenUnicodeList) unicodeRangeList[arrayIndex] = valUInt16; arrayIndex++;>>
 				)+
 				<<featSetUnicodeRange(g, unicodeRangeList);>>
 			  )
@@ -1943,7 +1943,7 @@ table_OS_2
 			  (
 				<<for (arrayIndex = 0; arrayIndex < kLenCodePageList; arrayIndex++) codePageList[arrayIndex] = kCodePageUnSet; arrayIndex = 0;>>
 				(
-				numUInt16>[valUInt16] <<codePageList[arrayIndex] = valUInt16; arrayIndex++;>>
+				numUInt16>[valUInt16] <<if (arrayIndex < kLenCodePageList) codePageList[arrayIndex] = valUInt16; arrayIndex++;>>
 				)+
 				<<featSetCodePageRange(g, codePageList);>>
 			  )

--- a/c/makeotf/makeotf_lib/source/hotconv/featgram.c
+++ b/c/makeotf/makeotf_lib/source/hotconv/featgram.c
@@ -4502,7 +4502,7 @@ table_OS_2()
                                                                                         do {
                                                                                             valUInt16 = numUInt16();
 
-                                                                                            if ((arrayIndex) < kLenUnicodeList) unicodeRangeList[arrayIndex] = valUInt16;
+                                                                                            if (arrayIndex < kLenUnicodeList) unicodeRangeList[arrayIndex] = valUInt16;
                                                                                             arrayIndex++;
                                                                                             zzLOOP(zztasp5);
                                                                                         } while ((LA(1) == T_NUM));
@@ -4531,7 +4531,7 @@ table_OS_2()
                                                                                             do {
                                                                                                 valUInt16 = numUInt16();
 
-                                                                                                codePageList[arrayIndex] = valUInt16;
+                                                                                                if (arrayIndex < kLenCodePageList) codePageList[arrayIndex] = valUInt16;
                                                                                                 arrayIndex++;
                                                                                                 zzLOOP(zztasp5);
                                                                                             } while ((LA(1) == T_NUM));

--- a/c/makeotf/makeotf_lib/source/typecomp/recode.c
+++ b/c/makeotf/makeotf_lib/source/typecomp/recode.c
@@ -4622,10 +4622,10 @@ void InitStaticFontData(tcCtx g, int font__serif_selector, double *StdVW, double
         /* are the same for all masters, in all the fill-in fonts.                   */
         gi = cffGetGlyphInfo(ctx, h->newGlyph.fill_in_cff[font_index].scaling_gid, h->metricsPathcb);
 
-        cffFree(ctx);
-
         scaling_gid_bottom = gi->bbox.bottom;
         scaling_gid_top = gi->bbox.top;
+
+        cffFree(ctx);
 
         /* Now get the font transform matrix and the UDV to be used with   */
         /* this master face of the target font, for the new glyph from the */


### PR DESCRIPTION
This PR fixes two issues found by running `makeotfexe_test.py` with `AddressSanitizer` (ASAN):
* `heap-use-after-free` in `recode.c`
* `stack-buffer-overflow` in `featgram.c`
