### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/OpenTypeFeatureFileSpecification.md
+++ b/docs/OpenTypeFeatureFileSpecification.md
@@ -1714,7 +1714,7 @@ feature test {
 Note that both the contextual substitution rules use the same lookups. This is
 because there is more than one rule in each referenced lookup, and different
 rules within the referenced lookups will match in the different contexts. In the
-first contextual substitution rule, the lookup `CNTXT_LIGS`will be applied at
+first contextual substitution rule, the lookup `CNTXT_LIGS` will be applied at
 the input sequence glyph “f”, and the glyphs “f” and “i” will be replaced by
 “f_i”. The lookup `CNTXT_SUB` will be applied at the input sequence glyph “n”,
 and the glyph “n” will be replaced by “n.end”. This will happen only when the


### PR DESCRIPTION
## Description

Tiny fix in feature file specification docs.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [ ] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
