### PR TITLE
[workflows] fix ubuntu wheel libxml2

### DIFF
--- a/.github/scripts/patchwheel.py
+++ b/.github/scripts/patchwheel.py
@@ -1,0 +1,62 @@
+"""
+This is a modified script for patching rpath,
+originally from https://github.com/arbor-sim/arbor
+"""
+
+import shutil
+import subprocess
+import argparse
+from pathlib import Path
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description=("Patch AFDKO wheels built with scikit-build and"
+                     " corrected by auditwheel. Linux only.")
+    )
+    parser.add_argument(
+        "path",
+        type=dir_path,
+        help=("The path where your wheels are located."
+              " They will be patched in place."),
+    )
+    parser.add_argument(
+        "-ko",
+        "--keepold",
+        action="store_true",
+        help="If you want to keep the old wheels in /old",
+    )
+
+    return parser.parse_args()
+
+
+def dir_path(path):
+    path = Path(path)
+    if Path.is_dir(path):
+        return path
+    else:
+        raise argparse.ArgumentTypeError(f"{path} is not a valid path")
+
+
+parsed_args = parse_arguments()
+Path.mkdir(parsed_args.path / "old", exist_ok=True)
+
+for inwheel in parsed_args.path.glob("*.whl"):
+    zipdir = Path(f"{inwheel}.unzip")
+
+    subprocess.check_call(f"unzip {inwheel} -d {zipdir}", shell=True)
+
+    libxml2n = list(zipdir.glob("**/libxml2*.so*"))[0]
+    subprocess.check_call(f"patchelf --set-rpath '$ORIGIN' {libxml2n}",
+                          shell=True)
+
+    # TODO? correct checksum/bytecounts in *.dist-info/RECORD.
+    # So far, Python does not report mismatches
+
+    outwheel = Path(shutil.make_archive(inwheel, "zip", zipdir))
+    Path.rename(inwheel, parsed_args.path / "old" / inwheel.name)
+    Path.rename(outwheel, parsed_args.path / inwheel.name)
+    shutil.rmtree(zipdir)
+
+if not parsed_args.keepold:
+    shutil.rmtree(parsed_args.path / "old")

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -58,6 +58,7 @@ jobs:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_SKIP: "*musllinux*"
         CIBW_BEFORE_ALL_LINUX: "yum install -y libuuid-devel && yum install -y libxml2-devel"
+        CIBW_REPAIR_WHEEL_COMMAND_LINUX: 'auditwheel repair -w {dest_dir} {wheel} && python ../scripts/patchwheel.py {dest_dir}'
         CIBW_ENVIRONMENT_LINUX: "CFLAGS='-I/usr/include/libxml2'"
 
     - name: Build sdist (Ubuntu only)

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -58,7 +58,7 @@ jobs:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_SKIP: "*musllinux*"
         CIBW_BEFORE_ALL_LINUX: "yum install -y libuuid-devel && yum install -y libxml2-devel"
-        CIBW_REPAIR_WHEEL_COMMAND_LINUX: 'auditwheel repair -w {dest_dir} {wheel} && python ../scripts/patchwheel.py {dest_dir}'
+        CIBW_REPAIR_WHEEL_COMMAND_LINUX: 'auditwheel repair -w {dest_dir} {wheel} && python /project/.github/scripts/patchwheel.py {dest_dir}'
         CIBW_ENVIRONMENT_LINUX: "CFLAGS='-I/usr/include/libxml2'"
 
     - name: Build sdist (Ubuntu only)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -44,3 +44,21 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---------------------------------------------------------------------------
+
+The file patchwheel.py is copied & modified from the Arbor project
+(https://github.com/arbor-sim/arbor) under the 
+BSD 3-Clause "New" or "Revised" License:
+
+Copyright 2016-2020 Eidgenössische Technische Hochschule Zürich and Forschungszentrum Jülich GmbH.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
## Description

Trying to fix wheel issue where libxml2 installation does not have `rpath` by using patch script to fix rpath

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [ ] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
