### PR TITLE
Do not assume presence of STAT.AxisValueArray

### DIFF
--- a/python/afdko/buildcff2vf.py
+++ b/python/afdko/buildcff2vf.py
@@ -406,7 +406,7 @@ def validate_stat_values(ttFont):
     errors = []
     stat_range_vals = {}
 
-    if hasattr(stat.table.AxisValueArray, "AxisValue"):
+    if hasattr(stat.table, "AxisValueArray.AxisValue"):
         for av in stat.table.AxisValueArray.AxisValue:
             axis_tag = stat.table.DesignAxisRecord.Axis[av.AxisIndex].AxisTag
             if axis_tag not in stat_range_vals:


### PR DESCRIPTION
Same as #1282 – but on a branch (to run the tests).
This fixes #1281 , but I’d like @punchcutter to have a look – it could be that my fix is too simple.