### PR TITLE
Fix C-code coverage reporting

### DIFF
--- a/.github/workflows/run_cvg.yml
+++ b/.github/workflows/run_cvg.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Build AFDKO wheel
       env:
-        XFLAGS: '--coverage'
+        CFLAGS: '--coverage'
       run: |
         python -m pip install --upgrade pip
         python -m pip install build>=0.7.0


### PR DESCRIPTION
The last time C-code coverage results were reported was in June 1, 2021
https://codecov.io/gh/adobe-type-tools/afdko/tree/1523970f566cc6049a6fe543690837db94a1b61d

Coverage results in June 8, 2021
https://codecov.io/gh/adobe-type-tools/afdko/tree/01a35dacc9e8d1735b7f752f3232d38c34e6f843

Coverage results after this change
https://codecov.io/gh/adobe-type-tools/afdko/tree/3199a40373fafd0185a5ca4cc8cfc9d33a8084c3