### PR TITLE
flake8 fix

### DIFF
--- a/python/afdko/checkoutlinesufo.py
+++ b/python/afdko/checkoutlinesufo.py
@@ -113,7 +113,8 @@ class FontFile(object):
         else:
             if self.ufo_format <= UFOFormatVersion.FORMAT_2_0:
                 # Up-convert the UFO to format 3
-                warnings.warn("The UFO was up-converted to format 3.")
+                warnings.warn("The UFO was up-converted to format 3.",
+                              UserWarning)
                 self.ufo_format = UFOFormatVersion.FORMAT_3_0
 
                 with UFOWriter(self.defcon_font.path,

--- a/python/afdko/checkoutlinesufo.py
+++ b/python/afdko/checkoutlinesufo.py
@@ -114,7 +114,7 @@ class FontFile(object):
             if self.ufo_format <= UFOFormatVersion.FORMAT_2_0:
                 # Up-convert the UFO to format 3
                 warnings.warn("The UFO was up-converted to format 3.",
-                              UserWarning)
+                              UserWarning, stacklevel=2)
                 self.ufo_format = UFOFormatVersion.FORMAT_3_0
 
                 with UFOWriter(self.defcon_font.path,


### PR DESCRIPTION
## Description

flake8 was failing on linux due to the stacklevel being a default of 1 in a checkoutlinesufo warning. Updating to fix flake8 failure.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
~~- [ ] I have added **test code and data** to prove that my code functions correctly~~
- [ ] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
