### PR TITLE
[tx_test.py] change skip regex for bug1218 to skip date & time metrics

### DIFF
--- a/tests/tx_test.py
+++ b/tests/tx_test.py
@@ -1084,4 +1084,11 @@ def test_pdf_single_glyph():
 
     runner(CMD + ['-a', '-o', 'pdf', '1', '-f', input_path, output_path])
 
-    assert differ([expected_path, output_path, '-s', *PDF_SKIP])
+    skip = PDF_SKIP[:]
+    skip.insert(0, '-s')
+    regex_skip = PDF_SKIP_REGEX[:]
+    for regex in regex_skip:
+        skip.append('-r')
+        skip.append(regex)
+
+    assert differ([expected_path, output_path] + skip)


### PR DESCRIPTION
This change is intended to fix this issue:
```
--- /home/runner/work/afdko/afdko/tests/tx_data/expected_output/bug1218.pdf
+++ /tmp/tmppqy3jwgv/bug1218.pdf
@@ -36,5 +36,5 @@
 (Em:  4000 units)'
-498.50 30.00 Td
+500.30 30.00 Td
 
-16.00 0.00 Td
+14.10 0.00 Td
```

Here's the relevant section of the PDF, for context:
```
(Filename:  bug1218.otf)'
(FontName:  UPM-Regular)'
(Em:  4000 units)'
500.30 30.00 Td
(Date:  02 Oct 20)'
14.10 0.00 Td
(Time:  13:49)'
```