### PR TITLE
[uforead] Set currentiFD to 0

### DIFF
--- a/c/shared/source/uforead/uforead.c
+++ b/c/shared/source/uforead/uforead.c
@@ -1790,7 +1790,7 @@ static int parseXMLFile(ufoCtx h, char* filename, const char* filetype){
         if (setFontDictKey(h, keyName, cur) && cur != NULL)
            cur = cur->next;
     }
-    return ufoErrSrcStream;
+    return ufoSuccess;
 }
 
 /* ToDo: add extra warnings for verbose-output*/
@@ -1899,7 +1899,7 @@ static int parseFontInfo(ufoCtx h) {
     fixUnsetDictValues(h);
     h->cb.stm.close(&h->cb.stm, h->stm.src);
     h->stm.src = NULL;
-    return ufoSuccess;
+    return parsingSuccess;
 }
 
 static int parseUFO(ufoCtx h) {

--- a/c/shared/source/uforead/uforead.c
+++ b/c/shared/source/uforead/uforead.c
@@ -1881,6 +1881,7 @@ static char* parseXMLKeyValue(ufoCtx h, xmlNodePtr cur){
 
 static int parseFontInfo(ufoCtx h) {
     const char* filetype = "plist";
+    currentiFD = 0;
 
     h->src.next = h->mark = NULL;
     h->cb.stm.clientFileName = "fontinfo.plist";


### PR DESCRIPTION
## Description

I found this while debugging #1538, which looks like the problem was mostly solved for by the libxml2 changes in #1515 and #1523. The only remaining issue seems to be the following:

`currentiFD` is a variable used to track which font dict index is pointed to in the FDArray. This is used in UFO parsing of fontinfo.plist, as well as glyphs files (in that order). While parsing glyphs files, the `currentiFD` is changed to -1. `mergefonts` parses fontinfo.plist again after the glyphs files, which causes a memory leak in non-M1 and a fail in M1 Macs because `currentiFD` should start with 0 (this points to the initial font dictionary).

Since the test doesn't fail on non-M1 unless ASAN is enabled, I did not add a new test.

This is a temporary fix as I'll rewrite glyphs parsing when working on #1522

I also included a small fix where the ufoErrSrcStream was being returned instead of ufoSuccess.

## Checklist:
- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
