### PR TITLE
makeotf and shared: Fix some linux compile problems with "bool"

### DIFF
--- a/c/makeotf/lib/typecomp/parse.c
+++ b/c/makeotf/lib/typecomp/parse.c
@@ -2428,12 +2428,12 @@ static void saveForceBold(parseCtx h, DICT *dict, int iKey) {
         char *end = p + token->length;
 
         while ((p += strspn(p, " []{}")) < end) {
-            char *bool = p;
+            char *boole = p;
 
             p += strcspn(p, " ]}");
-            if (strncmp(bool, "false", 5) == 0) {
+            if (strncmp(boole, "false", 5) == 0) {
                 array[cnt++] = 0;
-            } else if (strncmp(bool, "true", 4) == 0) {
+            } else if (strncmp(boole, "true", 4) == 0) {
                 array[cnt++] = 1;
             } else {
                 badKeyValue(h, iKey);

--- a/c/makeotf/source/c_main.c
+++ b/c/makeotf/source/c_main.c
@@ -40,8 +40,6 @@ jmp_buf mark;
 
 int KeepGoing = 0;
 
-typedef char bool;
-
 static char *progname; /* Program name */
 static cbCtx cbctx;    /* Client callback context */
 

--- a/c/shared/source/t1read/t1read.c
+++ b/c/shared/source/t1read/t1read.c
@@ -1857,14 +1857,14 @@ finish:
 
 /* Parse boolean value and return 0 if false and 1 if true. */
 static long parseBool(t1rCtx h, int kKey) {
-    long bool = 0; /* Suppress optimizer warning */
+    long boole = 0; /* Suppress optimizer warning */
     pstToken *token = getToken(h);
     switch (token->type) {
         case pstOperator:
             if (pstMatch(h->pst, token, "false"))
-                bool = 0;
+                boole = 0;
             else if (pstMatch(h->pst, token, "true"))
-                bool = 1;
+                boole = 1;
             else
                 badKeyValue(h, kKey);
             break;
@@ -1896,14 +1896,14 @@ static long parseBool(t1rCtx h, int kKey) {
                 badKeyValue(h, kKey);
 
             if (kKey == kForceBold)
-                bool = value >= h->mm.ForceBoldThreshold;
+                boole = value >= h->mm.ForceBoldThreshold;
             else
-                bool = value >= 0.5;
+                boole = value >= 0.5;
         } break;
         default:
             badKeyValue(h, kKey);
     }
-    return bool;
+    return boole;
 }
 
 /* Parse font matrix. Return 1 if Top dict FontMatrix else 0. */


### PR DESCRIPTION
## Description

I ran into some post-libxml2 commit compilation problems on Arch Linux, which
seem to be related to libxml2 header files pulling the `stdbool.h` header into some new contexts:

```
FAILED: c/shared/source/CMakeFiles/t1read.dir/t1read/t1read.c.o 
/usr/local/bin/cc -DANTLR4CPP_STATIC -I/usr/include/libxml2 -I/home/skef/src/afdko2/c/shared/source/../include -I/home/skef/src/afdko2/c/shared/source/../resource -O2 -g -DNDEBUG -MD -MT c/shared/source/CMakeFiles/t1read.dir/t1read/t1read.c.o -MF c/shared/source/CMakeFiles/t1read.dir/t1read/t1read.c.o.d -o c/shared/source/CMakeFiles/t1read.dir/t1read/t1read.c.o -c /home/skef/src/afdko2/c/shared/source/t1read/t1read.c
In file included from /usr/include/unicode/umachine.h:52,
                 from /usr/include/unicode/utypes.h:38,
                 from /usr/include/unicode/ucnv_err.h:88,
                 from /usr/include/unicode/ucnv.h:51,
                 from /usr/include/libxml2/libxml/encoding.h:31,
                 from /usr/include/libxml2/libxml/parser.h:812,
                 from /usr/include/libxml2/libxml/globals.h:18,
                 from /usr/include/libxml2/libxml/threads.h:35,
                 from /usr/include/libxml2/libxml/xmlmemory.h:218,
                 from /usr/include/libxml2/libxml/tree.h:1307,
                 from /home/skef/src/afdko2/c/shared/source/../include/ctlshare.h:18,
                 from /home/skef/src/afdko2/c/shared/source/../include/t1read.h:8,
                 from /home/skef/src/afdko2/c/shared/source/t1read/t1read.c:18:
/home/skef/src/afdko2/c/shared/source/t1read/t1read.c: In function ‘parseBool’:
/home/skef/src/afdko2/c/shared/source/t1read/t1read.c:1860:10: error: both ‘long’ and ‘_Bool’ in declaration specifiers
 1860 |     long bool = 0; /* Suppress optimizer warning */
      |          ^~~~
/home/skef/src/afdko2/c/shared/source/t1read/t1read.c:1860:15: error: expected identifier or ‘(’ before ‘=’ token
 1860 |     long bool = 0; /* Suppress optimizer warning */
      |               ^
In file included from /usr/include/unicode/umachine.h:52,
                 from /usr/include/unicode/utypes.h:38,
                 from /usr/include/unicode/ucnv_err.h:88,
                 from /usr/include/unicode/ucnv.h:51,
                 from /usr/include/libxml2/libxml/encoding.h:31,
                 from /usr/include/libxml2/libxml/parser.h:812,
                 from /usr/include/libxml2/libxml/globals.h:18,
                 from /usr/include/libxml2/libxml/threads.h:35,
                 from /usr/include/libxml2/libxml/xmlmemory.h:218,
                 from /usr/include/libxml2/libxml/tree.h:1307,
                 from /home/skef/src/afdko2/c/shared/source/../include/ctlshare.h:18,
                 from /home/skef/src/afdko2/c/shared/source/../include/t1read.h:8,
                 from /home/skef/src/afdko2/c/shared/source/t1read/t1read.c:18:
/home/skef/src/afdko2/c/shared/source/t1read/t1read.c:1865:17: error: expected expression before ‘_Bool’
 1865 |                 bool = 0;
      |                 ^~~~
/home/skef/src/afdko2/c/shared/source/t1read/t1read.c:1867:17: error: expected expression before ‘_Bool’
 1867 |                 bool = 1;
      |                 ^~~~
/home/skef/src/afdko2/c/shared/source/t1read/t1read.c:1899:17: error: expected expression before ‘_Bool’
 1899 |                 bool = value >= h->mm.ForceBoldThreshold;
      |                 ^~~~
/home/skef/src/afdko2/c/shared/source/t1read/t1read.c:1901:17: error: expected expression before ‘_Bool’
 1901 |                 bool = value >= 0.5;
      |                 ^~~~
/home/skef/src/afdko2/c/shared/source/t1read/t1read.c:1906:12: error: expected expression before ‘_Bool’
 1906 |     return bool;
      |            ^~~~

```

This is a trivial PR to change some variables named `bool` to `boole`.

We might need this as a quick rev of the recent release -- I'm not sure.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
