### PR TITLE
Attempting to fix random Windows CI GitHub Actions failures

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ flake8-bugbear>=20.1.4
 ninja>=1.9.0
 pip>=19.0.2
 pytest-cov>=2.6.1
-pytest-xdist>=2.5.0
+pytest-xdist==3.0.2
 scikit-build==0.16.2
 setuptools>=40.8.0
 setuptools_scm>=3.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-cmake>=3.14
+cmake==3.24.3
 codecov>=2.0.15
 cpplint>=1.4.3
 cython>=0.29.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ ninja>=1.9.0
 pip>=19.0.2
 pytest-cov>=2.6.1
 pytest-xdist>=2.5.0
-scikit-build>=0.11.1
+scikit-build==0.16.2
 setuptools>=40.8.0
 setuptools_scm>=3.2.0
 wheel>=0.33.1


### PR DESCRIPTION
_Looks_ like CMake 3.25.0 is breaking our Windows build. There's a patch for 3.25.1, but it's not on PyPI yet. Looks like Cmake v3.24.3 was working fine, so this is to test if CMake version is the issue while we wait for 3.25.1 to be on PyPI.