### PR TITLE
Force static link of libxml2 on both windows and linux

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -60,7 +60,7 @@ jobs:
         # CIBW_BEFORE_ALL_LINUX: "yum install -y libuuid-devel && yum install -y libxml2-devel"
         # CIBW_ENVIRONMENT_LINUX: "CFLAGS='-I/usr/include/libxml2'"
         CIBW_BEFORE_ALL_LINUX: "yum install -y libuuid-devel"
-        CIBW_ENVIRONMENT_LINUX: "FORCE_BUILD_LIBXML2=ON"
+        CIBW_ENVIRONMENT: "FORCE_BUILD_LIBXML2=ON"
 
     - name: Build sdist (Ubuntu only)
       if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION

## Description

What it says on the tin.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [ ] I have verified that new and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
