### PR TITLE
Boost number of makeinstancesufo pool processors by one

### DIFF
--- a/python/afdko/makeinstancesufo.py
+++ b/python/afdko/makeinstancesufo.py
@@ -342,7 +342,7 @@ def run(options):
 
     logger.info("Built %s instances." % newInstancesCount)
     # Remove glyph.lib and font.lib (except for "public.glyphOrder")
-    pool = multiprocessing.Pool(os.cpu_count() - 1)
+    pool = multiprocessing.Pool(os.cpu_count())
     pool.starmap(postProcessInstance, [(instancePath, options)
                                        for instancePath in newInstancesList])
 


### PR DESCRIPTION
## Description

The makeinstancesufo tests currently fail on single-processor systems due to requesting 0 cores for the multiprocessing pool. This bumps the count by one.

The motivation to leave one processor free is understandable. However, if the "organizing" thread isn't very active when the pool is running it seems fine to rely on the timesharing in the OS and just use all the cores. 

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
