### PR TITLE
[tx] initialize variables in doFile

### DIFF
--- a/c/tx/source/tx.c
+++ b/c/tx/source/tx.c
@@ -8,7 +8,7 @@
 
 #include "tx_shared.h"
 
-#define TX_VERSION CTL_MAKE_VERSION(1, 2, 4)
+#define TX_VERSION CTL_MAKE_VERSION(1, 2, 5)
 
 #include "varread.h"
 
@@ -372,6 +372,9 @@ static void doFile(txCtx h, char *srcname) {
     char *p;
     struct stat fileStat;
     int statErrNo;
+
+    /* initialize fileStat */
+    memset(&fileStat, 0, sizeof(struct stat));
 
     /* Set src name */
     if (h->file.sr != NULL) {


### PR DESCRIPTION
## Description

This adds initialization of the `fileStat` variable in `doFile`. Previously `fileStat` was accessed prior to initialization.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] ~I have added **test code and data** to prove that my code functions correctly~ n/a
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~ n/a
