### PR TITLE
Copy va_list for second use (and add va_end's to avoid leaking)

### DIFF
--- a/c/makeotf/lib/hotconv/FeatCtx.cpp
+++ b/c/makeotf/lib/hotconv/FeatCtx.cpp
@@ -298,16 +298,19 @@ void FeatCtx::msgPrefix(char **premsg, char **prefix) {
 }
 
 void FeatCtx::featMsg(int msgType, const char *fmt, ...) {
-    va_list ap;
+    va_list ap, cap;
     std::vector<char> buf;
     buf.resize(128);
 
     va_start(ap, fmt);
+    va_copy(cap, ap);
     int l = vsnprintf(buf.data(), 128, fmt, ap) + 1;
+    va_end(ap);
     if ( l > 128 ) {
         buf.resize(l);
-        vsnprintf(buf.data(), l, fmt, ap);
+        vsnprintf(buf.data(), l, fmt, cap);
     }
+    va_end(cap);
     hotMsg(g, msgType, buf.data());
 }
 


### PR DESCRIPTION
## Description

The error-printing code first tries to use a 128 byte buffer for output and then resizes if that fails. This code was mistakenly assuming the va_list wasn't altered as part of the call. This PR makes a copy va_list in case it is needed. It also adds va_end calls that were mistakenly left out of the original PR. 

Closes #1504 

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
