### PR TITLE
[checkoutlinesufo] implement -o (output file) option

### DIFF
--- a/python/afdko/checkoutlinesufo.py
+++ b/python/afdko/checkoutlinesufo.py
@@ -10,6 +10,7 @@ import argparse
 from functools import cmp_to_key
 import re
 from shutil import copy2
+import shutil
 import sys
 import textwrap
 from tqdm import tqdm, trange
@@ -347,6 +348,15 @@ def get_options(args):
              'the modified version of the glyphs is added. The new layer is '
              f"named: '{PROCD_GLYPHS_LAYER}'"
     )
+    parser.add_argument(
+        '-o',
+        '--output-file',
+        metavar='FILE_PATH',
+        nargs='?',
+        help='Specify an output file to save to. RECOMMENDED for non-UFO '
+             'inputs since the default behavior will overwrite the input.'
+    )
+
     ufo_opts = parser.add_argument_group('UFO-only options')
     ufo_opts.add_argument(
         '-w',
@@ -386,6 +396,16 @@ def get_options(args):
     font_format = get_font_format(parsed_args.font_path)
     if font_format not in ('UFO', 'OTF', 'CFF', 'PFA', 'PFB', 'PFC'):
         parser.error('Font format is not supported.')
+
+    if parsed_args.output_file:
+        src = parsed_args.font_path
+        dst = parsed_args.output_file
+        if font_format == 'UFO':
+            shutil.rmtree(dst, ignore_errors=True)
+            shutil.copytree(src, dst)
+        else:
+            shutil.copy(src, dst)
+        parsed_args.font_path = dst
 
     options = COOptions()
 

--- a/python/afdko/checkoutlinesufo.py
+++ b/python/afdko/checkoutlinesufo.py
@@ -4,7 +4,7 @@
 Tool that performs outline quality checks and can remove path overlaps.
 """
 
-__version__ = '2.4.4'
+__version__ = '2.4.5'
 
 import argparse
 from functools import cmp_to_key

--- a/python/afdko/checkoutlinesufo.py
+++ b/python/afdko/checkoutlinesufo.py
@@ -9,7 +9,6 @@ __version__ = '2.4.4'
 import argparse
 from functools import cmp_to_key
 import re
-from shutil import copy2
 import shutil
 import sys
 import textwrap
@@ -177,7 +176,7 @@ class FontFile(object):
                 raise FocusFontError('Failed to convert UFO font to CFF.')
 
             if self.font_type == CFF_FONT_TYPE:
-                copy2(temp_cff_path, self.font_path)
+                shutil.copy2(temp_cff_path, self.font_path)
 
             else:  # OTF_FONT_TYPE
                 if not run_shell_command([

--- a/tests/checkoutlinesufo_test.py
+++ b/tests/checkoutlinesufo_test.py
@@ -1,5 +1,6 @@
 import pytest
 from shutil import copy2, copytree
+import os
 
 from booleanOperations.booleanGlyph import BooleanGlyph
 from defcon import Glyph
@@ -9,6 +10,7 @@ from afdko.checkoutlinesufo import remove_tiny_sub_paths
 from afdko.fdkutils import (
     get_temp_file_path,
     get_temp_dir_path,
+    get_font_format,
 )
 from test_utils import (
     get_input_path,
@@ -113,3 +115,20 @@ def test_cidkeyed_remove_overlap(filename, diffmode):
     runner(CMD + ['-f', actual_path, '-o', 'e', 'q', '=no-overlap-checks'])
     expected_path = get_expected_path('cidfont.subset.checked')
     assert differ([expected_path, actual_path] + diffmode)
+
+
+@pytest.mark.parametrize('input_font, expected_font', [
+    ('ufo3.ufo', 'ufo3-proc-layer.ufo'),
+    ('font.pfa', 'font.pfa'),
+])
+def test_output_file_option(input_font, expected_font):
+    """
+    Test the '-o' (output file) option.
+    """
+    in_path = get_input_path(input_font)
+    out_path = os.path.join(get_temp_dir_path(), input_font)
+    expected_path = get_expected_path(expected_font)
+    runner(CMD + ['-f', in_path, '-o', 'e', 'o', '_' + out_path])
+
+    assert get_font_format(out_path) == get_font_format(in_path)
+    assert differ([expected_path, out_path])


### PR DESCRIPTION
## Description

- updated checkoutlinesufo to accept -o/--output-file option, a path specifying an output file. When this option is specified, the input file will first be copied to the specified output file path, and successive operations will occur on that path.
- added test case (uses existing input/expected data)

closes #1242 

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [x] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
