### PR TITLE
add guards for h->otl == NULL before calling otlSubtableAdd

### DIFF
--- a/c/makeotf/include/hotconv.h
+++ b/c/makeotf/include/hotconv.h
@@ -12,7 +12,7 @@ This software is licensed as OpenSource, under the Apache License, Version 2.0. 
 extern "C" {
 #endif
 
-#define HOT_VERSION 0x010100 /* Library version (1.1.0) */
+#define HOT_VERSION 0x010101 /* Library version (1.1.1) */
 /* Major, minor, build = (HOT_VERSION >> 16) & 0xff, (HOT_VERSION >> 8) & 0xff, HOT_VERSION & 0xff) */
 /* Warning: this string is now part of heuristic used by CoolType to identify the
 first round of CoolType fonts which had the backtrack sequence of a chaining

--- a/c/makeotf/lib/hotconv/GPOS.c
+++ b/c/makeotf/lib/hotconv/GPOS.c
@@ -379,6 +379,10 @@ int GPOSFill(hotCtx g) {
 
     createAnonLookups(g, h);
 
+    if (h->otl == NULL) {
+        return 0;
+    }
+
     /* Add OTL features */
     /* See GSUB.c::GSUBFill() for an explanation of the subtable order */
 

--- a/c/makeotf/lib/hotconv/GSUB.c
+++ b/c/makeotf/lib/hotconv/GSUB.c
@@ -217,6 +217,10 @@ int GSUBFill(hotCtx g) {
 
     createAnonLookups(g, h);
 
+    if (h->otl == NULL) {
+        return 0;
+    }
+
     /* Add OTL features */
 
     /* The font tables are in the order:

--- a/tests/makeotfexe_data/expected_output/bug1349.ttx
+++ b/tests/makeotfexe_data/expected_output/bug1349.ttx
@@ -18,7 +18,7 @@
       Noto Sans Mono CJK JP VF
     </namerecord>
     <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
-      Version 2.004;hotconv 1.1.0;makeotfexe 2.6.0
+      Version 2.004;hotconv 1.1.1;makeotfexe 2.6.0
     </namerecord>
     <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
       NotoSansMonoCJKjpVF-Regular


### PR DESCRIPTION
## Description

Add guards for h->otl == NULL in GSUB and GPOS code. Previously this was not explicitly checked, but could be NULL resulting in segfault.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] ~~I have added **test code and data** to prove that my code functions correctly~~
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
