### PR TITLE
Revert #1212, lowercase error message only

### DIFF
--- a/python/afdko/makeinstancesufo.py
+++ b/python/afdko/makeinstancesufo.py
@@ -241,10 +241,11 @@ def validateDesignspaceDoc(dsDoc, dsoptions, **kwArgs):
     for i, inst in enumerate(dsDoc.instances):
         if dsoptions.indexList and i not in dsoptions.indexList:
             continue
-        for attr_name in ('familyname', 'postscriptfontname', 'stylename'):
+        for attr_name in ('familyName', 'postScriptFontName', 'styleName'):
             if getattr(inst, attr_name, None) is None:
                 logger.warning(
-                    f"Instance at index {i} has no '{attr_name}' attribute.")
+                    f"Instance at index {i} has no "
+                    f"'{attr_name.lower()}' attribute.")
         if inst.path is None:
             raise DesignSpaceDocumentError(
                 f"Instance at index {i} has no 'filename' attribute.")


### PR DESCRIPTION
This really fixes #1211.
The attributes stay camelCase, only the error message is reported in all-lowercase.

## Checklist:

- [X] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [X] I have verified that new and existing tests pass locally with my changes
- [X] I have performed a self-review of my own code
