### PR TITLE
[hotconv] fix warning for negative TypoLineGap.

### DIFF
--- a/c/makeotf/lib/hotconv/hot.c
+++ b/c/makeotf/lib/hotconv/hot.c
@@ -764,7 +764,7 @@ static void prepWinData(hotCtx g) {
     }
 
     /* warn if the line gap is negative. */
-    if (font->TypoAscender < 0) {
+    if (font->TypoLineGap < 0) {
         hotMsg(g, hotWARNING, "The feature file OS/2 override TypoLineGap value is negative!");
     }
 


### PR DESCRIPTION
## Description
This is a fix for #1653.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

I ran tests locally and they all passed except the infinite loop one which always crashes for me.

It seems like it might be useful to have a new test that checks for that warning but I don't yet know enough about the testing framework to be able to write one myself.