### PR TITLE
Drop Python 3.7

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install multilib packages
       run: sudo apt-get install gcc-multilib g++-multilib

--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -28,20 +28,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         exclude:
           - os: macos-latest
-            python-version: "3.7"
-          - os: macos-latest
             python-version: "3.8"
           - os: macos-latest
             python-version: "3.9"
-          - os: windows-latest
-            python-version: "3.7"
+          - os: macos-latest
+            python-version: "3.10"
           - os: windows-latest
             python-version: "3.8"
           - os: windows-latest
             python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.10"
 
     steps:
 

--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -34,14 +34,10 @@ jobs:
             python-version: "3.8"
           - os: macos-latest
             python-version: "3.9"
-          - os: macos-latest
-            python-version: "3.10"
           - os: windows-latest
             python-version: "3.8"
           - os: windows-latest
             python-version: "3.9"
-          - os: windows-latest
-            python-version: "3.10"
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ projects.
 Installation
 ------------
 
-The AFDKO requires [Python](http://www.python.org/download) 3.7
-or later. **⚠️ Starting April 3, 2023, the AFDKO will require Python 3.8 or later.** Due to our dependencies already dropping support and requiring Python 3.8 in their latest versions, we will also be dropping Python 3.7 support on April 3, 2023.
+The AFDKO requires [Python](http://www.python.org/download) 3.8
+or later.
 Regarding Python 3.11: while Python 3.11 itself is now relatively stable, we are waiting to let some known tool-chain problems resolve.
 
 Releases are available on the [Python Package
@@ -107,7 +107,7 @@ On the Mac, install these with:
 
 On Linux (Ubuntu 17.10 LTS or later), install these with:
 
-    apt-get -y install python3.7
+    apt-get -y install python3.8
     apt-get -y install python-pip
     apt-get -y install python-dev
     apt-get -y install uuid-dev

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 cmake>=3.14
-codecov>=2.0.15
 cpplint>=1.4.3
 cython>=0.29.5
 flake8>=3.7.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ lxml==4.9.2
 booleanOperations==0.9.0
 defcon[lxml,pens]==0.10.2
 fontMath==0.9.3
-fontTools[unicode,woff,lxml,ufo]<=4.39.3
+fontTools[unicode,woff,lxml,ufo]<=4.38.0
 psautohint==2.4.0
 tqdm==4.64.1
 ufonormalizer==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ lxml==4.9.2
 booleanOperations==0.9.0
 defcon[lxml,pens]==0.10.2
 fontMath==0.9.3
-fontTools[unicode,woff,lxml,ufo]<=4.38.0
+fontTools[unicode,woff,lxml,ufo]<=4.39.3
 psautohint==2.4.0
 tqdm==4.64.1
 ufonormalizer==0.6.1

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ def main():
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',
@@ -192,7 +192,7 @@ def main():
               ],
           },
           zip_safe=False,
-          python_requires='>=3.7',
+          python_requires='>=3.8',
           setup_requires=[
               'wheel',
               'setuptools_scm',


### PR DESCRIPTION
## Description

⚠️ Starting April 3, 2023, the AFDKO will require Python 3.8 or later. Due to our dependencies already dropping support and requiring Python 3.8 in their latest versions, we will also be dropping Python 3.7 support on April 3, 2023.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
