### PR TITLE
Drop Python 3.6, add Python 3.10 support

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -3,7 +3,7 @@ name: Build Python Wheels
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9a-z]+'
+      - '\d+\.\d+\.[0-9a-z]+'
 
   workflow_dispatch:
     inputs:
@@ -31,34 +31,30 @@ jobs:
       with:
         fetch-depth: 0  # unshallow fetch for setuptools-scm
 
-    - name: Use MSBuild (Windows only)
-      uses: microsoft/setup-msbuild@v1.0.2
-      if: matrix.os == 'windows-latest'
-
-    - name: Install Python 3.7
+    - name: Install Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt -r requirements-dev.txt
-        pip install cibuildwheel
+        python-version: '3.9'
 
     - name: Build wheel
-      run: |
-        git config --global url.https://github.com/.insteadOf git://github.com/
-        python -m cibuildwheel --output-dir dist
+      uses: pypa/cibuildwheel@v2.3.0
+      with:
+        output-dir: dist
       env:
-        CIBW_BUILD: "cp36-*"
+        CIBW_BUILD: "cp39-*"
+        CIBW_ARCHS_MACOS: x86_64
+        CIBW_ARCHS_WINDOWS: AMD64
+        CIBW_ARCHS_LINUX: x86_64
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-        CIBW_SKIP: "pp* cp*manylinux_i686 cp*manylinux_aarch64 cp*manylinux_ppc64le cp*manylinux_s390x cp*win32"
+        CIBW_SKIP: "*musllinux*"
         CIBW_BEFORE_ALL_LINUX: "yum install -y libuuid-devel"
 
     - name: Build sdist (Ubuntu only)
       if: matrix.os == 'ubuntu-latest'
-      run: python setup.py sdist
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build>=0.7.0
+        python -m build --sdist
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v2
@@ -74,6 +70,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
     - name: Get date & flat tag
       id: date_tag
       run: |

--- a/.github/workflows/run_cvg.yml
+++ b/.github/workflows/run_cvg.yml
@@ -2,10 +2,17 @@ name: C and Python coverage
 
 on:
   push:
-    branches:
-      - '*'
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+
   pull_request:
-    branches: [master, develop]
+    branches: [develop]
+    types: [opened]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+
   workflow_dispatch:
     inputs:
       reason:
@@ -17,33 +24,39 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
+
     - name: Log reason (manual run only)
       if: github.event_name == 'workflow_dispatch'
       run: |
         echo "Reason for triggering: ${{ github.event.inputs.reason }}"
 
-    - uses: actions/checkout@v1
+    - name: Check out
+      uses: actions/checkout@v2
       with:
-        submodules: true
+        fetch-depth: 0  # unshallow fetch for setuptools-scm
 
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: "3.8"
 
