### PR TITLE
[hotconv] reset dsigCnt in hotReuse() so subsequent conversions add full stub 'DSIG' table.

### DIFF
--- a/c/makeotf/lib/hotconv/hot.c
+++ b/c/makeotf/lib/hotconv/hot.c
@@ -851,6 +851,8 @@ static void setVBounds(hotCtx g) {
     }
 }
 
+static unsigned int dsigCnt = 0;
+
 static void hotReuse(hotCtx g) {
     g->hadError = 0;
     g->convertFlags = 0;
@@ -859,11 +861,11 @@ static void hotReuse(hotCtx g) {
     sfntReuse(g);
     mapReuse(g);
     featReuse(g);
+    dsigCnt = 0;
 }
 
 char *refillDSIG(void *ctx, long *count, unsigned long tag) {
     static const char data[] = "\x00\x00\x00\x01\x00\x00\x00";
-    static unsigned int dsigCnt = 0;
     if (dsigCnt == 0) {
         *count = 8;
         dsigCnt = 1;


### PR DESCRIPTION
## Description
This is a patch to fix bug #1647. Basically, I moved the static `dsigCount` variable outside the `refillDSIG()` function, and reset it in `hotReuse()`.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation


I think I finally have all local tests working except for `test_infinite_loop_with_dflt_lookups_bug965()`. That test fails before and after my changes, so I don't think it'd be related.

Unlike the previous bugs I've encountered , this strikes me as one that could probably use a test? The thing is, as I've mentioned elsewhere, I'm not sure if it's possible to trigger this bug using existing tools, and I'm still in the process of learning Python enough to write a test. If you think it warrants a test and could create one, that would certainly help in my learning process.
 