### PR TITLE
[tx] update limit to avoid large memory allocations

### DIFF
--- a/c/public/lib/api/cffread.h
+++ b/c/public/lib/api/cffread.h
@@ -7,7 +7,7 @@
 
 #include "ctlshare.h"
 
-#define CFR_VERSION CTL_MAKE_VERSION(2, 1, 2)
+#define CFR_VERSION CTL_MAKE_VERSION(2, 1, 3)
 
 #include "absfont.h"
 

--- a/c/public/lib/source/cffread/cffread.c
+++ b/c/public/lib/source/cffread/cffread.c
@@ -50,7 +50,7 @@ static char *applestd[258] =
 #define SHORT_PS_NAME_LIMIT   63 /* according to the OpenType name table spec */
 #define LONG_PS_NAME_LIMIT   127 /* according to Adobe tech notes #5902 */
 #define STRING_BUFFER_LIMIT 1024 /* used to load family name/full name/copyright/trademark strings */
-#define SUBR_INDEX_CNT_LIMIT 134217728 /* limit subrINDEX cnt to avoid large memory allocations */
+#define SUBR_INDEX_CNT_LIMIT 67108864 /* limit subrINDEX cnt to avoid large memory allocations */
 
 #define ARRAY_LEN(t) (sizeof(t) / sizeof((t)[0]))
 


### PR DESCRIPTION
## Description

- amend previous fix to 1/2 of previous limit (the `malloc` in question used *8, not *4)
- bump `cffread` version #
