### PR TITLE
[buildcff2vf] clarify reason for VarLibCFFPointTypeMergeErrors

### DIFF
--- a/python/afdko/buildcff2vf.py
+++ b/python/afdko/buildcff2vf.py
@@ -35,6 +35,7 @@ class CFF2VFError(Exception):
 class CFF2VFCompatibilizationError(VarLibCFFPointTypeMergeError):
     """To distinguish when raised during compatibilization"""
 
+
 # set up for printing progress notes
 def progress(self, message, *args, **kws):
     # Note: message must contain the format specifiers for any strings in args.

--- a/python/afdko/buildcff2vf.py
+++ b/python/afdko/buildcff2vf.py
@@ -32,6 +32,9 @@ class CFF2VFError(Exception):
     """Base exception for buildcff2vf"""
 
 
+class CFF2VFCompatibilizationError(VarLibCFFPointTypeMergeError):
+    """To distinguish when raised during compatibilization"""
+
 # set up for printing progress notes
 def progress(self, message, *args, **kws):
     # Note: message must contain the format specifiers for any strings in args.
@@ -569,9 +572,12 @@ def main(args=None):
     # fonts without having to recompile and save them.
     try:
         varFont, _, _ = varLib.build(designspace, otfFinder)
-    except VarLibCFFPointTypeMergeError:
-        logger.error("The input set requires compatibilization. Please try "
-                     "again with the -c (--check-compat) option.")
+    except VarLibCFFPointTypeMergeError as exc:
+        msg = str(exc)
+        if not isinstance(exc, CFF2VFCompatibilizationError):
+            # if not in --check-compat mode, add suggestion to try
+            msg += ". Please try again with the -c (--check-compat) option."
+        logger.error(msg)
         return 0
 
     if not options.keep_glyph_names:

--- a/tests/buildcff2vf_test.py
+++ b/tests/buildcff2vf_test.py
@@ -90,7 +90,7 @@ def test_subset_vf():
 
 def test_bug1003(capfd):
     """
-    Check that "the input set requires compatibilization" message is in
+    Check that the underlying fontTools.varLib exception message is in
     stderr when run without '-c' option.
     """
     input_dir = get_input_path('bug1003')
@@ -99,7 +99,10 @@ def test_bug1003(capfd):
     ds_path = os.path.join(temp_dir, 'bug1003.designspace')
     runner(CMD + ['-o', 'd', f'_{ds_path}'])
     captured = capfd.readouterr()
-    assert "The input set requires compatibilization" in captured.err
+    expected = ("Glyph 'a': 'rlineto' at point index 2 in master index 1 "
+                "differs from the default font point type 'rrcurveto'. Please "
+                "try again with the -c (--check-compat) option.")
+    assert expected in captured.err
 
 
 def test_bug1003_compat():


### PR DESCRIPTION
## Description

Improve reporting of underlying problem when `VarLibCFFPointTypeMergeError` is encountered in `buildcff2vf`

Closes #1312 

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [x] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
