### PR TITLE
[spec] Deprecate anonymous data blocks

### DIFF
--- a/c/makeotf/makeotf_lib/api/hotconv.h
+++ b/c/makeotf/makeotf_lib/api/hotconv.h
@@ -12,7 +12,7 @@ This software is licensed as OpenSource, under the Apache License, Version 2.0. 
 extern "C" {
 #endif
 
-#define HOT_VERSION 0x010077 /* Library version (1.0.119) */
+#define HOT_VERSION 0x010078 /* Library version (1.0.120) */
 /* Major, minor, build = (HOT_VERSION >> 16) & 0xff, (HOT_VERSION >> 8) & 0xff, HOT_VERSION & 0xff) */
 /* Warning: this string is now part of heuristic used by CoolType to identify the
 first round of CoolType fonts which had the backtrack sequence of a chaining

--- a/c/makeotf/makeotf_lib/build/hotpccts/featgram.g
+++ b/c/makeotf/makeotf_lib/build/hotpccts/featgram.g
@@ -2358,7 +2358,7 @@ topLevelStatement
 
 anonBlock
 	:	K_anon t:T_TAG		<<h->anonData.tag = $t.ulval;>>
-			   				<<featAddAnonData(); featSetTagReturnMode(START);>>
+			   				<<featAddAnonData(); h->syntax.numAnon++; featSetTagReturnMode(START);>>
 	;
 
 featureFile

--- a/c/makeotf/makeotf_lib/source/hotconv/feat.c
+++ b/c/makeotf/makeotf_lib/source/hotconv/feat.c
@@ -257,6 +257,7 @@ struct featCtx_ {
     /* --- Stores stats on deprecated feature file syntax */
     struct {
         unsigned short numExcept;
+        unsigned short numAnon;
     } syntax;
 
     dnaDCL(GNode *, markClasses);  /* Container for head nodes or mark classes */
@@ -4328,8 +4329,9 @@ void featNew(hotCtx hot) {
 /* Emit report on any deprecated feature file syntax encountered */
 
 static void reportOldSyntax(void) {
+    int one;
     if (h->syntax.numExcept > 0) {
-        int one = h->syntax.numExcept == 1;
+        one = h->syntax.numExcept == 1;
 
         hotMsg(g, hotNOTE,
                "There %s %hd instance%s of the deprecated \"except\" syntax in the"
@@ -4341,6 +4343,17 @@ static void reportOldSyntax(void) {
                " Contextual and not a Single Substitution rule.)",
                one ? "is" : "are",
                h->syntax.numExcept,
+               one ? "" : "s");
+    }
+    if (h->syntax.numAnon > 0) {
+        one = h->syntax.numAnon == 1;
+
+        hotMsg(g, hotNOTE,
+               "There %s %hd instance%s of the deprecated \"anon\" block in the"
+               " feature file. makeotf currently parses these blocks without providing any"
+               " interface to retrieve them but they will be removed from a future standard.",
+               one ? "is" : "are",
+               h->syntax.numAnon,
                one ? "" : "s");
     }
 }

--- a/c/makeotf/makeotf_lib/source/hotconv/featgram.c
+++ b/c/makeotf/makeotf_lib/source/hotconv/featgram.c
@@ -6007,6 +6007,7 @@ anonBlock()
         zzCONSUME;
 
         featAddAnonData();
+        h->syntax.numAnon++;
         featSetTagReturnMode(START);
         zzEXIT(zztasp1);
         return;

--- a/c/makeotf/source/main.c
+++ b/c/makeotf/source/main.c
@@ -30,7 +30,7 @@
 
 jmp_buf mark;
 
-#define MAKEOTF_VERSION "2.5.65604"
+#define MAKEOTF_VERSION "2.5.65605"
 /* Warning: this string is now part of heuristic used by CoolType to identify the
    first round of CoolType fonts which had the backtrack sequence of a chaining
    contextual substitution ordered incorrectly.  Fonts with the old ordering MUST match

--- a/docs/OpenTypeFeatureFileSpecification.md
+++ b/docs/OpenTypeFeatureFileSpecification.md
@@ -1,4 +1,4 @@
----
+--
 title: OpenType Feature File Specification
 layout: default
 ---
@@ -6,12 +6,12 @@ layout: default
 OpenType™ Feature File Specification
 ---
 
-Copyright 2015-2020 Adobe. All Rights Reserved. This software is licensed as
+Copyright 2015-2021 Adobe. All Rights Reserved. This software is licensed as
 OpenSource, under the Apache License, Version 2.0. This license is available at:
 http://opensource.org/licenses/Apache-2.0.
 
-Document version 1.25.1
-Last updated 5 July 2020
+Document version 1.25.2
+Last updated 26 April 2021
 
 **Caution: Portions of the syntax unimplemented by Adobe are subject to change.**
 
@@ -170,8 +170,8 @@ contexts.
 
 [`anchor`](#2.e.vii)<br>
 [`anchorDef`](#2.e.viii)<br>
-[`anon`](#10)<br>
-[`anonymous`](#10)<br>
+[`anon`](#10) (deprecated)<br>
+[`anonymous`](#10) (deprecated)<br>
 [`by`](#5.a)<br>
 [`contourpoint`](#2.e.vi)<br>
 [`cursive`](#6.c)<br>
@@ -3907,6 +3907,11 @@ table STAT {
 <a name="10"></a>
 ## 10. Specifying anonymous data blocks
 
+**Note:** Anonymous data blocks are deprecated and will cause a warning to
+appear. The Adobe implementation may never have provided an interface to
+anonyomous block content and definitely has not since 2014. They will
+be removed from a future version of the standard.
+
 The feature file can contain `anonymous` tagged blocks of data that must be
 passed back to the client of the implementation software. These blocks of data
 typically contain information needed to specify custom or unsupported tables.
@@ -3959,6 +3964,9 @@ along with the tag `sbit`.
 
 <a name="11"></a>
 ## 11. Document revisions
+
+**v1.25.2 [26 April 2021]:**
+*   Deprecated [anonymous data blocks](#10)
 
 **v1.25.1 [5 July 2020]:**
 *   Added information and examples to [STAT table](#9.e)

--- a/python/afdko/makeotf.py
+++ b/python/afdko/makeotf.py
@@ -26,7 +26,7 @@ if needed.
 """
 
 __version__ = """\
-makeotf.py v2.8.6 March 11 2021
+makeotf.py v2.8.7 April 26 2021
 """
 
 __methods__ = """


### PR DESCRIPTION
## Description

This change deprecates anonymous data blocks (section 10 of the specification) and adds a warning to `makeotfexe` when one is encountered. The changes are parallel to the `except` keyword.

`makeotfexe` has lacked any interface for retrieving anonymous blocks as far back as the present repository goes and it is likely it never had one.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
