### PR TITLE
[skip-ci] [spec] [formatting-only] fix bad linebreak

### DIFF
--- a/docs/OpenTypeFeatureFileSpecification.md
+++ b/docs/OpenTypeFeatureFileSpecification.md
@@ -2139,9 +2139,9 @@ special column title. When you specify the value of a class pair, you are
 specifying the value in only one cell of the spreadsheet. When you specify a
 series of kern pair rules between a particular left side class and a series of
 right side classes, you are filling in a series of cells in the row for the
-specific left side class. All cells for which no values are specified are set to
-0. When programs look for a kern value between “Ygrave” and something else, they
-look through the list of left side class definitions to find the first
+specific left side class. All cells for which no values are specified are set
+to 0. When programs look for a kern value between “Ygrave” and something
+else, they look through the list of left side class definitions to find the first
 occurrence of “Ygrave”. By definition, the first spreadsheet row which includes
 “Ygrave” will define the kern pair value of “Ygrave” with all other right-side
 classes, e.g spreadsheet columns. Since a pair value with a right-side period


### PR DESCRIPTION
## Description

Documentation-only fix: an unfortunate hard-wrap in docs/OpenTypeFeatureFileSpecification.md caused a line to begin with "0. ", unintentionally creating a numbered list in the rendered Markdown.

closes #1507 

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] ~I have added **test code and data** to prove that my code functions correctly~
- [ ] ~I have verified that new and existing tests pass locally with my changes~
- [x] I have performed a self-review of my own code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
