### PR TITLE
[build_wheels.yml] Try yum instead of apt-get for linux

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -41,7 +41,7 @@ jobs:
         CIBW_BUILD: "cp36-*"
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
         CIBW_SKIP: "pp* cp*manylinux_i686 cp*manylinux_aarch64 cp*manylinux_ppc64le cp*manylinux_s390x cp*win32"
-        CIBW_BEFORE_BUILD_LINUX: "apt-get -y install uuid-dev"
+        CIBW_BEFORE_BUILD_LINUX: "yum install -y uuid-dev"
 
     - name: Build sdist (Ubuntu only)
       if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
Related to #1376 , #1375 , #1374 

Attempting to fix `sh: apt-get: command not found`, which may be because of docker linux images using `yum` as a package manager. 