### PR TITLE
Make designspace attributes lowercase.

### DIFF
--- a/python/afdko/makeinstancesufo.py
+++ b/python/afdko/makeinstancesufo.py
@@ -241,7 +241,7 @@ def validateDesignspaceDoc(dsDoc, dsoptions, **kwArgs):
     for i, inst in enumerate(dsDoc.instances):
         if dsoptions.indexList and i not in dsoptions.indexList:
             continue
-        for attr_name in ('familyName', 'postScriptFontName', 'styleName'):
+        for attr_name in ('familyname', 'postscriptfontname', 'stylename'):
             if getattr(inst, attr_name, None) is None:
                 logger.warning(
                     f"Instance at index {i} has no '{attr_name}' attribute.")


### PR DESCRIPTION
Make designspace attributes all lowercase, corresponding to the specification here: https://github.com/fonttools/fonttools/tree/master/Doc/source/designspaceLib\#attributes-9
The spec itself seems to be inconsistent in attribute casing.

Tested with a `<designspace format="3">` file.

Resolves #1211 .