### PR TITLE
Remove `types` setting from `pull_request`

### DIFF
--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -8,7 +8,6 @@ on:
 
   pull_request:
     branches: [develop]
-    types: [opened]
     paths-ignore:
       - 'docs/**'
       - '**.md'


### PR DESCRIPTION
Removes the `types` setting from `pull_request` section of workflow files.

This setting was originally added to prevent the CI from triggering twice (on `push` and on `pull-request`) with each commit to a branch with an opened PR. The current workflow configuration works fine for developers that have privileges to push branches to the repo, but it has the adverse side-effect of getting the CI stuck on PRs from forks, if the external developer makes commits to their branches after the PR has been opened.

I've made this same change on another project and I'm only seeing duplicate CI runs on one kind of event: when the PR is opened. After that, all commits to the branch only trigger `pull_request` CI runs (and not `push` CI runs).