### PR TITLE
[makeotfexe] Allow negative internal leading

### DIFF
--- a/c/makeotf/makeotf_lib/source/hotconv/hot.c
+++ b/c/makeotf/makeotf_lib/source/hotconv/hot.c
@@ -715,9 +715,8 @@ static void prepWinData(hotCtx g) {
     }
     intLeading = font->win.ascent + font->win.descent - font->unitsPerEm;
     if (intLeading < 0) {
-        /* Avoid negative internal leading */
-        font->win.ascent -= intLeading;
-        intLeading = 0;
+        /* Warn about negative internal leading */
+        hotMsg(g, hotWARNING, "Negative internal leading: win.ascent + win.descent < unitsPerEm");
     }
 
     /* Set typo ascender/descender/linegap */

--- a/tests/buildmasterotfs_data/expected_output/master0.ttx
+++ b/tests/buildmasterotfs_data/expected_output/master0.ttx
@@ -95,7 +95,7 @@
     <sTypoAscender value="483"/>
     <sTypoDescender value="-517"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="987"/>
+    <usWinAscent value="483"/>
     <usWinDescent value="13"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/buildmasterotfs_data/expected_output/master1.ttx
+++ b/tests/buildmasterotfs_data/expected_output/master1.ttx
@@ -95,7 +95,7 @@
     <sTypoAscender value="503"/>
     <sTypoDescender value="-497"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="984"/>
+    <usWinAscent value="503"/>
     <usWinDescent value="16"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts-bit7n-bit8n-bit9n.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts-bit7n-bit8n-bit9n.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts-bit7y-bit8n-bit7n-bit8y.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts-bit7y-bit8n-bit7n-bit8y.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts-bit7y-bit8n-bit9n.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts-bit7y-bit8n-bit9n.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts-bit7y-bit8y-bit9y.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts-bit7y-bit8y-bit9y.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts-ga.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts-ga.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts-gf-ga-nga.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts-gf-ga-nga.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts-gf-ga.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts-gf-ga.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts-gf-nga-ga.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts-gf-nga-ga.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts-gf-nga.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts-gf-nga.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts-gf.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts-gf.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts-nga.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts-nga.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts-r-ga-gf.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts-r-ga-gf.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts-r-ga.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts-r-ga.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts-r-gf.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts-r-gf.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts-r-nga.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts-r-nga.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts-r.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts-r.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug497/opts.ttx
+++ b/tests/makeotf_data/expected_output/bug497/opts.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/bug751.txt
+++ b/tests/makeotf_data/expected_output/bug751.txt
@@ -2,4 +2,5 @@ tx: --- tests/makeotf_data/input/bug751.ufo
 tx: (ufr) Warning: Encountered empty <string> for fontinfo key copyright. Skipping
 tx: (ufr) Warning: Encountered empty <string> for fontinfo key trademark. Skipping
 makeotf [Warning] Could not find default features file. Font will be built without any layout features.
+makeotfexe [WARNING] <Exercise1-Regular> Negative internal leading: win.ascent + win.descent < unitsPerEm
 Built development mode font 'Exercise1-Regular.otf'.

--- a/tests/makeotf_data/expected_output/font_dev.ttx
+++ b/tests/makeotf_data/expected_output/font_dev.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="739"/>
     <sTypoDescender value="-261"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="987"/>
+    <usWinAscent value="739"/>
     <usWinDescent value="13"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/font_dev_output.txt
+++ b/tests/makeotf_data/expected_output/font_dev_output.txt
@@ -1,4 +1,5 @@
 makeotf [Warning] Could not find default features file. Font will be built without any layout features.
 makeotf [Warning] Could not find FontMenuNameDB file. Font will be built with menu names derived from PostScript name.
 makeotfexe [WARNING] FontMenuNameDB file was not specified or not found. [SourceSerifPro-Regular]
+makeotfexe [WARNING] <SourceSerifPro-Regular> Negative internal leading: win.ascent + win.descent < unitsPerEm
 Built development mode font 'font.otf'.

--- a/tests/makeotf_data/expected_output/font_rel.ttx
+++ b/tests/makeotf_data/expected_output/font_rel.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="739"/>
     <sTypoDescender value="-261"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="987"/>
+    <usWinAscent value="739"/>
     <usWinDescent value="13"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/font_rel_output.txt
+++ b/tests/makeotf_data/expected_output/font_rel_output.txt
@@ -5,4 +5,5 @@ makeotfexe [WARNING] unhinted <a>
 makeotfexe [WARNING] unhinted <b>
 makeotfexe [WARNING] FontMenuNameDB file was not specified or not found. [SourceSerifPro-Regular]
 makeotfexe [WARNING] Glyph renaming was requested, but the GlyphOrderAndAliasDB file was not specified.
+makeotfexe [WARNING] <SourceSerifPro-Regular> Negative internal leading: win.ascent + win.descent < unitsPerEm
 Built release mode font 'font.otf' Revision 1.000

