### PR TITLE
Fix reading cid names in UFOs

### DIFF
--- a/c/public/lib/source/uforead/uforead.c
+++ b/c/public/lib/source/uforead/uforead.c
@@ -3712,7 +3712,7 @@ int ufoIterateGlyphs(ufoCtx h, abfGlyphCallbacks* glyph_cb) {
     for (i = 0; i < h->chars.index.cnt; i++) {
         hasCIDNames(h, i, glyph_cb);
     }
-    
+
     for (i = 0; i < h->chars.index.cnt; i++) {
         int res;
         res = readGlyph(h, i, glyph_cb);


### PR DESCRIPTION
Fix for https://github.com/adobe-type-tools/afdko/issues/1245
We only set CID flags if all glyphs conform to the same `cidXXXXX` naming pattern. Otherwise we can't assume it is meant to be a CID-keyed font. 