### PR TITLE
[tests] add flake8-bugbear

### DIFF
--- a/.circleci/check_source_code.sh
+++ b/.circleci/check_source_code.sh
@@ -4,26 +4,10 @@ set -e
 
 # activate virtual environment
 source venv/bin/activate
-# check source files
-flake8 setup.py
-flake8 tests/*.py
-pushd python/afdko
-flake8 buildcff2vf.py
-flake8 buildmasterotfs.py
-flake8 checkoutlinesufo.py
-flake8 convertfonttocid.py
-flake8 fdkutils.py
-flake8 makeinstancesufo.py
-flake8 makeotf.py
-flake8 otc2otf.py
-flake8 otf2ttf.py
-flake8 pdflib/otfpdf.py
-flake8 pdflib/pdfmetrics.py
-flake8 ttfdecomponentizer.py
-flake8 ttfcomponentizer.py
-flake8 ttxn.py
-flake8 ufotools.py
-popd
+# check Python source files with flake8
+flake8 --count --show-source --statistics --config=.flake8
+
+# check C files with cpplint
 cpplint --recursive --quiet c/detype1
 cpplint --recursive --quiet c/makeotf/makeotf_lib/source
 cpplint --recursive --quiet c/makeotf/makeotf_lib/api

--- a/.flake8
+++ b/.flake8
@@ -2,10 +2,24 @@
 
 # explicitly select all Errors, Failures, and Warnings
 # (override default ignore list)
-select = E,F,W
+select = E,F,W,B,B901,B902,B903
 
 # ignore W504 line break before binary operator
 ignore = W504
 
 # explicitly set line length limitation
 max-line-length = 79
+
+# exclude files that haven't had linting fixes applied yet
+exclude = 
+    agd.py,
+    beztools.py,
+    comparefamily.py,
+    otf2otc.py,
+    proofpdf.py,
+    **/pdflib/fontpdf.py,
+    **/pdflib/pdfdoc.py,
+    **/pdflib/pdfgen.py,
+    **/pdflib/pdfgeom.py,
+    **/pdflib/pdfutils.py,
+    **/pdflib/ttfpdf.py

--- a/.flake8
+++ b/.flake8
@@ -22,4 +22,5 @@ exclude =
     **/pdflib/pdfgen.py,
     **/pdflib/pdfgeom.py,
     **/pdflib/pdfutils.py,
-    **/pdflib/ttfpdf.py
+    **/pdflib/ttfpdf.py,
+    ./venv*

--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -1,4 +1,4 @@
-name: Test Python Package
+name: AFDKO Test Suite
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
       - README.md
 
 jobs:
-  build:
+  run_tests:
     if: contains(toJson(github.event.commits), '[skip ci]') == false && contains(toJson(github.event.commits), '[skip github]') == false
 
     runs-on: ${{ matrix.os }}
@@ -48,13 +48,9 @@ jobs:
         pip install -r requirements.txt -r requirements-dev.txt .
         pip freeze --all
     
-    - name: Lint with flake8
+    - name: Lint with flake8 using .flake8 config file
       run: |
-        pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude **/comparefamily.py,**/beztools.py
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-line-length=127 --statistics
+        flake8 . --count --show-source --statistics --config=.flake8
 
     - name: Test with pytest
       run: |

--- a/python/afdko/checkoutlinesufo.py
+++ b/python/afdko/checkoutlinesufo.py
@@ -4,7 +4,7 @@
 Tool that performs outline quality checks and can remove path overlaps.
 """
 
-__version__ = '2.4.3'
+__version__ = '2.4.4'
 
 import argparse
 from functools import cmp_to_key
@@ -967,13 +967,13 @@ def restore_contour_order(fixed_glyph, original_contours):
     # just add them on the end.
     if num_contours != 0:
         ci2 = len(new_contours)
-        for ci, contour in new_list:
+        for ci, _contour in new_list:
             order_list.append([ci2, ci])
 
     # Now re-order the new list
     order_list.sort()
     new_contour_list = []
-    for ci2, ci in order_list:
+    for _ci2, ci in order_list:
         new_contour_list.append(new_contours[ci])
 
     fixed_glyph.clearContours()

--- a/python/afdko/convertfonttocid.py
+++ b/python/afdko/convertfonttocid.py
@@ -1,7 +1,7 @@
 # Copyright 2014 Adobe. All rights reserved.
 
 """