--- a/tests/makeotf_data/expected_output/t1pfa-dev.ttx
+++ b/tests/makeotf_data/expected_output/t1pfa-dev.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/t1pfa-rel.ttx
+++ b/tests/makeotf_data/expected_output/t1pfa-rel.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/ttf-dev.ttx
+++ b/tests/makeotf_data/expected_output/ttf-dev.ttx
@@ -110,7 +110,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/ttf-rel.ttx
+++ b/tests/makeotf_data/expected_output/ttf-rel.ttx
@@ -110,7 +110,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/ufo2-dev.ttx
+++ b/tests/makeotf_data/expected_output/ufo2-dev.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/ufo2-rel.ttx
+++ b/tests/makeotf_data/expected_output/ufo2-rel.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/ufo3-dev.ttx
+++ b/tests/makeotf_data/expected_output/ufo3-dev.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotf_data/expected_output/ufo3-rel.ttx
+++ b/tests/makeotf_data/expected_output/ufo3-rel.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotfexe_data/expected_output/bug1227.ttx
+++ b/tests/makeotfexe_data/expected_output/bug1227.ttx
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.18">
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="3"/>
+    <xAvgCharWidth value="575"/>
+    <usWeightClass value="800"/>
+    <usWidthClass value="3"/>
+    <fsType value="00000000 00000100"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="240"/>
+    <sFamilyClass value="2053"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="15"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="2"/>
+      <bStrokeVariation value="2"/>
+      <bArmStyle value="8"/>
+      <bLetterForm value="2"/>
+      <bMidline value="9"/>
+      <bXHeight value="4"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000010 00000011"/>
+    <ulUnicodeRange2 value="00011000 10000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="ADBE"/>
+    <fsSelection value="00000000 00000000"/>
+    <usFirstCharIndex value="97"/>
+    <usLastCharIndex value="98"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="600"/>
+    <usWinDescent value="321"/>
+    <ulCodePageRange1 value="00000000 00000010 00000000 00000101"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="400"/>
+    <sCapHeight value="600"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+</ttFont>

--- a/tests/makeotfexe_data/expected_output/bug438.ttx
+++ b/tests/makeotfexe_data/expected_output/bug438.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="660"/>
     <sTypoDescender value="-340"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="988"/>
+    <usWinAscent value="660"/>
     <usWinDescent value="12"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotfexe_data/expected_output/font_dev.ttx
+++ b/tests/makeotfexe_data/expected_output/font_dev.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="739"/>
     <sTypoDescender value="-261"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="987"/>
+    <usWinAscent value="739"/>
     <usWinDescent value="13"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotfexe_data/expected_output/font_dev_output.txt
+++ b/tests/makeotfexe_data/expected_output/font_dev_output.txt
@@ -2,3 +2,4 @@ makeotfexe [WARNING] unhinted <.notdef>
 makeotfexe [WARNING] unhinted <a>
 makeotfexe [WARNING] unhinted <b>
 makeotfexe [WARNING] FontMenuNameDB file was not specified or not found. [SourceSerifPro-Regular]
+makeotfexe [WARNING] <SourceSerifPro-Regular> Negative internal leading: win.ascent + win.descent < unitsPerEm

--- a/tests/makeotfexe_data/expected_output/font_rel.ttx
+++ b/tests/makeotfexe_data/expected_output/font_rel.ttx
@@ -96,7 +96,7 @@
     <sTypoAscender value="739"/>
     <sTypoDescender value="-261"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="987"/>
+    <usWinAscent value="739"/>
     <usWinDescent value="13"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotfexe_data/expected_output/font_rel_output.txt
+++ b/tests/makeotfexe_data/expected_output/font_rel_output.txt
@@ -3,3 +3,4 @@ makeotfexe [WARNING] unhinted <a>
 makeotfexe [WARNING] unhinted <b>
 makeotfexe [WARNING] FontMenuNameDB file was not specified or not found. [SourceSerifPro-Regular]
 makeotfexe [WARNING] Glyph renaming was requested, but the GlyphOrderAndAliasDB file was not specified.
+makeotfexe [WARNING] <SourceSerifPro-Regular> Negative internal leading: win.ascent + win.descent < unitsPerEm

--- a/tests/makeotfexe_data/expected_output/spec/9f-10.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9f-10.ttx
@@ -43,7 +43,7 @@
     <sTypoAscender value="0"/>
     <sTypoDescender value="-1000"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="1000"/>
+    <usWinAscent value="0"/>
     <usWinDescent value="0"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotfexe_data/expected_output/spec/9f-3.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9f-3.ttx
@@ -43,7 +43,7 @@
     <sTypoAscender value="0"/>
     <sTypoDescender value="-1000"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="1000"/>
+    <usWinAscent value="0"/>
     <usWinDescent value="0"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotfexe_data/expected_output/spec/9f-6.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9f-6.ttx
@@ -43,7 +43,7 @@
     <sTypoAscender value="0"/>
     <sTypoDescender value="-1000"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="1000"/>
