### PR TITLE
Restore stack-like behavior of parseGLIF transform pointer

### DIFF
--- a/c/shared/source/uforead/uforead.c
+++ b/c/shared/source/uforead/uforead.c
@@ -796,7 +796,7 @@ static void matMult(float* result, float* a, float* b) {
 static void setTransformValue(Transform* transform, float val, int valIndex) {
     transform->mtx[valIndex] = val;
     if ((valIndex == 0) || (valIndex == 3)) {
-        if (valIndex != 1.0) {
+        if (val != 1.0) {
             transform->isDefault = 0;
             transform->isOffsetOnly = 0;
         }
@@ -2750,9 +2750,11 @@ static int parseGLIF(ufoCtx h, abfGlyphInfo* gi, abfGlyphCallbacks* glyph_cb, Tr
      We need to convert it to the initial move-to, but we also need to
      re-issue it as the original point type at the end of the path.
      */
+    Transform *currentTransform;
 
     const char* filetype = "glyph";
     h->parseState.UFOFile = parsingGLIF;
+    currentTransform = h->parseState.GLIFInfo.transform;
     h->parseState.GLIFInfo.transform = transform;
     int result = ufoSuccess;
     int state = outlineStart;
@@ -2785,6 +2787,7 @@ static int parseGLIF(ufoCtx h, abfGlyphInfo* gi, abfGlyphCallbacks* glyph_cb, Tr
 
     /* An odd exit - didn't see  "</glyph>"  */
     h->cb.stm.close(&h->cb.stm, h->stm.src);
+    h->parseState.GLIFInfo.transform = currentTransform;
     return result;
 }
 


### PR DESCRIPTION
Also Fix ancient transform->isDefault logic error.

## Description

What it says on the tin.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
