### PR TITLE
[requirements.txt] change fontTools version from '<=' to '=='

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ lxml==4.9.2
 booleanOperations==0.9.0
 defcon[lxml,pens]==0.10.2
 fontMath==0.9.3
-fontTools[unicode,woff,lxml,ufo]<=4.39.4
+fontTools[unicode,woff,lxml,ufo]==4.39.4
 psautohint==2.4.0
 tqdm==4.65.0
 ufonormalizer==0.6.1


### PR DESCRIPTION
to accept more versions.
Should fix #1660 

## Description

* currently, setup.py changes '==' to '>=' but we had set fontTools to '<=' due to an earlier issue where we had to pin the version number. We no longer need to pin the version number, so we're changing it back to '=='.
* as Miguel mentioned, we should add support for more string replacement cases in setup.py — I'll look at that in a few days, but pushing this PR first to get a pre-release out for issue #1660 .

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [ ] I have verified that new and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
