### PR TITLE
[spot] fix name table LANG_TAG_REC_SIZE size definition.

### DIFF
--- a/c/spot/sfnt_includes/sfnt_name.h
+++ b/c/spot/sfnt_includes/sfnt_name.h
@@ -32,8 +32,8 @@ typedef struct
     Card16 length;
     Card16 offset;
 } LangTagRecord;
-#define LANG_TAG_REC_SIZE (SIZEOF(NameRecord, length) + \
-                           SIZEOF(NameRecord, offset))
+#define LANG_TAG_REC_SIZE (SIZEOF(LangTagRecord, length) + \
+                           SIZEOF(LangTagRecord, offset))
 
 typedef struct
 {


### PR DESCRIPTION
Correcting this definition doesn't actually change the value, since the sizes of the `length` and `offset` fields of `LangTagRecord` are identical to those of the `NameRecord`.

## Description

This is a bug fix for #1636 name table LANG_TAG_REC_SIZE size definition.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [ ] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

Since this doesn't actually have any effective change, I didn't run the tests (which I still haven't been able to get fully working yet).