### PR TITLE
[build_wheels.yml] Remove env installation of libxml2 for Windows

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -58,9 +58,7 @@ jobs:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_SKIP: "*musllinux*"
         CIBW_BEFORE_ALL_LINUX: "yum install -y libuuid-devel && yum install -y libxml2-devel"
-        CIBW_BEFORE_BUILD_WINDOWS: "code --install libxml2"
         CIBW_ENVIRONMENT_LINUX: "CFLAGS='-I/usr/include/libxml2'"
-        CIBW_ENVIRONMENT_WINDOWS: "CFLAGS='-I/usr/include/libxml2'"
 
     - name: Build sdist (Ubuntu only)
       if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
Attempting to fix pre-release fail where Windows cannot install libxml2 with these commands in the env (it needs to run ExternalProject_Add in cmake!). I think removing these commands should help, since the other wheels files (testpythonpackage.yml) build that way, but we'll have to test with another prerelease push