### PR TITLE
Fixing the two instances of "rU"

### DIFF
--- a/python/afdko/agd.py
+++ b/python/afdko/agd.py
@@ -10,7 +10,7 @@ python/afdko, the set of commands is:
     import fdkutils
 	resources_dir = fdkutils.get_resources_dir()
 	kAGD_TXTPath = os.path.join(resources_dir, "AGD.txt")
-	fp = open(kAGD_TXTPath, "rU")
+	fp = open(kAGD_TXTPath, "r")
 	agdTextPath = fp.read()
 	fp.close()
 	gAGDDict = agd.dictionary(agdTextPath)

--- a/python/afdko/comparefamily.py
+++ b/python/afdko/comparefamily.py
@@ -5010,7 +5010,7 @@ def main():
 	from afdko import agd
 	resources_dir = fdkutils.get_resources_dir()
 	kAGD_TXTPath = os.path.join(resources_dir, "AGD.txt")
-	fp = open(kAGD_TXTPath, "rU")
+	fp = open(kAGD_TXTPath, "r")
 	agdTextPath = fp.read()
 	fp.close()
 	gAGDDict = agd.dictionary(agdTextPath)


### PR DESCRIPTION
## Description

Replaces the two instances of "rU" with "r", as python now deals with newlines by default since Python 3.4. Fixes #1583

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [-] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
