### PR TITLE
[spot] fix 'kern' subtable Format3 rightClass memory leak (double allocation).

### DIFF
--- a/c/spot/source/kern.c
+++ b/c/spot/source/kern.c
@@ -119,7 +119,6 @@ static Format3 *read3(Card32 offset, Card32 length) {
     fmt->kernValue = (FWord *)memNew(sizeof(FWord) * fmt->kernValueCount);
     fmt->leftClass = (Card8 *)memNew(sizeof(Card8) * fmt->glyphCount);
     fmt->rightClass = (Card8 *)memNew(sizeof(Card8) * fmt->glyphCount);
-    fmt->rightClass = (Card8 *)memNew(sizeof(Card8) * fmt->glyphCount);
     fmt->kernIndex = (Card8 *)memNew(sizeof(Card8) * kernIndexSize);
 
     /* Read value arrays */


### PR DESCRIPTION
## Description
This is a bug fix for #1626 [spot] kern.c memory leak. 

## Checklist:
Regarding the following checklist, I've tried to get the tests to run and pass locally for me and I can't seem to get that working despite switching to Python 3.10 (from 3.11; that actually made it worse). The failures seem consistent and AFAICT, aren't related to `spot`. I'm hoping you guys can test on your end to confirm?

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [ ] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

The last 2 don't really seem applicable to such a minor change.