### PR TITLE
git protocol security fix for utfcpp/antlr4

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -43,7 +43,6 @@ jobs:
         output-dir: dist
       run: |
         git config --global url.https://github.com/.insteadOf git://github.com/
-        python -m cibuildwheel --output-dir dist
       env:
         CIBW_BUILD: "cp39-*"
         CIBW_ARCHS_MACOS: universal2
@@ -55,7 +54,6 @@ jobs:
         output-dir: dist
       run: |
         git config --global url.https://github.com/.insteadOf git://github.com/
-        python -m cibuildwheel --output-dir dist
       env:
         CIBW_BUILD: "cp39-*"
         CIBW_ARCHS_MACOS: x86_64
@@ -68,6 +66,7 @@ jobs:
     - name: Build sdist (Ubuntu only)
       if: matrix.os == 'ubuntu-latest'
       run: |
+        git config --global url.https://github.com/.insteadOf git://github.com/
         python -m pip install --upgrade pip
         python -m pip install build>=0.7.0
         python -m build --sdist

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -41,6 +41,9 @@ jobs:
       uses: pypa/cibuildwheel@v2.3.1
       with:
         output-dir: dist
+      run: |
+        git config --global url.https://github.com/.insteadOf git://github.com/
+        python -m cibuildwheel --output-dir dist
       env:
         CIBW_BUILD: "cp39-*"
         CIBW_ARCHS_MACOS: universal2
@@ -50,6 +53,9 @@ jobs:
       uses: pypa/cibuildwheel@v2.3.1
       with:
         output-dir: dist
+      run: |
+        git config --global url.https://github.com/.insteadOf git://github.com/
+        python -m cibuildwheel --output-dir dist
       env:
         CIBW_BUILD: "cp39-*"
         CIBW_ARCHS_MACOS: x86_64

--- a/.github/workflows/run_cvg.yml
+++ b/.github/workflows/run_cvg.yml
@@ -44,10 +44,11 @@ jobs:
       env:
         CFLAGS: '--coverage'
       run: |
+        git config --global url.https://github.com/.insteadOf git://github.com/
         python -m pip install --upgrade pip
         python -m pip install build>=0.7.0
         python -m build --wheel
-        git config --global url.https://github.com/.insteadOf git://github.com/
+        
 
     - name: Install AFDKO wheel
       run: |

--- a/.github/workflows/run_cvg.yml
+++ b/.github/workflows/run_cvg.yml
@@ -47,6 +47,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install build>=0.7.0
         python -m build --wheel
+        git config --global url.https://github.com/.insteadOf git://github.com/
 
     - name: Install AFDKO wheel
       run: |

--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -91,6 +91,7 @@ jobs:
 
     - name: Install AFDKO
       run: |
+        git config --global url.https://github.com/.insteadOf git://github.com/
         python -m pip install .
         python -m pip freeze --all
 


### PR DESCRIPTION
This is a temporary fix for installing utfcpp within ANTLR4 build. GitHub's protocol security improvement was made permanent today: https://github.blog/2021-09-01-improving-git-protocol-security-github/

The fix right now is running `git config --global url.https://github.com/.insteadOf git://github.com/` in the wheels before building the FDK. We had these commands in the wheels before, but were removed a few months ago.
The permanent fix for this will be upgrading to the latest ANTLR4.