### PR TITLE
Force `maxPoolCapacity` to be at least 1

### DIFF
--- a/python/afdko/otf2ttf.py
+++ b/python/afdko/otf2ttf.py
@@ -152,11 +152,12 @@ def main(args=None):
 
     files = list(chain.from_iterable(map(glob.glob, options.input)))
 
-    # Set the pool capacity to be the minimum of file quantity and CPU count
-    maxPoolCapacity = min(os.cpu_count(), len(files))
+    # Set the pool capacity to be the minimum of file quantity and CPU count,
+    # at least 1.
+    maxPoolCapacity = max(min(os.cpu_count(), len(files)), 1)
     # Limit parallel capacity to 60 on win32 to avoid WaitForMultipleObjects
     # errors. See https://bugs.python.org/issue45077
-    if sys.platform == "win32" and maxPoolCapacity >= 60:
+    if sys.platform == "win32" and maxPoolCapacity > 60:
         maxPoolCapacity = 60
     # Do not use "with" statement, or code coverage will malfunction.
     pool = Pool(maxPoolCapacity)


### PR DESCRIPTION
## Description

#1421 introduced only an upper-limit but not a lower one. It causes errors in some cases.

This pr shall fix the problem.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
