### PR TITLE
Clarify glyph name ranges (2.g.i)

### DIFF
--- a/docs/OpenTypeFeatureFileSpecification.md
+++ b/docs/OpenTypeFeatureFileSpecification.md
@@ -686,6 +686,18 @@ in an alternate substitution lookup type rule.
 <a name="2.g.i"></a>
 #### 2.g.i. Ranges
 
+A glyph range is a notational mechanism in the feature file grammar that makes it
+possible to define a class of several glyphs is a concise way. The mechanism makes
+use of glyph names that use a contiguous alphabetic sequence A–Z or a–z (or
+sub-sequences thereof), or that use contiguous numeric sequences, such as 0–9. A
+range is specified by referencing starting and ending glyph names, and all of the
+glyph names in the implied sequence are included in the class. The glyphs referenced
+by these names do not have to be in a contiguous sequence in a font file or sources;
+only their names need to be in a contiguous sequence.
+
+If a glyph name within the implied sequence does not correspond to a glyph in the font
+file or font sources, it is ignored.
+
 A range of glyphs is denoted by a hyphen:
 
 ```fea
@@ -703,7 +715,8 @@ feature file glyph names. For example:
 For CID fonts, the ordering is the CID ordering.
 
 For non-CID fonts, the ordering is independent of the ordering of glyphs in the
-font. `<firstGlyph>` and `<lastGlyph>` must be the same length and can differ:
+font. `<firstGlyph>` and `<lastGlyph>` must be the same length and can differ only
+in one of the following ways:
 
 1.  By a single letter from A-Z, either uppercase or lowercase. For example:
 

--- a/docs/OpenTypeFeatureFileSpecification.md
+++ b/docs/OpenTypeFeatureFileSpecification.md
@@ -688,8 +688,8 @@ in an alternate substitution lookup type rule.
 
 A glyph range is a notational mechanism in the feature file grammar that makes it
 possible to define a class of several glyphs is a concise way. The mechanism makes
-use of glyph names that use a contiguous alphabetic sequence A–Z or a–z (or
-sub-sequences thereof), or that use contiguous numeric sequences, such as 0–9. A
+use of glyph names that use a contiguous alphabetic sequence A to Z or a to z (or
+sub-sequences thereof), or that use contiguous numeric sequences, such as 0 to 9. A
 range is specified by referencing starting and ending glyph names, and all of the
 glyph names in the implied sequence are included in the class. The glyphs referenced
 by these names do not have to be in a contiguous sequence in a font file or sources;


### PR DESCRIPTION
The current description of glyph name ranges is unclear in a few critical points.

Fixes #1222 

## Description

This is a proposed enhancement to the feature file spec documentation. The current
wording in section 2.g.i regarding ranges is unclear. At several points, a reader can be
left scratching their heads wondering what was meant. This is intended to provide
greater clarity in that section.

## Checklist:

- [X ] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [ ] I have verified that new and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
