### PR TITLE
[requirements] remove mutatorMath, update fontTools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ lxml==4.6.2
 booleanOperations==0.9.0
 defcon[pens,lxml]==0.7.2
 fontMath==0.6.0
-fontTools[woff,ufo,unicode,lxml]==4.18.1
+fontTools[woff,ufo,unicode,lxml]==4.18.2
 psautohint==2.2.0
 tqdm==4.54.1
 ufonormalizer==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ booleanOperations==0.9.0
 defcon[pens,lxml]==0.7.2
 fontMath==0.6.0
 fontTools[woff,ufo,unicode,lxml]==4.18.1
-mutatorMath==3.0.1
 psautohint==2.2.0
 tqdm==4.54.1
 ufonormalizer==0.5.2


### PR DESCRIPTION
[`mutatorMath`](https://github.com/LettError/MutatorMath) is a dependency of [`ufoProcessor`](https://github.com/LettError/ufoProcessor) but it's not a direct dependency of **afdko**.