### PR TITLE
[sfntedit] Fix bug when attempting to add non-existent file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ cov*.xml
 
 # temp output dirs created during tests
 **/temp_output
+
+# macOS cruft
+.DS_Store

--- a/c/sfntedit/source/Efile.c
+++ b/c/sfntedit/source/Efile.c
@@ -45,9 +45,9 @@ int fileExists(const char *filename) {
 void fileOpenRead(const char *filename, File *fyl) {
     {
         fyl->fp = sysOpenSearchpath(filename);
+        fyl->name = filename;
         if (fyl->fp == NULL)
             fileError(fyl);
-        fyl->name = filename;
     }
 }
 

--- a/c/sfntedit/source/main.c
+++ b/c/sfntedit/source/main.c
@@ -39,7 +39,7 @@ jmp_buf mark;
 
 #endif /* SUNOS */
 
-#define VERSION "1.4.3"
+#define VERSION "1.4.4"
 
 /* Data type sizes (bytes) */
 #define uint16_ 2

--- a/tests/sfntedit_test.py
+++ b/tests/sfntedit_test.py
@@ -98,3 +98,13 @@ def test_missing_table_extract_bug160():
     assert b'[WARNING]: table missing (xyz )' in output
     expected_path = get_expected_path('head_light.tb')
     assert differ([expected_path, actual_path, '-m', 'bin'])
+
+
+def test_missing_file_add_bug_1658():
+    font_path = get_input_path(ITALIC)
+    actual_path = get_temp_file_path()
+    stderr_path = runner(CMD + ['-s', '-e', '-o', 'a', '_GDEF=non_existing_GDEF_file',  # noqa: E501
+                         '-f', font_path, actual_path])
+    with open(stderr_path, 'rb') as f:
+        output = f.read()
+    assert b'[FATAL]: file error <No such file or directory> [non_existing_GDEF_file]' in output  # noqa: E501


### PR DESCRIPTION
## Description

Modified sfntedit code to show the correct filename when non-existing file is specified for adding a table (`-a` mode).

Closes #1658

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [x] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
