### PR TITLE
Make sure format 3 post table doesn't break makeotf

### DIFF
--- a/python/afdko/makeotf.py
+++ b/python/afdko/makeotf.py
@@ -2332,6 +2332,7 @@ def fixPost(glyphList, font):
             extraNamesList.append(gname)
 
     post_table = font['post']
+    post_table.mapping = {}
     post_table.formatType = 2
     post_table.glyphOrder = glyphOrderList
     post_table.extraNames = extraNamesList


### PR DESCRIPTION
## Description

According to the https://github.com/fonttools/fonttools/issues/2178#issuecomment-774528018, it makes sure script doesn't fail on attempt to convert format 3 post table to format 2.

Fixes #1301