### PR TITLE
Build universal2 wheel instead of arm64

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -36,17 +36,17 @@ jobs:
       with:
         python-version: '3.9'
 
-    - name: Build wheel (only macosx_arm64)
+    - name: Build wheel (only macosx_universal2)
       if: matrix.os == 'macos-latest'
       uses: pypa/cibuildwheel@v2.3.1
       with:
         output-dir: dist
       env:
         CIBW_BUILD: "cp39-*"
-        CIBW_ARCHS_MACOS: arm64
-        CIBW_ENVIRONMENT_MACOS: "CFLAGS='-arch arm64' CXXFLAGS='-arch arm64' LDFLAGS='-arch arm64'"
+        CIBW_ARCHS_MACOS: universal2
+        CIBW_ENVIRONMENT_MACOS: "CFLAGS='-arch arm64 -arch x86_64' CXXFLAGS='-arch arm64 -arch x86_64' LDFLAGS='-arch arm64 -arch x86_64'"
 
-    - name: Build wheel (except macosx_arm64)
+    - name: Build wheel (except macosx_universal2)
       uses: pypa/cibuildwheel@v2.3.1
       with:
         output-dir: dist


### PR DESCRIPTION
Builds `universal2` (`x86_64` & `arm64`) wheel instead of `arm64`-only wheel, for macOS.

https://pypi.org/project/afdko/3.8.0b0/#files