### PR TITLE
fix reserved ID range in name table

### DIFF
--- a/docs/OpenTypeFeatureFileSpecification.md
+++ b/docs/OpenTypeFeatureFileSpecification.md
@@ -3371,7 +3371,7 @@ nameid <id> [<string attribute>] <string>;
 ```
 
 An `<id>` is a number specifying the ID of the name string to be added to the
-name table. Note that IDs 2 and 6 (Family, Subfamily, Unique, Full, Version, and
+name table. Note that IDs 1 through 6 (Family, Subfamily, Unique, Full, Version, and
 FontName) are reserved by the implementation and cannot be overridden; doing so
 will elicit a warning message and the record will be ignored.
 


### PR DESCRIPTION
[skip ci]

The original text says "IDs 2 and 6 ... are reserved" but in parentheses gives a list of 6 fields that are reserved. "Family, Subfamily, Unique, Full, Version, and FontName" plausibly correspond to the Name IDs 1 through 6 in the OpenType spec https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-ids but annoyingly the OpenType spec doesn't give them canonical short names.

I therefore suspect that "IDs 1 through 6" is intended.

But i haven't cross-checked against what the implementation actually does.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [x] I have made corresponding changes to the documentation