-    - name: Build and install AFDKO wheel
+    - name: Build AFDKO wheel
       env:
         XFLAGS: '--coverage'
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt -r requirements-dev.txt
-        git config --global url.https://github.com/.insteadOf git://github.com/
-        python setup.py bdist_wheel
-        echo 'Installing AFDKO wheel...'
-        pip install dist/*.whl -q
-        
-    - name: Generate and upload Python and C coverage
+        python -m pip install build>=0.7.0
+        python -m build --wheel
+
+    - name: Install AFDKO wheel
       run: |
-        pip install pytest pytest-cov
-        python -m pytest tests --cov --cov-report=xml
+        python -m pip install dist/*.whl -q
+
+    - name: Generate Python and C coverage
+      run: |
+        python -m pip install pytest-cov -q
+        python -m pytest tests --cov --cov-report=xml --color=yes
+
+    - name: Upload coverage results
+      run: |
         bash <(curl -s https://codecov.io/bash) -y .codecov.yml

--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -8,6 +8,7 @@ on:
 
   pull_request:
     branches: [develop]
+    types: [opened]
     paths-ignore:
       - 'docs/**'
       - '**.md'
@@ -27,20 +28,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         exclude:
           - os: macos-latest
-            python-version: 3.6
+            python-version: "3.7"
           - os: macos-latest
-            python-version: 3.7
+            python-version: "3.8"
           - os: macos-latest
-            python-version: 3.8
+            python-version: "3.10"
           - os: windows-latest
-            python-version: 3.6
+            python-version: "3.7"
           - os: windows-latest
-            python-version: 3.7
+            python-version: "3.8"
           - os: windows-latest
-            python-version: 3.8
+            python-version: "3.9"
 
     steps:
 
@@ -49,49 +50,54 @@ jobs:
       run: |
         echo "Reason for triggering: ${{ github.event.inputs.reason }}"
 
-    - uses: actions/checkout@v1
+    - name: Check out
+      uses: actions/checkout@v2
       with:
-        submodules: true
-
-    - name: Use MSBuild (Windows)
-      uses: microsoft/setup-msbuild@v1.0.2
-      with:
-        vs-version: '[16.4,]'
-      if: matrix.os == 'windows-latest'
+        fetch-depth: 0  # unshallow fetch for setuptools-scm
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt -r requirements-dev.txt
+    - name: Use MSBuild (Windows)
+      if: matrix.os == 'windows-latest'
+      uses: microsoft/setup-msbuild@v1.1
+      with:
+        vs-version: '[16.4,]'
+        msbuild-architecture: x64
 
     - name: Set Windows generator to Visual Studio
+      if: matrix.os == 'windows-latest'
       run: |
         echo "CMAKE_GENERATOR=Visual Studio 16 2019" >> $GITHUB_ENV
         echo "CMAKE_GENERATOR_PLATFORM=x64" >> $GITHUB_ENV
       shell: bash
-      if: matrix.os == 'windows-latest'
 
-    - name: Install AFDKO (Other)
+    - name: Install dependencies
       run: |
-        git config --global url.https://github.com/.insteadOf git://github.com/
-        pip install .
-        pip freeze --all
-      shell: bash
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements.txt -r requirements-dev.txt
 
-    - name: Lint Python code with flake8 using .flake8 config file
+    - name: Lint Python code with flake8 using .flake8 config file (Linux only)
+      if: matrix.os == 'ubuntu-latest'
       run: |
-        flake8 . --count --show-source --statistics --config=.flake8
+        flake8 --count --show-source --statistics --config=.flake8
 
     - name: Lint C code with cpplint using script (Linux only)
       if: matrix.os == 'ubuntu-latest'
       run: |
         ./.run_cpplint.sh
 
+    - name: Install AFDKO
+      run: |
+        python -m pip install .
+        python -m pip freeze --all
+
     - name: Test with pytest
       run: |
-        pytest --no-cov tests
+        python -m pytest --no-cov tests --color=yes
+
+    - name: Test uninstall AFDKO
+      run: |
+        python -m pip uninstall afdko -y

--- a/.run_cpplint.sh
+++ b/.run_cpplint.sh
@@ -1,3 +1,5 @@
+set -ex
+
 cpplint --recursive --quiet c/detype1
 cpplint --recursive --quiet c/makeotf/include
 cpplint --recursive --quiet c/makeotf/resource

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ projects.
 Installation
 ------------
 
-The AFDKO requires [Python](http://www.python.org/download) 3.6
+The AFDKO requires [Python](http://www.python.org/download) 3.7
 or later.
 
 Releases are available on the [Python Package
@@ -106,7 +106,7 @@ On the Mac, install these with:
 
 On Linux (Ubuntu 17.10 LTS or later), install these with:
 
-    apt-get -y install python3.6
+    apt-get -y install python3.7
     apt-get -y install python-pip
     apt-get -y install python-dev
     apt-get -y install uuid-dev

--- a/c/makeotf/lib/hotconv/hot.c
+++ b/c/makeotf/lib/hotconv/hot.c
@@ -99,7 +99,7 @@ hotCtx hotNew(hotCallbacks *hotcb) {
     g->font.licenseID = NULL;
 
     /* Get current time */
-    
+
     time(&now);
     SAFE_LOCALTIME(&now, &g->time);
 

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ def main():
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',
@@ -192,7 +192,7 @@ def main():
               ],
           },
           zip_safe=False,
-          python_requires='>=3.6',
+          python_requires='>=3.7',
           setup_requires=[
               'wheel',
               'setuptools_scm',


### PR DESCRIPTION
## Description
Updates and improvements to dropping Python 3.6 and add Python 3.10 support:
- Update test workflow (run on Python 3.7, 3.8, 3.9, and 3.10 only, update cpplint run, colorize pytest log, test uninstall AFDKO)
- Update coverage workflow (make AFDKO installation & coverage upload separate steps)
- Update build_wheels workflow (use CIBW Action, only build Python 3.7-3.10 wheels, update tag-matching, remove "Use MSBuild" step)
- Other miscellaneous updates and improvements to GHA workflows
- Update README.md to indicate Python 3.7 minimum

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [x] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
