### PR TITLE
Add ignore-contour-order flag to checkoutlinesufo

### DIFF
--- a/python/afdko/checkoutlinesufo.py
+++ b/python/afdko/checkoutlinesufo.py
@@ -250,6 +250,11 @@ def get_options(args):
         help='run in quiet mode'
     )
     parser.add_argument(
+        '--ignore-contour-order',
+        action='store_true',
+        help='do not attempt to restore contour order'
+    )
+    parser.add_argument(
         '--no-overlap-checks',
         action='store_true',
         help='turn off path overlap checks'
@@ -408,6 +413,7 @@ def get_options(args):
     options.check_all = parsed_args.all
     options.clear_hash_map = parsed_args.clear_hash_map
     options.write_to_default_layer = parsed_args.write_to_default_layer
+    options.ignore_contour_order = parsed_args.ignore_contour_order
 
     return options
 
@@ -871,9 +877,9 @@ def sort_contours(c1, c2):
 def restore_contour_order(fixed_glyph, original_contours):
     """ The pyClipper library first sorts all the outlines by x position,
     then y position. I try to undo that, so that un-touched contours will end
-    up in the same order as the in the original, and any conbined contours
+    up in the same order as the in the original, and any combined contours
     will end up in a similar order. The reason I try to match new contours
-    to the old is to reduce arbitraryness in the new contour order between
+    to the old is to reduce arbitrariness in the new contour order between
     similar fonts. I can't completely avoid this, but I can reduce how often
     it happens.
     """
@@ -894,7 +900,7 @@ def restore_contour_order(fixed_glyph, original_contours):
     # Match contours that have not changed.
     # This will fix the order of the contours that have not been touched.
     num_contours = len(new_list)
-    if num_contours > 0:  # If the new contours aren't already all matched..
+    if num_contours > 0:  # If the new contours aren't already all matched.
         for i in range(num_contours):
             ci, contour = new_list[i]
             for j in old_index_list:
@@ -1097,7 +1103,8 @@ def run(args=None):
                 # them prior to restore_contour_order.
                 thresholdAttrGlyph(fixed_glyph, 1)
 
-                restore_contour_order(fixed_glyph, original_contours)
+                if not options.ignore_contour_order:
+                    restore_contour_order(fixed_glyph, original_contours)
 
             # The following is needed when the script is called from another
             # script with Popen():

--- a/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/data/com.adobe.type.processedHashMap
+++ b/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/data/com.adobe.type.processedHashMap
@@ -1,0 +1,4 @@
+{
+'cid51107': ['038da74e3ef78cb1e0d15e3afab6e73231af7ebb1a96ace346fafa9505c60ce58247dbddaa23a073da349b33740bcf9d86b8df389698ced4ec5ee82f3776de57', ['checkOutlines']],
+'hashMapVersion': (1, 0),
+}

--- a/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/fontinfo.plist
+++ b/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/fontinfo.plist
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ascender</key>
+	<integer>800</integer>
+	<key>capHeight</key>
+	<integer>0</integer>
+	<key>descender</key>
+	<integer>-200</integer>
+	<key>familyName</key>
+	<string>outline-test</string>
+	<key>openTypeHeadCreated</key>
+	<string>2021/02/01 17:50:27</string>
+	<key>openTypeNamePreferredSubfamilyName</key>
+	<string>ExtraLight</string>
+	<key>openTypeOS2WeightClass</key>
+	<integer>200</integer>
+	<key>openTypeOS2WidthClass</key>
+	<integer>5</integer>
+	<key>postscriptBlueFuzz</key>
+	<integer>1</integer>
+	<key>postscriptBlueScale</key>
+	<real>0.04</real>
+	<key>postscriptBlueShift</key>
+	<integer>7</integer>
+	<key>postscriptBlueValues</key>
+	<array>
+		<integer>7</integer>
+		<integer>7</integer>
+	</array>
+	<key>postscriptFontName</key>
+	<string>outlineTestExtraLight</string>
+	<key>postscriptOtherBlues</key>
+	<array/>
+	<key>styleMapFamilyName</key>
+	<string>outline-test ExtraLight</string>
+	<key>styleMapStyleName</key>
+	<string>regular</string>
+	<key>styleName</key>
+	<string>ExtraLight</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>versionMajor</key>
+	<integer>1</integer>
+	<key>versionMinor</key>
+	<integer>0</integer>
+	<key>xHeight</key>
+	<integer>0</integer>
+</dict>
+</plist>

--- a/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/glyphs.com.adobe.type.processedglyphs/cid51107.glif
+++ b/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/glyphs.com.adobe.type.processedglyphs/cid51107.glif
@@ -1,0 +1,220 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="cid51107" format="2">
+  <advance width="1000"/>
+  <outline>
+    <contour>
+      <point x="422" y="835" type="line"/>
+      <point x="397" y="809"/>
+      <point x="356" y="772"/>
+      <point x="315" y="738" type="curve"/>
+      <point x="366" y="703"/>
+      <point x="408" y="666"/>
+      <point x="433" y="637" type="curve"/>
+      <point x="469" y="658" type="line"/>
+      <point x="446" y="682"/>
+      <point x="409" y="713"/>
+      <point x="372" y="739" type="curve"/>
+      <point x="402" y="764"/>
+      <point x="434" y="792"/>
+      <point x="463" y="819" type="curve"/>
+    </contour>
+    <contour>
+      <point x="619" y="835" type="line"/>
+      <point x="592" y="809"/>
+      <point x="550" y="772"/>
+      <point x="507" y="738" type="curve"/>
+      <point x="558" y="703"/>
+      <point x="604" y="666"/>
+      <point x="630" y="637" type="curve"/>
+      <point x="666" y="659" type="line"/>
+      <point x="642" y="682"/>
+      <point x="603" y="714"/>
+      <point x="565" y="739" type="curve"/>
+      <point x="596" y="764"/>
+      <point x="631" y="791"/>
+      <point x="660" y="819" type="curve"/>
+    </contour>
+    <contour>
+      <point x="820" y="835" type="line"/>
+      <point x="794" y="809"/>
+      <point x="749" y="772"/>
+      <point x="704" y="738" type="curve"/>
+      <point x="758" y="703"/>
+      <point x="805" y="666"/>
+      <point x="831" y="637" type="curve"/>
+      <point x="867" y="659" type="line"/>
+      <point x="843" y="682"/>
+      <point x="803" y="714"/>
+      <point x="763" y="739" type="curve"/>
+      <point x="796" y="764"/>
+      <point x="831" y="791"/>
+      <point x="863" y="818" type="curve"/>
+    </contour>
+    <contour>
+      <point x="83" y="814" type="line"/>
+      <point x="124" y="764"/>
+      <point x="175" y="694"/>
+      <point x="198" y="652" type="curve"/>
+      <point x="238" y="676" type="line"/>
+      <point x="214" y="718"/>
+      <point x="163" y="784"/>
+      <point x="121" y="834" type="curve"/>
+    </contour>
+    <contour>
+      <point x="333" y="634" type="line"/>
+      <point x="333" y="418" type="line"/>
+      <point x="879" y="418" type="line"/>
+      <point x="879" y="634" type="line"/>
+    </contour>
+    <contour>
+      <point x="61" y="296" type="curve"/>
+      <point x="68" y="302"/>
+      <point x="93" y="309"/>
+      <point x="117" y="309" type="curve" smooth="yes"/>
+      <point x="224" y="309" type="line"/>
+      <point x="193" y="143"/>
+      <point x="126" y="26"/>
+      <point x="37" y="-40" type="curve"/>
+      <point x="48" y="-47"/>
+      <point x="64" y="-64"/>
+      <point x="71" y="-74" type="curve"/>
+      <point x="120" y="-37"/>
+      <point x="163" y="16"/>
+      <point x="198" y="84" type="curve"/>
+      <point x="277" y="-38"/>
+      <point x="409" y="-59"/>
+      <point x="629" y="-59" type="curve" smooth="yes"/>
+      <point x="734" y="-59"/>
+      <point x="860" y="-57"/>
+      <point x="948" y="-51" type="curve"/>
+      <point x="951" y="-38"/>
+      <point x="957" y="-15"/>
+      <point x="965" y="-4" type="curve"/>
+      <point x="868" y="-13"/>
+      <point x="733" y="-15"/>
+      <point x="628" y="-15" type="curve" smooth="yes"/>
+      <point x="422" y="-15"/>
+      <point x="285" y="2"/>
+      <point x="217" y="124" type="curve"/>
+      <point x="243" y="186"/>
+      <point x="263" y="259"/>
+      <point x="276" y="343" type="curve"/>
+      <point x="251" y="353" type="line"/>
+      <point x="242" y="352" type="line"/>
+      <point x="118" y="352" type="line"/>
+      <point x="170" y="419"/>
+      <point x="243" y="534"/>
+      <point x="282" y="594" type="curve"/>
+      <point x="245" y="610" type="line"/>
+      <point x="235" y="605" type="line"/>
+      <point x="46" y="605" type="line"/>
+      <point x="46" y="561" type="line"/>
+      <point x="207" y="561" type="line"/>
+      <point x="168" y="497"/>
+      <point x="106" y="399"/>
+      <point x="83" y="375" type="curve"/>
+      <point x="68" y="356"/>
+      <point x="53" y="350"/>
+      <point x="40" y="346" type="curve"/>
+      <point x="46" y="334"/>
+      <point x="58" y="309"/>
+    </contour>
+    <contour>
+      <point x="379" y="597" type="line"/>
+      <point x="616" y="597" type="line"/>
+      <point x="579" y="547"/>
+      <point x="499" y="510"/>
+      <point x="423" y="486" type="curve"/>
+      <point x="433" y="480"/>
+      <point x="446" y="466"/>
+      <point x="452" y="458" type="curve"/>
+      <point x="500" y="476"/>
+      <point x="552" y="500"/>
+      <point x="594" y="529" type="curve"/>
+      <point x="654" y="507"/>
+      <point x="727" y="476"/>
+      <point x="767" y="457" type="curve"/>
+      <point x="785" y="485" type="line"/>
+      <point x="746" y="503"/>
+      <point x="678" y="529"/>
+      <point x="619" y="550" type="curve"/>
+      <point x="633" y="562"/>
+      <point x="645" y="574"/>
+      <point x="654" y="588" type="curve"/>
+      <point x="616" y="597" type="line"/>
+      <point x="833" y="597" type="line"/>
+      <point x="833" y="455" type="line"/>
+      <point x="379" y="455" type="line"/>
+    </contour>
+    <contour>
+      <point x="789" y="398" type="line"/>
+      <point x="789" y="192"/>
+      <point x="815" y="26"/>
+      <point x="891" y="26" type="curve" smooth="yes"/>
+      <point x="915" y="26"/>
+      <point x="931" y="55"/>
+      <point x="939" y="133" type="curve"/>
+      <point x="930" y="137"/>
+      <point x="917" y="145"/>
+      <point x="908" y="153" type="curve"/>
+      <point x="905" y="97"/>
+      <point x="896" y="72"/>
+      <point x="888" y="72" type="curve" smooth="yes"/>
+      <point x="851" y="72"/>
+      <point x="829" y="207"/>
+      <point x="831" y="398" type="curve"/>
+    </contour>
+    <contour>
+      <point x="349" y="31" type="curve"/>
+      <point x="361" y="38"/>
+      <point x="383" y="46"/>
+      <point x="538" y="88" type="curve"/>
+      <point x="535" y="97"/>
+      <point x="533" y="111"/>
+      <point x="531" y="122" type="curve"/>
+      <point x="404" y="94" type="line"/>
+      <point x="404" y="190" type="line"/>
+      <point x="538" y="190" type="line"/>
+      <point x="538" y="227" type="line"/>
+      <point x="404" y="227" type="line"/>
+      <point x="404" y="297" type="line"/>
+      <point x="537" y="297" type="line"/>
+      <point x="537" y="335" type="line"/>
+      <point x="404" y="335" type="line"/>
+      <point x="404" y="396" type="line"/>
+      <point x="361" y="396" type="line"/>
+      <point x="361" y="116" type="line" smooth="yes"/>
+      <point x="361" y="83"/>
+      <point x="345" y="78"/>
+      <point x="332" y="75" type="curve"/>
+      <point x="338" y="63"/>
+      <point x="346" y="42"/>
+    </contour>
+    <contour>
+      <point x="573" y="33" type="curve"/>
+      <point x="585" y="40"/>
+      <point x="608" y="48"/>
+      <point x="767" y="90" type="curve"/>
+      <point x="765" y="98"/>
+      <point x="763" y="113"/>
+      <point x="761" y="124" type="curve"/>
+      <point x="629" y="95" type="line"/>
+      <point x="629" y="190" type="line"/>
+      <point x="759" y="190" type="line"/>
+      <point x="759" y="227" type="line"/>
+      <point x="629" y="227" type="line"/>
+      <point x="629" y="297" type="line"/>
+      <point x="759" y="297" type="line"/>
+      <point x="759" y="335" type="line"/>
+      <point x="629" y="335" type="line"/>
+      <point x="629" y="393" type="line"/>
+      <point x="585" y="393" type="line"/>
+      <point x="585" y="118" type="line" smooth="yes"/>
+      <point x="585" y="85"/>
+      <point x="570" y="80"/>
+      <point x="557" y="77" type="curve"/>
+      <point x="563" y="65"/>
+      <point x="571" y="44"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/glyphs.com.adobe.type.processedglyphs/contents.plist
+++ b/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/glyphs.com.adobe.type.processedglyphs/contents.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>cid51107</key>
+    <string>cid51107.glif</string>
+  </dict>
+</plist>

--- a/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/glyphs/cid51107.glif
+++ b/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/glyphs/cid51107.glif
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="cid51107" format="2">
+	<advance width="1000"/>
+	<outline>
+		<contour>
+			<point x="379" y="597" type="line"/>
+			<point x="833" y="597" type="line"/>
+			<point x="833" y="455" type="line"/>
+			<point x="379" y="455" type="line"/>
+		</contour>
+		<contour>
+			<point x="333" y="634" type="line"/>
+			<point x="333" y="418" type="line"/>
+			<point x="879" y="418" type="line"/>
+			<point x="879" y="634" type="line"/>
+		</contour>
+		<contour>
+			<point x="422" y="835" type="line"/>
+			<point x="397" y="809"/>
+			<point x="356" y="772"/>
+			<point x="315" y="738" type="curve"/>
+			<point x="366" y="703"/>
+			<point x="408" y="666"/>
+			<point x="433" y="637" type="curve"/>
+			<point x="469" y="658" type="line"/>
+			<point x="446" y="682"/>
+			<point x="409" y="713"/>
+			<point x="372" y="739" type="curve"/>
+			<point x="402" y="764"/>
+			<point x="434" y="792"/>
+			<point x="463" y="819" type="curve"/>
+		</contour>
+		<contour>
+			<point x="619" y="835" type="line"/>
+			<point x="592" y="809"/>
+			<point x="550" y="772"/>
+			<point x="507" y="738" type="curve"/>
+			<point x="558" y="703"/>
+			<point x="604" y="666"/>
+			<point x="630" y="637" type="curve"/>
+			<point x="666" y="659" type="line"/>
+			<point x="642" y="682"/>
+			<point x="603" y="714"/>
+			<point x="565" y="739" type="curve"/>
+			<point x="596" y="764"/>
+			<point x="631" y="791"/>
+			<point x="660" y="819" type="curve"/>
+		</contour>
+		<contour>
+			<point x="820" y="835" type="line"/>
+			<point x="794" y="809"/>
+			<point x="749" y="772"/>
+			<point x="704" y="738" type="curve"/>
+			<point x="758" y="703"/>
+			<point x="805" y="666"/>
+			<point x="831" y="637" type="curve"/>
+			<point x="867" y="659" type="line"/>
+			<point x="843" y="682"/>
+			<point x="803" y="714"/>
+			<point x="763" y="739" type="curve"/>
+			<point x="796" y="764"/>
+			<point x="831" y="791"/>
+			<point x="863" y="818" type="curve"/>
+		</contour>
+		<contour>
+			<point x="789" y="398" type="line"/>
+			<point x="789" y="192"/>
+			<point x="815" y="26"/>
+			<point x="891" y="26" type="curve"/>
+			<point x="915" y="26"/>
+			<point x="931" y="55"/>
+			<point x="939" y="133" type="curve"/>
+			<point x="930" y="137"/>
+			<point x="917" y="145"/>
+			<point x="908" y="153" type="curve"/>
+			<point x="905" y="97"/>
+			<point x="896" y="72"/>
+			<point x="888" y="72" type="curve"/>
+			<point x="851" y="72"/>
+			<point x="829" y="207"/>
+			<point x="831" y="398" type="curve"/>
+		</contour>
+		<contour>
+			<point x="387" y="335" type="line"/>
+			<point x="387" y="297" type="line"/>
+			<point x="537" y="297" type="line"/>
+			<point x="537" y="335" type="line"/>
+		</contour>
+		<contour>
+			<point x="388" y="227" type="line"/>
+			<point x="388" y="190" type="line"/>
+			<point x="538" y="190" type="line"/>
+			<point x="538" y="227" type="line"/>
+		</contour>
+		<contour>
+			<point x="349" y="31" type="line"/>
+			<point x="361" y="38"/>
+			<point x="383" y="46"/>
+			<point x="538" y="88" type="curve"/>
+			<point x="535" y="97"/>
+			<point x="533" y="111"/>
+			<point x="531" y="122" type="curve"/>
+			<point x="370" y="86" type="line"/>
+			<point x="348" y="67" type="line"/>
+		</contour>
+		<contour>
+			<point x="349" y="31" type="curve"/>
+			<point x="349" y="46"/>
+			<point x="404" y="64"/>
+			<point x="404" y="64" type="curve"/>
+			<point x="404" y="396" type="line"/>
+			<point x="361" y="396" type="line"/>
+			<point x="361" y="116" type="line"/>
+			<point x="361" y="83"/>
+			<point x="345" y="78"/>
+			<point x="332" y="75" type="curve"/>
+			<point x="338" y="63"/>
+			<point x="346" y="42"/>
+		</contour>
+		<contour>
+			<point x="573" y="33" type="line"/>
+			<point x="585" y="40"/>
+			<point x="608" y="48"/>
+			<point x="767" y="90" type="curve"/>
+			<point x="765" y="98"/>
+			<point x="763" y="113"/>
+			<point x="761" y="124" type="curve"/>
+			<point x="595" y="88" type="line"/>
+			<point x="572" y="69" type="line"/>
+		</contour>
+		<contour>
+			<point x="573" y="33" type="curve"/>
+			<point x="573" y="48"/>
+			<point x="629" y="66"/>
+			<point x="629" y="66" type="curve"/>
+			<point x="629" y="393" type="line"/>
+			<point x="585" y="393" type="line"/>
+			<point x="585" y="118" type="line"/>
+			<point x="585" y="85"/>
+			<point x="570" y="80"/>
+			<point x="557" y="77" type="curve"/>
+			<point x="563" y="65"/>
+			<point x="571" y="44"/>
+		</contour>
+		<contour>
+			<point x="601" y="335" type="line"/>
+			<point x="601" y="297" type="line"/>
+			<point x="759" y="297" type="line"/>
+			<point x="759" y="335" type="line"/>
+		</contour>
+		<contour>
+			<point x="602" y="227" type="line"/>
+			<point x="602" y="190" type="line"/>
+			<point x="759" y="190" type="line"/>
+			<point x="759" y="227" type="line"/>
+		</contour>
+		<contour>
+			<point x="616" y="597" type="line"/>
+			<point x="579" y="547"/>
+			<point x="499" y="510"/>
+			<point x="423" y="486" type="curve"/>
+			<point x="433" y="480"/>
+			<point x="446" y="466"/>
+			<point x="452" y="458" type="curve"/>
+			<point x="529" y="486"/>
+			<point x="614" y="530"/>
+			<point x="654" y="588" type="curve"/>
+		</contour>
+		<contour>
+			<point x="578" y="535" type="line"/>
+			<point x="641" y="512"/>
+			<point x="724" y="478"/>
+			<point x="767" y="457" type="curve"/>
+			<point x="785" y="485" type="line"/>
+			<point x="741" y="505"/>
+			<point x="658" y="537"/>
+			<point x="595" y="558" type="curve"/>
+		</contour>
+		<contour>
+			<point x="83" y="814" type="line"/>
+			<point x="124" y="764"/>
+			<point x="175" y="694"/>
+			<point x="198" y="652" type="curve"/>
+			<point x="238" y="676" type="line"/>
+			<point x="214" y="718"/>
+			<point x="163" y="784"/>
+			<point x="121" y="834" type="curve"/>
+		</contour>
+		<contour>
+			<point x="46" y="605" type="line"/>
+			<point x="46" y="561" type="line"/>
+			<point x="244" y="561" type="line"/>
+			<point x="244" y="605" type="line"/>
+		</contour>
+		<contour>
+			<point x="212" y="133" type="curve"/>
+			<point x="180" y="115" type="line"/>
+			<point x="257" y="-34"/>
+			<point x="392" y="-59"/>
+			<point x="629" y="-59" type="curve"/>
+			<point x="734" y="-59"/>
+			<point x="860" y="-57"/>
+			<point x="948" y="-51" type="curve"/>
+			<point x="951" y="-38"/>
+			<point x="957" y="-15"/>
+			<point x="965" y="-4" type="curve"/>
+			<point x="868" y="-13"/>
+			<point x="733" y="-15"/>
+			<point x="628" y="-15" type="curve"/>
+			<point x="417" y="-15"/>
+			<point x="279" y="3"/>
+		</contour>
+		<contour>
+			<point x="229" y="352" type="line"/>
+			<point x="229" y="342" type="line"/>
+			<point x="202" y="159"/>
+			<point x="132" y="30"/>
+			<point x="37" y="-40" type="curve"/>
+			<point x="48" y="-47"/>
+			<point x="64" y="-64"/>
+			<point x="71" y="-74" type="curve"/>
+			<point x="170" y="1"/>
+			<point x="245" y="139"/>
+			<point x="276" y="343" type="curve"/>
+			<point x="251" y="353" type="line"/>
+			<point x="242" y="352" type="line"/>
+		</contour>
+		<contour>
+			<point x="61" y="296" type="line"/>
+			<point x="68" y="302"/>
+			<point x="93" y="309"/>
+			<point x="117" y="309" type="curve"/>
+			<point x="243" y="309" type="line"/>
+			<point x="243" y="352" type="line"/>
+			<point x="93" y="352" type="line"/>
+			<point x="61" y="337" type="line"/>
+		</contour>
+		<contour>
+			<point x="61" y="296" type="curve"/>
+			<point x="61" y="311"/>
+			<point x="103" y="333"/>
+			<point x="103" y="333" type="curve"/>
+			<point x="155" y="394"/>
+			<point x="239" y="528"/>
+			<point x="282" y="594" type="curve"/>
+			<point x="245" y="610" type="line"/>
+			<point x="229" y="602" type="line"/>
+			<point x="229" y="599" type="line"/>
+			<point x="200" y="548"/>
+			<point x="112" y="405"/>
+			<point x="83" y="375" type="curve"/>
+			<point x="68" y="356"/>
+			<point x="53" y="350"/>
+			<point x="40" y="346" type="curve"/>
+			<point x="46" y="334"/>
+			<point x="58" y="309"/>
+		</contour>
+	</outline>
+	<lib>
+		<dict>
+			<key>com.schriftgestaltung.Glyphs.lastChange</key>
+			<string>2021-02-01 08:55:45 +0000</string>
+		</dict>
+	</lib>
+</glyph>

--- a/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/glyphs/contents.plist
+++ b/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/glyphs/contents.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>cid51107</key>
+	<string>cid51107.glif</string>
+</dict>
+</plist>

--- a/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/layercontents.plist
+++ b/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/layercontents.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+    <array>
+      <string>com.adobe.type.processedglyphs</string>
+      <string>glyphs.com.adobe.type.processedglyphs</string>
+    </array>
+  </array>
+</plist>

--- a/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/lib.plist
+++ b/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/lib.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.schriftgestaltung.DisplayStrings</key>
+	<array/>
+	<key>com.schriftgestaltung.disablesAutomaticAlignment</key>
+	<true/>
+	<key>com.schriftgestaltung.font.customParameters</key>
+	<array>
+		<dict>
+			<key>name</key>
+			<string>glyphOrder</string>
+			<key>value</key>
+			<array>
+				<string>cid51107</string>
+			</array>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>glyphOrder</string>
+			<key>value</key>
+			<array>
+				<string>cid51107</string>
+			</array>
+		</dict>
+	</array>
+	<key>com.schriftgestaltung.fontMasterID</key>
+	<string>master01</string>
+	<key>com.schriftgestaltung.glyphOrder</key>
+	<array>
+		<string>cid51107</string>
+	</array>
+	<key>com.schriftgestaltung.useNiceNames</key>
+	<false/>
+	<key>public.glyphOrder</key>
+	<array>
+		<string>cid51107</string>
+	</array>
+</dict>
+</plist>

--- a/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/metainfo.plist
+++ b/tests/checkoutlinesufo_data/expected_output/contour-restore-ignored.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/tests/checkoutlinesufo_data/input/contour-restore.ufo/fontinfo.plist
+++ b/tests/checkoutlinesufo_data/input/contour-restore.ufo/fontinfo.plist
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ascender</key>
+	<integer>800</integer>
+	<key>capHeight</key>
+	<integer>0</integer>
+	<key>descender</key>
+	<integer>-200</integer>
+	<key>familyName</key>
+	<string>outline-test</string>
+	<key>openTypeHeadCreated</key>
+	<string>2021/02/01 17:50:27</string>
+	<key>openTypeNamePreferredSubfamilyName</key>
+	<string>ExtraLight</string>
+	<key>openTypeOS2WeightClass</key>
+	<integer>200</integer>
+	<key>openTypeOS2WidthClass</key>
+	<integer>5</integer>
+	<key>postscriptBlueFuzz</key>
+	<integer>1</integer>
+	<key>postscriptBlueScale</key>
+	<real>0.04</real>
+	<key>postscriptBlueShift</key>
+	<integer>7</integer>
+	<key>postscriptBlueValues</key>
+	<array>
+		<integer>7</integer>
+		<integer>7</integer>
+	</array>
+	<key>postscriptFontName</key>
+	<string>outlineTestExtraLight</string>
+	<key>postscriptOtherBlues</key>
+	<array/>
+	<key>styleMapFamilyName</key>
+	<string>outline-test ExtraLight</string>
+	<key>styleMapStyleName</key>
+	<string>regular</string>
+	<key>styleName</key>
+	<string>ExtraLight</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>versionMajor</key>
+	<integer>1</integer>
+	<key>versionMinor</key>
+	<integer>0</integer>
+	<key>xHeight</key>
+	<integer>0</integer>
+</dict>
+</plist>

--- a/tests/checkoutlinesufo_data/input/contour-restore.ufo/glyphs/cid51107.glif
+++ b/tests/checkoutlinesufo_data/input/contour-restore.ufo/glyphs/cid51107.glif
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="cid51107" format="2">
+	<advance width="1000"/>
+	<outline>
+		<contour>
+			<point x="379" y="597" type="line"/>
+			<point x="833" y="597" type="line"/>
+			<point x="833" y="455" type="line"/>
+			<point x="379" y="455" type="line"/>
+		</contour>
+		<contour>
+			<point x="333" y="634" type="line"/>
+			<point x="333" y="418" type="line"/>
+			<point x="879" y="418" type="line"/>
+			<point x="879" y="634" type="line"/>
+		</contour>
+		<contour>
+			<point x="422" y="835" type="line"/>
+			<point x="397" y="809"/>
+			<point x="356" y="772"/>
+			<point x="315" y="738" type="curve"/>
+			<point x="366" y="703"/>
+			<point x="408" y="666"/>
+			<point x="433" y="637" type="curve"/>
+			<point x="469" y="658" type="line"/>
+			<point x="446" y="682"/>
+			<point x="409" y="713"/>
+			<point x="372" y="739" type="curve"/>
+			<point x="402" y="764"/>
+			<point x="434" y="792"/>
+			<point x="463" y="819" type="curve"/>
+		</contour>
+		<contour>
+			<point x="619" y="835" type="line"/>
+			<point x="592" y="809"/>
+			<point x="550" y="772"/>
+			<point x="507" y="738" type="curve"/>
+			<point x="558" y="703"/>
+			<point x="604" y="666"/>
+			<point x="630" y="637" type="curve"/>
+			<point x="666" y="659" type="line"/>
+			<point x="642" y="682"/>
+			<point x="603" y="714"/>
+			<point x="565" y="739" type="curve"/>
+			<point x="596" y="764"/>
+			<point x="631" y="791"/>
+			<point x="660" y="819" type="curve"/>
+		</contour>
+		<contour>
+			<point x="820" y="835" type="line"/>
+			<point x="794" y="809"/>
+			<point x="749" y="772"/>
+			<point x="704" y="738" type="curve"/>
+			<point x="758" y="703"/>
+			<point x="805" y="666"/>
+			<point x="831" y="637" type="curve"/>
+			<point x="867" y="659" type="line"/>
+			<point x="843" y="682"/>
+			<point x="803" y="714"/>
+			<point x="763" y="739" type="curve"/>
+			<point x="796" y="764"/>
+			<point x="831" y="791"/>
+			<point x="863" y="818" type="curve"/>
+		</contour>
+		<contour>
+			<point x="789" y="398" type="line"/>
+			<point x="789" y="192"/>
+			<point x="815" y="26"/>
+			<point x="891" y="26" type="curve"/>
+			<point x="915" y="26"/>
+			<point x="931" y="55"/>
+			<point x="939" y="133" type="curve"/>
+			<point x="930" y="137"/>
+			<point x="917" y="145"/>
+			<point x="908" y="153" type="curve"/>
+			<point x="905" y="97"/>
+			<point x="896" y="72"/>
+			<point x="888" y="72" type="curve"/>
+			<point x="851" y="72"/>
+			<point x="829" y="207"/>
+			<point x="831" y="398" type="curve"/>
+		</contour>
+		<contour>
+			<point x="387" y="335" type="line"/>
+			<point x="387" y="297" type="line"/>
+			<point x="537" y="297" type="line"/>
+			<point x="537" y="335" type="line"/>
+		</contour>
+		<contour>
+			<point x="388" y="227" type="line"/>
+			<point x="388" y="190" type="line"/>
+			<point x="538" y="190" type="line"/>
+			<point x="538" y="227" type="line"/>
+		</contour>
+		<contour>
+			<point x="349" y="31" type="line"/>
+			<point x="361" y="38"/>
+			<point x="383" y="46"/>
+			<point x="538" y="88" type="curve"/>
+			<point x="535" y="97"/>
+			<point x="533" y="111"/>
+			<point x="531" y="122" type="curve"/>
+			<point x="370" y="86" type="line"/>
+			<point x="348" y="67" type="line"/>
+		</contour>
+		<contour>
+			<point x="349" y="31" type="curve"/>
+			<point x="349" y="46"/>
+			<point x="404" y="64"/>
+			<point x="404" y="64" type="curve"/>
+			<point x="404" y="396" type="line"/>
+			<point x="361" y="396" type="line"/>
+			<point x="361" y="116" type="line"/>
+			<point x="361" y="83"/>
+			<point x="345" y="78"/>
+			<point x="332" y="75" type="curve"/>
+			<point x="338" y="63"/>
+			<point x="346" y="42"/>
+		</contour>
+		<contour>
+			<point x="573" y="33" type="line"/>
+			<point x="585" y="40"/>
+			<point x="608" y="48"/>
+			<point x="767" y="90" type="curve"/>
+			<point x="765" y="98"/>
+			<point x="763" y="113"/>
+			<point x="761" y="124" type="curve"/>
+			<point x="595" y="88" type="line"/>
+			<point x="572" y="69" type="line"/>
+		</contour>
+		<contour>
+			<point x="573" y="33" type="curve"/>
+			<point x="573" y="48"/>
+			<point x="629" y="66"/>
+			<point x="629" y="66" type="curve"/>
+			<point x="629" y="393" type="line"/>
+			<point x="585" y="393" type="line"/>
+			<point x="585" y="118" type="line"/>
+			<point x="585" y="85"/>
+			<point x="570" y="80"/>
+			<point x="557" y="77" type="curve"/>
+			<point x="563" y="65"/>
+			<point x="571" y="44"/>
+		</contour>
+		<contour>
+			<point x="601" y="335" type="line"/>
+			<point x="601" y="297" type="line"/>
+			<point x="759" y="297" type="line"/>
+			<point x="759" y="335" type="line"/>
+		</contour>
+		<contour>
+			<point x="602" y="227" type="line"/>
+			<point x="602" y="190" type="line"/>
+			<point x="759" y="190" type="line"/>
+			<point x="759" y="227" type="line"/>
+		</contour>
+		<contour>
+			<point x="616" y="597" type="line"/>
+			<point x="579" y="547"/>
+			<point x="499" y="510"/>
+			<point x="423" y="486" type="curve"/>
+			<point x="433" y="480"/>
+			<point x="446" y="466"/>
+			<point x="452" y="458" type="curve"/>
+			<point x="529" y="486"/>
+			<point x="614" y="530"/>
+			<point x="654" y="588" type="curve"/>
+		</contour>
+		<contour>
+			<point x="578" y="535" type="line"/>
+			<point x="641" y="512"/>
+			<point x="724" y="478"/>
+			<point x="767" y="457" type="curve"/>
+			<point x="785" y="485" type="line"/>
+			<point x="741" y="505"/>
+			<point x="658" y="537"/>
+			<point x="595" y="558" type="curve"/>
+		</contour>
+		<contour>
+			<point x="83" y="814" type="line"/>
+			<point x="124" y="764"/>
+			<point x="175" y="694"/>
+			<point x="198" y="652" type="curve"/>
+			<point x="238" y="676" type="line"/>
+			<point x="214" y="718"/>
+			<point x="163" y="784"/>
+			<point x="121" y="834" type="curve"/>
+		</contour>
+		<contour>
+			<point x="46" y="605" type="line"/>
+			<point x="46" y="561" type="line"/>
+			<point x="244" y="561" type="line"/>
+			<point x="244" y="605" type="line"/>
+		</contour>
+		<contour>
+			<point x="212" y="133" type="curve"/>
+			<point x="180" y="115" type="line"/>
+			<point x="257" y="-34"/>
+			<point x="392" y="-59"/>
+			<point x="629" y="-59" type="curve"/>
+			<point x="734" y="-59"/>
+			<point x="860" y="-57"/>
+			<point x="948" y="-51" type="curve"/>
+			<point x="951" y="-38"/>
+			<point x="957" y="-15"/>
+			<point x="965" y="-4" type="curve"/>
+			<point x="868" y="-13"/>
+			<point x="733" y="-15"/>
+			<point x="628" y="-15" type="curve"/>
+			<point x="417" y="-15"/>
+			<point x="279" y="3"/>
+		</contour>
+		<contour>
+			<point x="229" y="352" type="line"/>
+			<point x="229" y="342" type="line"/>
+			<point x="202" y="159"/>
+			<point x="132" y="30"/>
+			<point x="37" y="-40" type="curve"/>
+			<point x="48" y="-47"/>
+			<point x="64" y="-64"/>
+			<point x="71" y="-74" type="curve"/>
+			<point x="170" y="1"/>
+			<point x="245" y="139"/>
+			<point x="276" y="343" type="curve"/>
+			<point x="251" y="353" type="line"/>
+			<point x="242" y="352" type="line"/>
+		</contour>
+		<contour>
+			<point x="61" y="296" type="line"/>
+			<point x="68" y="302"/>
+			<point x="93" y="309"/>
+			<point x="117" y="309" type="curve"/>
+			<point x="243" y="309" type="line"/>
+			<point x="243" y="352" type="line"/>
+			<point x="93" y="352" type="line"/>
+			<point x="61" y="337" type="line"/>
+		</contour>
+		<contour>
+			<point x="61" y="296" type="curve"/>
+			<point x="61" y="311"/>
+			<point x="103" y="333"/>
+			<point x="103" y="333" type="curve"/>
+			<point x="155" y="394"/>
+			<point x="239" y="528"/>
+			<point x="282" y="594" type="curve"/>
+			<point x="245" y="610" type="line"/>
+			<point x="229" y="602" type="line"/>
+			<point x="229" y="599" type="line"/>
+			<point x="200" y="548"/>
+			<point x="112" y="405"/>
+			<point x="83" y="375" type="curve"/>
+			<point x="68" y="356"/>
+			<point x="53" y="350"/>
+			<point x="40" y="346" type="curve"/>
+			<point x="46" y="334"/>
+			<point x="58" y="309"/>
+		</contour>
+	</outline>
+	<lib>
+		<dict>
+			<key>com.schriftgestaltung.Glyphs.lastChange</key>
+			<string>2021-02-01 08:55:45 +0000</string>
+		</dict>
+	</lib>
+</glyph>

--- a/tests/checkoutlinesufo_data/input/contour-restore.ufo/glyphs/contents.plist
+++ b/tests/checkoutlinesufo_data/input/contour-restore.ufo/glyphs/contents.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>cid51107</key>
+	<string>cid51107.glif</string>
+</dict>
+</plist>

--- a/tests/checkoutlinesufo_data/input/contour-restore.ufo/layercontents.plist
+++ b/tests/checkoutlinesufo_data/input/contour-restore.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<array>
+		<string>public.default</string>
+		<string>glyphs</string>
+	</array>
+</array>
+</plist>

--- a/tests/checkoutlinesufo_data/input/contour-restore.ufo/lib.plist
+++ b/tests/checkoutlinesufo_data/input/contour-restore.ufo/lib.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.schriftgestaltung.DisplayStrings</key>
+	<array/>
+	<key>com.schriftgestaltung.disablesAutomaticAlignment</key>
+	<true/>
+	<key>com.schriftgestaltung.font.customParameters</key>
+	<array>
+		<dict>
+			<key>name</key>
+			<string>glyphOrder</string>
+			<key>value</key>
+			<array>
+				<string>cid51107</string>
+			</array>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>glyphOrder</string>
+			<key>value</key>
+			<array>
+				<string>cid51107</string>
+			</array>
+		</dict>
+	</array>
+	<key>com.schriftgestaltung.fontMasterID</key>
+	<string>master01</string>
+	<key>com.schriftgestaltung.glyphOrder</key>
+	<array>
+		<string>cid51107</string>
+	</array>
+	<key>com.schriftgestaltung.useNiceNames</key>
+	<false/>
+	<key>public.glyphOrder</key>
+	<array>
+		<string>cid51107</string>
+	</array>
+</dict>
+</plist>

--- a/tests/checkoutlinesufo_data/input/contour-restore.ufo/metainfo.plist
+++ b/tests/checkoutlinesufo_data/input/contour-restore.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>creator</key>
+	<string>com.schriftgestaltung.GlyphsUFOExport</string>
+	<key>formatVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/tests/checkoutlinesufo_test.py
+++ b/tests/checkoutlinesufo_test.py
@@ -132,3 +132,19 @@ def test_output_file_option(input_font, expected_font):
 
     assert get_font_format(out_path) == get_font_format(in_path)
     assert differ([expected_path, out_path])
+
+
+@pytest.mark.parametrize('input_font, expected_font', [
+    ('contour-restore.ufo', 'contour-restore-ignored.ufo'),
+])
+def test_ignore_contour_order(input_font, expected_font):
+    """
+    Test the '--ignore-contour-order' option.
+    """
+    in_path = get_input_path(input_font)
+    out_path = os.path.join(get_temp_dir_path(), input_font)
+    expected_path = get_expected_path(expected_font)
+    runner(CMD + ['-f', in_path, '-o', '=ignore-contour-order', '=all', 'e',
+                  'q', 'o', '_' + out_path])
+    assert get_font_format(out_path) == get_font_format(in_path)
+    assert differ([expected_path, out_path, '-r', r'^\s*<point'])


### PR DESCRIPTION
In some situations we have no use for attempting to restore the contour order so force it to be skipped with the `--ignore-contour-order` flag. 