-convertfonttocid.py. v 1.13.1 Jul 12 2019
+convertfonttocid.py. v 1.13.2 Jul 30 2020
 
 Convert a Type 1 font to CID, given multiple hint dict defs in the
 "fontinfo" file. See psautohint help, with the "--doc-fddict" option,
@@ -209,7 +209,7 @@ class FDDict(object):
         return "\n".join(fiList)
 
     def buildBlueLists(self):
-        baseline_overshoot = getattr(self, 'BaselineOvershoot')
+        baseline_overshoot = getattr(self, 'BaselineOvershoot', None)
         if baseline_overshoot is None:
             print("Error: FDDict definition %s is missing the "
                   "BaselineYCoord/BaselineOvershoot values. These are "
@@ -818,7 +818,7 @@ def fixFontDict(tempPath, fdDict):
         if not m:
             raise FontParseError("Failed to find FontMatrix in input font! "
                                  "%s" % tempPath)
-        emUnits = getattr(fdDict, 'OrigEmSqUnits')
+        emUnits = fdDict.OrigEmSqUnits
         a = 1.0 / emUnits
         target = "/FontMatrix [%s 0 0 %s 0 0] def" % (a, a)
         data = data[:m.start()] + target + data[m.end():]
@@ -961,7 +961,7 @@ def makeCIDFontInfo(fontPath, cidfontinfoPath):
                     value = "(" + value[1:-1] + ")"
                 string = "%s\t%s\n" % (key, value)
                 fp.write(string)
-    except (IOError, OSError):
+    except (OSError):
         raise FontInfoParseError(
             "Error. Could not open and write file '%s'" % cidfontinfoPath)
 

--- a/python/afdko/makeotf.py
+++ b/python/afdko/makeotf.py
@@ -26,7 +26,7 @@ if needed.
 """
 
 __version__ = """\
-makeotf.py v2.8.2 July 20 2020
+makeotf.py v2.8.3 July 30 2020
 """
 
 __methods__ = """
@@ -606,7 +606,7 @@ def readOptionFile(filePath, makeOTFParams, optionIndex):
     try:
         with open(filePath, "r", encoding='utf-8') as fp:
             data = fp.read()
-    except (IOError, OSError):
+    except (OSError):
         print("makeotf [Error] Could not read the options file %s. "
               "Please check the file protection settings." % filePath)
         error = True
@@ -697,7 +697,7 @@ def writeOptionsFile(makeOTFParams, filePath):
         try:
             with open(filePath, "w", encoding='utf-8') as fp:
                 fp.write(data)
-        except (IOError, OSError):
+        except (OSError):
             print("makeotf [Warning] Could not write the options file %s. "
                   "Please check the file protection settings for the file "
                   "and for the directory." % filePath)
@@ -734,7 +734,7 @@ def setOptionsFromFontInfo(makeOTFParams):
             with open(fontinfo_path, "r", encoding='utf-8') as fi:
                 data = fi.read()
             makeOTFParams.fontinfoPath = fontinfo_path
-        except (OSError, IOError):
+        except (OSError):
             print("makeotf [Error] Failed to find and open fontinfo file: "
                   "FSType, OS/2 V4 bits, and Bold and Italic settings may "
                   "not be correct.")
@@ -2002,7 +2002,7 @@ def convertFontIfNeeded(makeOTFParams):
                 if b"/Private" in data:
                     isTextPS = True
                     needsConversion = True
-        except (IOError, OSError):
+        except (OSError):
             print("makeotf [Error] Could not read font file at '%s'." %
                   filePath)
             raise MakeOTFShellError
@@ -2107,7 +2107,7 @@ def updateFontRevision(featuresPath, fontRevision):
         featuresPath = os.path.abspath(featuresPath)
         with open(featuresPath, "r", encoding='utf-8') as fp:
             data = fp.read()
-    except (IOError, OSError):
+    except (OSError):
         print("makeotf [Error] When trying to update the head table "
               "fontRevision field, failed to open '%s'." % featuresPath)
         return
@@ -2159,7 +2159,7 @@ def updateFontRevision(featuresPath, fontRevision):
     try:
         with open(featuresPath, "w", encoding='utf-8') as fp:
             fp.write(newData)
-    except (IOError, OSError):
+    except (OSError):
         print("makeotf [Error] When trying to update the head table "
               "fontRevision field, failed to write the new data to '%s'." %
               featuresPath)

--- a/python/afdko/ttfcomponentizer.py
+++ b/python/afdko/ttfcomponentizer.py
@@ -17,7 +17,7 @@ from defcon import Font
 from afdko.fdkutils import get_font_format
 
 
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 
 
 PUBLIC_PSNAMES = "public.postscriptNames"
@@ -120,7 +120,7 @@ class TTComponentizer(object):
 
             glyph = glyf_table[gname]
             glyph.__dict__.clear()
-            setattr(glyph, "components", components)
+            glyph.components = components
             glyph.numberOfContours = -1
             self.comp_count += 1
 

--- a/python/afdko/ttxn.py
+++ b/python/afdko/ttxn.py
@@ -90,7 +90,7 @@ import logging
 
 from afdko.fdkutils import get_temp_file_path
 
-__version__ = "1.21.2"
+__version__ = "1.21.3"
 
 log = logging.getLogger('fontTools.ttx')
 
@@ -1741,7 +1741,7 @@ class OTLConverter(object):
         for defList in sorted(self.markClassesByDefList.keys()):
             classRecList = self.markClassesByDefList[defList]
             defNameList = []
-            for nameList, anchor in defList:
+            for nameList, _anchor in defList:
                 defNameList.extend(list(nameList))
             lenList = len(defNameList)
             if lenList == 0:
@@ -2241,7 +2241,7 @@ def ttnDump(input_file, output, options, showExtensionFlag, supressHints=False,
                     if mapping[1] == "NULL":
                         delList.append(mapping)
             if delList:
-                for charCode, glyphName in delList:
+                for charCode, _glyphName in delList:
                     try:
                         del cmapSubtable.cmap[charCode]
                     except KeyError:

--- a/python/afdko/ufotools.py
+++ b/python/afdko/ufotools.py
@@ -16,10 +16,10 @@ from psautohint.ufoFont import norm_float
 
 from afdko import fdkutils
 
-__version__ = '1.35.1'
+__version__ = '1.35.2'
 
 __doc__ = """
-ufotools.py v1.35.1 Jun 11 2020
+ufotools.py v1.35.2 Jul 30 2020
 
 Originally developed to work with 'bez' files and UFO fonts in support of
 the autohint tool, ufotools.py is now only used in checkoutlinesufo (since
@@ -561,8 +561,8 @@ class UFOFontData(object):
             else:
                 width = 0
         except UFOParseError as e:
-            print("Error. skipping glyph '%s' because of parse error: %s" %
-                  (glyphFileName, e.message))
+            print(f"Error. skipping glyph '{glyphFileName}' because "
+                  f"of parse error: {str(e)}")
             return None, None, None
         return width, glifXML, outlineXML
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ codecov>=2.0.15
 cpplint>=1.4.3
 cython>=0.29.5
 flake8>=3.7.6
+flake8-bugbear>=20.1.4
 pip>=19.0.2
 pytest-cov>=2.6.1
 setuptools>=40.8.0

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -12,7 +12,7 @@ import subprocess
 import sys
 import tempfile
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 
 logger = logging.getLogger('runner')
 
@@ -106,7 +106,7 @@ def _check_save_path(path_str):
         open(check_path, 'a').close()
         if del_test_file:
             os.remove(check_path)
-    except (IOError, OSError):
+    except (OSError):
         raise argparse.ArgumentTypeError(
             f"{check_path} is not a valid path to write to.")
     return check_path


### PR DESCRIPTION
## Description

Add `flake8-bugbear` checks

- add flake8-bugbear to requirements-dev.txt
- enable flake8-bugbear checks in .flake8 config
- add exceptions to .flake8 config
- fix Python modules that had flake8-bugbear violations & update versions
- tweak GitHub Test action to use .flake8 config & other minor changes
- tweak CircleCI flake8 checks (pick up exceptions via config file)
