### PR TITLE
[buildcff2vf] Don't return zero when input requires compatibilization

### DIFF
--- a/python/afdko/buildcff2vf.py
+++ b/python/afdko/buildcff2vf.py
@@ -23,7 +23,7 @@ from fontTools.varLib.cff import (CFF2CharStringMergePen,
 
 from afdko.fdkutils import validate_path
 
-__version__ = '2.0.2'
+__version__ = '2.0.3'
 
 STAT_FILENAME = 'override.STAT.ttx'
 
@@ -572,7 +572,7 @@ def main(args=None):
     except VarLibCFFPointTypeMergeError:
         logger.error("The input set requires compatibilization. Please try "
                      "again with the -c (--check-compat) option.")
-        return 0
+        return 1
 
     if not options.keep_glyph_names:
         suppress_glyph_names(varFont)

--- a/tests/buildcff2vf_test.py
+++ b/tests/buildcff2vf_test.py
@@ -97,7 +97,8 @@ def test_bug1003(capfd):
     temp_dir = get_temp_dir_path('bug1003var')
     copytree(input_dir, temp_dir)
     ds_path = os.path.join(temp_dir, 'bug1003.designspace')
-    runner(CMD + ['-o', 'd', f'_{ds_path}'])
+    with pytest.raises(subprocess.CalledProcessError):
+        runner(CMD + ['-o', 'd', f'_{ds_path}'])
     captured = capfd.readouterr()
     assert "The input set requires compatibilization" in captured.err
 


### PR DESCRIPTION
## Description

What the title says. Fixes #1667.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [x] I have ~added~ updated **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
