### PR TITLE
Copy token string when using FeatCtx::tokstr()

### DIFF
--- a/c/makeotf/lib/hotconv/FeatCtx.cpp
+++ b/c/makeotf/lib/hotconv/FeatCtx.cpp
@@ -339,7 +339,8 @@ void FeatCtx::featMsg(int msgType, FeatVisitor *v,
 
 const char *FeatCtx::tokstr() {
     assert(current_visitor != NULL);
-    return current_visitor->currentTokStr();
+    current_visitor->currentTokStr(tokenStringBuffer);
+    return tokenStringBuffer.c_str();
 }
 
 void FeatCtx::setIDText()

--- a/c/makeotf/lib/hotconv/FeatCtx.h
+++ b/c/makeotf/lib/hotconv/FeatCtx.h
@@ -117,6 +117,7 @@ class FeatCtx {
     struct {
         unsigned short numExcept {0};
     } syntax;
+    std::string tokenStringBuffer;
 
     void CDECL featMsg(int msgType, const char *fmt, ...);
     void CDECL featMsg(int msgType, FeatVisitor *v,

--- a/c/makeotf/lib/hotconv/FeatVisitor.cpp
+++ b/c/makeotf/lib/hotconv/FeatVisitor.cpp
@@ -146,11 +146,11 @@ void FeatVisitor::Translate() {
 
 // --------------------------- Message Reporting -----------------------------
 
-const char *FeatVisitor::currentTokStr() {
+void FeatVisitor::currentTokStr(std::string &ts) {
     if ( current_msg_token == nullptr )
-        return nullptr;
+        return;
 
-    return current_msg_token->getText().c_str();
+    ts = current_msg_token->getText();
 }
 
 void FeatVisitor::newFileMsg(char **msg) {
@@ -222,8 +222,7 @@ antlrcpp::Any FeatVisitor::visitFeatureBlock(FeatParser::FeatureBlockContext *ct
     EntryPoint tmp_ep = include_ep;
     include_ep = &FeatParser::featureFile;
     if ( stage == vExtract ) {
-        Tag t = checkTag(ctx->starttag, ctx->endtag);
-        TOK(ctx);
+        Tag t = checkTag(TOK(ctx->starttag), ctx->endtag);
         fc->startFeature(t);
         if ( ctx->USE_EXTENSION() != nullptr )
             fc->flagExtension(false);

--- a/c/makeotf/lib/hotconv/FeatVisitor.h
+++ b/c/makeotf/lib/hotconv/FeatVisitor.h
@@ -49,7 +49,7 @@ class FeatVisitor : public FeatParserBaseVisitor {
     // Console message reporting utilities
     void newFileMsg(char **msg);
     void tokenPositionMsg(char **msg, bool full = false);
-    const char *currentTokStr();
+    void currentTokStr(std::string &ts);
 
     // Functions to mark the "current" token before calling into FeatCtx
     inline antlr4::Token *TOK(antlr4::Token *t) { current_msg_token = t; return t; }


### PR DESCRIPTION
## Description

I had thought that `std::string` objects retrieved from the parser tree are valid for the lifetime of the tree but there seems to be some other smart-pointer stuff going on. In most cases there is no difference (because strings are either used in the function where they're retrieved or passed "down") but FeatCtx::tokstr() needs to be changed to store the string.

I also changed the "reference token" for feature blocks to the start tag so that the error message makes sense. (That would have been a better choice to begin with anyway.)

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
