### PR TITLE
[skip ci] fix broken relative link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ PostScript and TrueType font data.
 
 This repository contains the data files, Python scripts, and sources for
 the command line programs that comprise the AFDKO. The project uses the
-[Apache 2.0 OpenSource license](LICENSE.md). Please note that the AFDKO
-makes use of several dependencies, listed in the requirements.txt file,
-which will automatically be installed if you install AFDKO with `pip`.
-Most of these dependencies are BSD or MIT license, with the exception of
-`tqdm`, which is [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/).
+[Apache 2.0 Open Source license](https://opensource.org/licenses/Apache-2.0).
+Please note that the AFDKO makes use of several dependencies, listed in the
+requirements.txt file, which will automatically be installed if you install
+AFDKO with `pip`. Most of these dependencies are BSD or MIT license, with
+the exception of `tqdm`, which is [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/).
 
 Please refer to the
 [AFDKO Overview](https://adobe-type-tools.github.io/afdko/AFDKO-Overview.html)


### PR DESCRIPTION
## Description

- fix typo ("OpenSource" -> "Open Source")
- use fully-qualified URL to link to Apache 2.0 license on OSI site (relative link fails when README is viewed through PyPI)

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- ~[ ] I have added **test code and data** to prove that my code functions correctly~
- ~[ ] I have verified that new and existing tests pass locally with my changes~
- ~[ ] I have performed a self-review of my own code~
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
