### PR TITLE
[hotconv] 'name': fix memory leak in addName()

### DIFF
--- a/c/makeotf/lib/hotconv/name.c
+++ b/c/makeotf/lib/hotconv/name.c
@@ -173,19 +173,15 @@ static void addName(nameCtx h,
                     size_t length, char *str) {
     char *dst;
     char *newStr;
-    newStr = MEM_NEW(h->g, length * sizeof(char));
     NameRecord *rec;
     int index;
     int omitMacNames = (h->g->convertFlags & HOT_OMIT_MAC_NAMES); /* omit all Mac platform names. */
 
-    if (platformId == HOT_NAME_MAC_PLATFORM) {
-        if (omitMacNames)
-            return;
-    }
-
     if (omitMacNames && (platformId == HOT_NAME_MAC_PLATFORM)) {
         return;
     }
+
+    newStr = MEM_NEW(h->g, length * sizeof(char));
 
     index = enumNames(h, 0, platformId, platspecId, languageId, nameId);
 


### PR DESCRIPTION
## Description

This fixes https://github.com/adobe-type-tools/afdko/issues/1643 [hotconv] 'name': memory leak in addName().

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [ ] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

As I've mentioned before, I still don't have testing figured out locally on my end, so I'll submit this and see how the tests do on your end.