### PR TITLE
[requirements.txt][buildcff2vf_data] fonttools update fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ lxml==4.9.2
 booleanOperations==0.9.0
 defcon[lxml,pens]==0.10.2
 fontMath==0.9.3
-fontTools[unicode,woff,lxml,ufo]==4.38.0
+fontTools[unicode,woff,lxml,ufo]==4.39.0
 psautohint==2.4.0
 tqdm==4.64.1
 ufonormalizer==0.6.1

--- a/tests/buildcff2vf_data/expected_output/GSUBVar.ttx
+++ b/tests/buildcff2vf_data/expected_output/GSUBVar.ttx
@@ -238,7 +238,7 @@
         <FeatureTag value="test"/>
         <Feature>
           <!-- LookupCount=1 -->
-          <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="0" value="1"/>
         </Feature>
       </FeatureRecord>
     </FeatureList>
@@ -280,7 +280,7 @@
             <FeatureIndex value="0"/>
             <Feature>
               <!-- LookupCount=1 -->
-              <LookupListIndex index="0" value="1"/>
+              <LookupListIndex index="0" value="0"/>
             </Feature>
           </SubstitutionRecord>
         </FeatureTableSubstitution>


### PR DESCRIPTION
## Description

Expected test output fix for [fonttools v4.39.0 rvrn update](https://github.com/fonttools/fonttools/releases/tag/4.39.0):
> [featureVars] Insert ‘rvrn’ lookup at the beginning of LookupList, to work around bug in Apple implementation of ‘rvrn’ feature which the spec says it should be processed early whereas on macOS 10.15 it follows lookup order ([#2140](https://github.com/fonttools/fonttools/issues/2140), [#2867](https://github.com/fonttools/fonttools/pull/2867)).

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [x] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
