### PR TITLE
makeinstancesufo fixes for fontMath 0.8.1 update

### DIFF
--- a/python/afdko/makeinstancesufo.py
+++ b/python/afdko/makeinstancesufo.py
@@ -148,6 +148,10 @@ def roundSelectedFontInfo(fontInfo):
             elif prop_name in ('postscriptBlueFuzz', 'postscriptBlueShift',
                                'postscriptSlantAngle'):
                 round_val = round(prop_val, 2)
+
+            elif prop_name == 'italicAngle':
+                round_val = round(prop_val)
+
             else:
                 round_val = int(round(prop_val))
 
@@ -191,10 +195,6 @@ def postProcessInstance(fontPath, options):
     clearCustomLibs(dFont)
 
     if options.no_round:
-        # '-r/--no-round' option was used but certain values (glyph widths,
-        # kerning values, font info values) still need to be rounded because
-        # of how they are stored in the final OTF
-        roundSelectedFontInfo(dFont.info)
         roundGlyphWidths(dFont)
         roundKerningValues(dFont)
     else:
@@ -202,6 +202,10 @@ def postProcessInstance(fontPath, options):
         # when 'roundGeometry' = False
         roundPostscriptBlueScale(dFont.info)
         roundKerningValues(dFont)
+    # even if '-r/--no-round' option was used, certain values (glyph widths,
+    # kerning values, font info values) still need to be rounded because
+    # of how they are stored in the final OTF
+    roundSelectedFontInfo(dFont.info)
 
     dFont.save()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,9 @@
 lxml==4.6.3
 booleanOperations==0.9.0
 defcon[lxml,pens]==0.8.1
-fontMath==0.6.0
-fontTools[woff,unicode,lxml,ufo]==4.24.4
+fontMath==0.8.1
+fontTools[ufo,woff,lxml,unicode]==4.25.1
 psautohint==2.3.0
-tqdm==4.61.1
+tqdm==4.61.2
 ufonormalizer==0.5.4
 ufoProcessor==1.9.0

--- a/tests/makeinstancesufo_data/expected_output/Dummy-ExtraMinus.ufo/fontinfo.plist
+++ b/tests/makeinstancesufo_data/expected_output/Dummy-ExtraMinus.ufo/fontinfo.plist
@@ -14,7 +14,7 @@
 		<array>
 		</array>
 		<key>italicAngle</key>
-		<integer>-180</integer>
+		<integer>0</integer>
 		<key>postscriptBlueFuzz</key>
 		<integer>0</integer>
 		<key>postscriptBlueScale</key>

--- a/tests/makeinstancesufo_data/expected_output/bold.ufo/fontinfo.plist
+++ b/tests/makeinstancesufo_data/expected_output/bold.ufo/fontinfo.plist
@@ -15,7 +15,7 @@
     <key>guidelines</key>
     <array/>
     <key>italicAngle</key>
-    <integer>2</integer>
+    <integer>1</integer>
     <key>openTypeHheaAscender</key>
     <integer>1036</integer>
     <key>openTypeHheaDescender</key>

--- a/tests/makeinstancesufo_data/expected_output/regular.ufo/fontinfo.plist
+++ b/tests/makeinstancesufo_data/expected_output/regular.ufo/fontinfo.plist
@@ -16,7 +16,7 @@
 		<array>
 		</array>
 		<key>italicAngle</key>
-		<integer>2</integer>
+		<integer>0</integer>
 		<key>openTypeHheaAscender</key>
 		<integer>1036</integer>
 		<key>openTypeHheaDescender</key>

--- a/tests/makeinstancesufo_data/expected_output/regular1.ufo/fontinfo.plist
+++ b/tests/makeinstancesufo_data/expected_output/regular1.ufo/fontinfo.plist
@@ -15,7 +15,7 @@
     <key>guidelines</key>
     <array/>
     <key>italicAngle</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>openTypeHheaAscender</key>
     <integer>1036</integer>
     <key>openTypeHheaDescender</key>

--- a/tests/makeinstancesufo_data/expected_output/semibold.ufo/fontinfo.plist
+++ b/tests/makeinstancesufo_data/expected_output/semibold.ufo/fontinfo.plist
@@ -16,7 +16,7 @@
 		<array>
 		</array>
 		<key>italicAngle</key>
-		<integer>2</integer>
+		<integer>1</integer>
 		<key>openTypeHheaAscender</key>
 		<integer>1036</integer>
 		<key>openTypeHheaDescender</key>

--- a/tests/makeinstancesufo_data/expected_output/ufo2.ufo/fontinfo.plist
+++ b/tests/makeinstancesufo_data/expected_output/ufo2.ufo/fontinfo.plist
@@ -13,7 +13,7 @@
 		<key>familyName</key>
 		<string>Source Serif Pro</string>
 		<key>italicAngle</key>
-		<integer>2</integer>
+		<integer>0</integer>
 		<key>openTypeHheaAscender</key>
 		<integer>1036</integer>
 		<key>openTypeHheaDescender</key>


### PR DESCRIPTION
This fixes test values for new, more accurate `italicAngle` values produced by the new fontMath 0.8.1 update.
This also fixes a bug in `makeinstancesufo` (not caught in tests until now) where `roundSelectedFontInfo(dFont.info)` was only called when the -r option was used (because it would have no-rounding _except_ for the values that need it) when they should always be rounded