### PR TITLE
[ttfcomponentizer] add warning for empty psnames

### DIFF
--- a/python/afdko/ttfcomponentizer.py
+++ b/python/afdko/ttfcomponentizer.py
@@ -17,7 +17,7 @@ from defcon import Font
 from afdko.fdkutils import get_font_format
 
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 
 PUBLIC_PSNAMES = "public.postscriptNames"
@@ -273,7 +273,13 @@ def get_glyph_names_mapping(ufo_path):
         return None, None
 
     if PUBLIC_PSNAMES in ufo.lib:
-        return ufo, ufo.lib[PUBLIC_PSNAMES]
+        ufo_names = ufo.lib[PUBLIC_PSNAMES]
+        if len(ufo_names) == 0:
+            # empty dict; warn
+            print(f"WARNING: The contents of {PUBLIC_PSNAMES} is empty. This "
+                  "may result in uncomponentized glyphs if final glyph names "
+                  "vary from production names.")
+        return ufo, ufo_names
 
     return ufo, get_goadb_names_mapping(ufo_path)
 

--- a/tests/ttfcomponentizer_test.py
+++ b/tests/ttfcomponentizer_test.py
@@ -33,6 +33,16 @@ EMPTY_LIB = b"""<?xml version="1.0" encoding="UTF-8"?>
     <dict/>
 </plist>
 """
+EMPTY_PSKEY = b"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+"http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+    <key>public.postscriptNames</key>
+    <dict/>
+    </dict>
+</plist>
+"""
 
 
 def _get_test_ttf_path():
@@ -206,6 +216,21 @@ def test_get_glyph_names_mapping_names_from_goadb():
     _write_file(lib_path, lib_data)
     assert sorted(result[1].keys()) == DESIGN_NAMES_LIST
     assert sorted(result[1].values()) == PRODCT_NAMES_LIST
+
+
+def test_warn_empty_psnames_key(capsys):
+    # the test UFO has a 'public.postscriptNames' in its lib;
+    # set the key to empty to ensure we get a warning
+    ufo_path = _get_test_ufo_path()
+    lib_path = os.path.join(ufo_path, 'lib.plist')
+    lib_data = _read_file(lib_path)
+    _write_file(lib_path, EMPTY_PSKEY)
+    result = ttfcomp.get_glyph_names_mapping(ufo_path)
+    _write_file(lib_path, lib_data)
+    assert len(result[1]) == 0
+    captured = capsys.readouterr()
+    # check (partial) warning message in stdout:
+    assert "WARNING: The contents of public.postscriptNames is empty." in captured.out  # noqa: E501
 
 
 def test_componentize():


### PR DESCRIPTION
## Description

Update `ttfcomponentizer` and related tests:
- add a warning when UFO lib.plist `public.postscriptNames` key is present but empty
- add test to ensure warning is issued for this condition

Closes #1198 
