### PR TITLE
agd: support five-digit code points

### DIFF
--- a/python/afdko/agd.py
+++ b/python/afdko/agd.py
@@ -44,7 +44,7 @@ class glyph:
 		for e in ee:
 			k, x = e # get key and its data
 			if k == 'uni':
-				self.uni = re.compile(r'[0-9A-F]{4}').search(x).group() # Unicode value
+				self.uni = re.compile(r'[0-9A-F]{4,5}').search(x).group() # Unicode value
 			elif k == 'fin': self.fin = re_name.search(x).group() # final name
 			elif k == 'ali':
 				for a in re_name.findall(x): self.ali.append(a) # name aliases
@@ -60,7 +60,7 @@ class glyph:
 	# Check a glyph for internal conflicts, problems, etc.
 	def check(self):
 		m = [] # holds reports of what was fixed
-		u = re.compile(r'uni([0-9A-F]{4})$') # Unicode value regexp
+		u = re.compile(r'u(ni)?([0-9A-F]{4,5})$') # Unicode value regexp
 		n = {}
 		# process aliases: remove duplicates, uninames, final names:
 		for a in self.ali:
@@ -82,12 +82,12 @@ class glyph:
 		if not self.uni:
 			if self.fin and u.match(self.fin):
 				m.append("Found Unicode value in final name '%s' of glyph '%s'." % (self.fin, self.name))
-				self.uni = u.match(self.fin).group(1) # Get Unicode from final name
+				self.uni = u.match(self.fin).group(2) # Get Unicode from final name
 			else:
 				for a in self.ali:
 					if u.match(a):
 						m.append("Found Unicode value in alias '%s' of glyph '%s'." % (a, self.name))
-						self.uni = u.match(a).group(1)
+						self.uni = u.match(a).group(2)
 						break
 		return m
 


### PR DESCRIPTION
## Description

bug fix to support 5-digit code points in tools relying on the agd.py module
resolves #1207

## Checklist:

- [X] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [ ] I have verified that new and existing tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

I would love to check all the boxes here, but don’t know where to start.
If necessary for this fix I’d appreciate being walked through. Thanks!
