### PR TITLE
[tx] Add safety initialization of pdwCtx structure in pdwNew

### DIFF
--- a/c/shared/include/pdfwrite.h
+++ b/c/shared/include/pdfwrite.h
@@ -7,7 +7,7 @@
 
 #include "ctlshare.h"
 
-#define PDW_VERSION CTL_MAKE_VERSION(1, 0, 6)
+#define PDW_VERSION CTL_MAKE_VERSION(1, 0, 7)
 
 #include "absfont.h"
 

--- a/c/shared/source/pdfwrite/pdfwrite.c
+++ b/c/shared/source/pdfwrite/pdfwrite.c
@@ -303,9 +303,12 @@ pdwCtx pdwNew(ctlMemoryCallbacks *mem_cb, ctlStreamCallbacks *stm_cb,
         return NULL;
 
     /* Allocate context */
-    h = mem_cb->manage(mem_cb, NULL, sizeof(struct pdwCtx_));
+    h = (pdwCtx)mem_cb->manage(mem_cb, NULL, sizeof(struct pdwCtx_));
     if (h == NULL)
         return NULL;
+
+    /* Safety initialization */
+    memset(h, 0, sizeof(*h));
 
     /* Copy callbacks */
     h->cb.mem = *mem_cb;

--- a/c/tx/source/tx.c
+++ b/c/tx/source/tx.c
@@ -8,7 +8,7 @@
 
 #include "tx_shared.h"
 
-#define TX_VERSION CTL_MAKE_VERSION(1, 2, 5)
+#define TX_VERSION CTL_MAKE_VERSION(1, 2, 6)
 
 #include "varread.h"
 


### PR DESCRIPTION
## Description

Updates to pdfwrite.c to avoid an out-of-bounds read error with malformed input files in `tx -pdf` mode caused by an uninitialized `pdwCtx` structure. Version numbers for pdfwrite and tx were also updated.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] ~I have added **test code and data** to prove that my code functions correctly~
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
