### PR TITLE
Clarify the use of hyphens in glyph names

### DIFF
--- a/docs/OpenTypeFeatureFileSpecification.md
+++ b/docs/OpenTypeFeatureFileSpecification.md
@@ -10,8 +10,8 @@ Copyright 2015-2021 Adobe. All Rights Reserved. This software is licensed as
 OpenSource, under the Apache License, Version 2.0. This license is available at:
 http://opensource.org/licenses/Apache-2.0.
 
-Document version 1.26
-Last updated 7 June 2021
+Document version 1.26.1
+Last updated 1 Aug 2023
 
 **Caution: Portions of the syntax unimplemented by Adobe are subject to change.**
 
@@ -615,7 +615,8 @@ supported for development glyph names:
     U+007C | Vertical bar
     U+007E ~ Tilde
 
-However, none of these characters are allowed at the start of a glyph name.
+However, none of these characters are allowed at the start of a glyph name and
+a hyphen may not be the last character in a name.
 
 For glyphs where the development glyph name differs from the final production
 glyph name, an implementation of the feature file syntax must be able to accept
@@ -3997,6 +3998,10 @@ along with the tag `sbit`.
 
 <a name="11"></a>
 ## 11. Document revisions
+
+<<<<<<< HEAD
+**v1.26.1 [1 Aug 2023]:**
+*   Clarify the use of hyphens in [glyph names](#2.f.i)
 
 **v1.26 [7 June 2021]:**
 *   Clarified syntax of [keywords](#2.c), [glyph names](#2.f.i), 


### PR DESCRIPTION
## Description

Having hyphens at the end of "development" glyph names makes handling ranges correctly in the grammar significantly trickier; the current implementation doesn't attempt to. As there doesn't seem to be a need for them in that location this PR updates the docs to clarify that they can't end a name.

Perhaps more controversially it also states that the special characters can't be used at the start of a name. The spec was ambiguous about this but the `featgram.g` implementation doesn't allow them at the beginning of a name. I agree with that decision—too dicey to allow them there. 

One additional question is whether we should go farther and restrict the use of more or all of the special characters at the end of a name. The main reason for doing that would be to reserve potential glyph operators for future use, which could be handled the way hyphens are handled now. I leave that up for discussion. 

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [ ] I have verified that new and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

Closes #970 
