### PR TITLE
Add throttling to OTF2TTF to avoid hangs on Windows with large CPU (#1420)

### DIFF
--- a/python/afdko/otf2ttf.py
+++ b/python/afdko/otf2ttf.py
@@ -154,7 +154,7 @@ def main(args=None):
 
     # Set the pool capacity to be the minimum of file quantity and CPU count
     maxPoolCapacity = min(os.cpu_count(), len(files))
-    # Limit parallel capacity to 60 on win32 to avoid WaitForMultipleObjects 
+    # Limit parallel capacity to 60 on win32 to avoid WaitForMultipleObjects
     # errors. See https://bugs.python.org/issue45077
     if sys.platform == "win32" and maxPoolCapacity >= 60:
         maxPoolCapacity = 60


### PR DESCRIPTION
## Description

This change adds throttling to `otf2ttf` to avoid hanging on Windows if the system has a CPU with 64 or more logical processors. Fixes #1420.

## Checklist:

- [X] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [X] I have verified that new and existing tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
