### PR TITLE
[mergefonts] fix stack-buffer-overflow

### DIFF
--- a/c/mergefonts/source/mergeFonts.c
+++ b/c/mergefonts/source/mergeFonts.c
@@ -1240,7 +1240,7 @@ static void readCIDFontInfo(txCtx h, char *filePath) {
             value[i++] = 0;
         }
         lineno++;
-        len = sscanf(buf, "%127s %128[^\n]", key, value);
+        len = sscanf(buf, "%127s %127[^\n]", key, value);
         if (len != 2) {
             if (len == -1)
                 continue;


### PR DESCRIPTION
This PR fixes a `stack-buffer-overflow` in `mergeFonts.c` found by running `mergefonts_test.py` with `AddressSanitizer` (ASAN).