+    <usWinAscent value="0"/>
     <usWinDescent value="0"/>
     <ulCodePageRange1 value="00000000 00111111 00000001 11111111"/>
     <ulCodePageRange2 value="11111111 11111111 00000000 00000000"/>

--- a/tests/makeotfexe_data/expected_output/spec/9f-7.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9f-7.ttx
@@ -43,7 +43,7 @@
     <sTypoAscender value="0"/>
     <sTypoDescender value="-1000"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="1000"/>
+    <usWinAscent value="0"/>
     <usWinDescent value="0"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotfexe_data/expected_output/spec/9f-9.ttx
+++ b/tests/makeotfexe_data/expected_output/spec/9f-9.ttx
@@ -43,7 +43,7 @@
     <sTypoAscender value="0"/>
     <sTypoDescender value="-1000"/>
     <sTypoLineGap value="200"/>
-    <usWinAscent value="1000"/>
+    <usWinAscent value="0"/>
     <usWinDescent value="0"/>
     <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>

--- a/tests/makeotfexe_data/input/bug1227/bug1227.fea
+++ b/tests/makeotfexe_data/input/bug1227/bug1227.fea
@@ -1,0 +1,20 @@
+table OS/2 {
+    FSType 4;
+    Panose 2 15 0 0 2 2 8 2 9 4;
+    TypoAscender 800;
+    TypoDescender -200; # Note that TypoDescender is negative for descent below the baseline.
+    winAscent 600;
+    winDescent 321; # Note that winDescent is positive for descent below the baseline.
+    UnicodeRange 0 1 9 55 59 60;
+#   0  - Basic Latin,            1  - Latin-1 Supplement
+#   9  - Cyrillic,               55 - CJK Compatibility
+#   59 - CJK Unified Ideographs, 60 - Private Use Area
+   CodePageRange 1252 1251 932;
+#   1252 - Latin 1, 1251 - Cyrllic, 932 - JIS/Japan
+   XHeight 400;
+   CapHeight 600;
+   WeightClass 800;
+   WidthClass 3;
+   Vendor "ADBE";
+   FamilyClass 0x0805;
+} OS/2;

--- a/tests/makeotfexe_test.py
+++ b/tests/makeotfexe_test.py
@@ -688,17 +688,21 @@ def test_spec(path):
                    '    <modified value=',
                    '-r', r'^\s+Version.*;hotconv.*;makeotfexe'])
 
+
 def test_negative_internal_loading_bug1227():
     input_filename = "font.pfa"
     feat_filename = "bug1227/bug1227.fea"
     actual_path = get_temp_file_path()
     ttx_filename = "bug1227.ttx"
-    stderr_path = runner(CMD + ['-s', '-e', '-o', 'f', f'_{get_input_path(input_filename)}',
-                        'ff', f'_{get_input_path(feat_filename)}',
-                        'o', f'_{actual_path}'])
+    stderr_path = runner(
+        CMD + ['-s', '-e', '-o',
+               'f', f'_{get_input_path(input_filename)}',
+               'ff', f'_{get_input_path(feat_filename)}',
+               'o', f'_{actual_path}'])
     actual_ttx = generate_ttx_dump(actual_path, ['OS/2'])
     expected_ttx = get_expected_path(ttx_filename)
     assert differ([expected_ttx, actual_ttx, '-s', '<usWinAscent 600'])
     with open(stderr_path, 'rb') as f:
         output = f.read()
-    assert (b'[WARNING] <SourceSerifPro-Regular> Negative internal leading: win.ascent + win.descent < unitsPerEm') in output
+    assert (b'[WARNING] <SourceSerifPro-Regular> Negative internal leading: '
+            b'win.ascent + win.descent < unitsPerEm') in output

--- a/tests/makeotfexe_test.py
+++ b/tests/makeotfexe_test.py
@@ -687,3 +687,18 @@ def test_spec(path):
                    '    <created value=' + SPLIT_MARKER +
                    '    <modified value=',
                    '-r', r'^\s+Version.*;hotconv.*;makeotfexe'])
+
+def test_negative_internal_loading_bug1227():
+    input_filename = "font.pfa"
+    feat_filename = "bug1227/bug1227.fea"
+    actual_path = get_temp_file_path()
+    ttx_filename = "bug1227.ttx"
+    stderr_path = runner(CMD + ['-s', '-e', '-o', 'f', f'_{get_input_path(input_filename)}',
+                        'ff', f'_{get_input_path(feat_filename)}',
+                        'o', f'_{actual_path}'])
+    actual_ttx = generate_ttx_dump(actual_path, ['OS/2'])
+    expected_ttx = get_expected_path(ttx_filename)
+    assert differ([expected_ttx, actual_ttx, '-s', '<usWinAscent 600'])
+    with open(stderr_path, 'rb') as f:
+        output = f.read()
+    assert (b'[WARNING] <SourceSerifPro-Regular> Negative internal leading: win.ascent + win.descent < unitsPerEm') in output


### PR DESCRIPTION
Also updates expected output for makeotf_test.py and makeotfexe_test.py

Fixes #1227 