### PR TITLE
Add Python 3.11 to CI test matrix

### DIFF
--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -28,16 +28,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         exclude:
           - os: macos-latest
             python-version: "3.8"
           - os: macos-latest
             python-version: "3.9"
+          - os: macos-latest
+            python-version: "3.10"
           - os: windows-latest
             python-version: "3.8"
           - os: windows-latest
             python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.10"
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ Installation
 ------------
 
 The AFDKO requires [Python](http://www.python.org/download) 3.8
-or later.
-Regarding Python 3.11: while Python 3.11 itself is now relatively stable, we are waiting to let some known tool-chain problems resolve.
+or later. It should work with any Python > 3.8, but occasionally
+tool-chain components and dependencies don't keep pace with major
+Python releases, so there might be some lag time while they catch up.
 
 Releases are available on the [Python Package
 Index](https://pypi.python.org/pypi/afdko) (PyPI) and can be installed


### PR DESCRIPTION
## Description

Add Python 3.11 to the testing matrix and update the README.md description of supported Python versions.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [x] I have added **test code and data** to prove that my code functions correctly
- [ ] ~~I have verified that new and existing tests pass locally with my changes~~
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
