### PR TITLE
[uforead] Comment out warning for empty strings & update tests

### DIFF
--- a/c/shared/source/uforead/uforead.c
+++ b/c/shared/source/uforead/uforead.c
@@ -999,7 +999,7 @@ static bool keyValueValid(ufoCtx h, xmlNodePtr cur, char* keyValue, char* keyNam
 //            message(h, "Warning: Encountered empty <%s> for fontinfo key %s. Skipping", cur->name, keyName);
     } else {
         if (!strcmp(keyValue, "")){
-        message(h, "Warning: Encountered empty <%s> for fontinfo key %s. Skipping", cur->name, keyName);
+//        message(h, "Warning: Encountered empty <%s> for fontinfo key %s. Skipping", cur->name, keyName);
         valid = false;
         }
     }
@@ -1391,7 +1391,7 @@ static int parseGlyphList(ufoCtx h, bool altLayer) {
             // get key name
             tk = getElementValue(h, state);
             if (tokenEqualStr(tk, "</key>")) {
-                message(h, "Warning: Encountered empty <key></key>. Text: '%s'.", getBufferContextPtr(h));
+//                message(h, "Warning: Encountered empty <key></key>. Text: '%s'.", getBufferContextPtr(h));
             } else {
                 h->parseKeyName = copyStr(h, tk->val);  // get a copy in memory
                 // get end-key.

--- a/tests/tx_test.py
+++ b/tests/tx_test.py
@@ -1223,8 +1223,7 @@ def test_non_FDArray_dict_parse():
     ("invalid-key-name", b'', 0),
     ("missing-key-name", b'', 0),
     ("missing-key-name-2", b'', 0),
-    ("empty-key-value", b'Warning: Encountered empty <string> for fontinfo ' +
-                        b'key postscriptFontName. Skipping', 0),
+    ("empty-key-value", b'', 0),
     ("missing-key-value", b'', 0),
     ("missing-key-value-2", b'', 0),
     ("bluesarray-string", b'', 0),


### PR DESCRIPTION
## Description

Small fix for #1535 . We'll put these messages back when we add a verbose option.

## Checklist:

- [ ] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [ ] I have verified that new and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
