### PR TITLE
[tx] check upper limit of hmtx size

### DIFF
--- a/c/public/lib/api/varread.h
+++ b/c/public/lib/api/varread.h
@@ -19,7 +19,7 @@ extern "C" {
    This library parses tables common tables used by variable OpenType fonts.
 */
 
-#define VARREAD_VERSION CTL_MAKE_VERSION(1, 0, 7)
+#define VARREAD_VERSION CTL_MAKE_VERSION(1, 0, 8)
 #define F2DOT14_TO_FIXED(v) (((Fixed)(v)) << 2)
 #define FIXED_TO_F2DOT14(v) ((var_F2dot14)(((Fixed)(v) + 0x00000002) >> 2))
 

--- a/c/public/lib/source/varread/varread.c
+++ b/c/public/lib/source/varread/varread.c
@@ -1084,7 +1084,7 @@ var_hmtx var_loadhmtx(sfrCtx sfr, ctlSharedStmCallbacks *sscb) {
 
     /* estimate the number of glyphs from the table size instead of reading the head table */
     numGlyphs = (table->length / 2) - hmtx->header.numberOfHMetrics;
-    if (numGlyphs < hmtx->header.numberOfHMetrics) {
+    if ((numGlyphs < hmtx->header.numberOfHMetrics) || (numGlyphs > 65535)) {
         sscb->message(sscb, "invalid hmtx table size");
         goto cleanup;
     }


### PR DESCRIPTION
Added an upper limit check on the size of `hmtx` to the existing lower limit check. This check limits the memory impact of a font with a malformed `hmtx` table.