### PR TITLE
Fix build failures discovered by an upcoming `gcc-14` release

### DIFF
--- a/c/shared/source/t1write/t1write.c
+++ b/c/shared/source/t1write/t1write.c
@@ -345,7 +345,8 @@ static int saveCstr(t1wCtx h, abfGlyphInfo *info,
     if (info != NULL && info->flags & ABF_GLYPH_CID &&
         !(h->arg.flags & T1W_TYPE_HOST)) {
         /* CID-keyed incremental download; write fd index */
-        if (writeTmp(h, 1, &info->iFD))
+        unsigned char c = info->iFD;
+        if (writeTmp(h, 1, &c))
             return 1;
         cstr->length++;
     }

--- a/c/shared/source/tx_shared/tx_shared.c
+++ b/c/shared/source/tx_shared/tx_shared.c
@@ -386,7 +386,7 @@ static long stm_tell(ctlStreamCallbacks *cb, void *stream) {
 }
 
 /* Read from stream. */
-static size_t stm_read(ctlStreamCallbacks *cb, Stream *stream, char **ptr) {
+static size_t stm_read(ctlStreamCallbacks *cb, void *stream, char **ptr) {
     Stream *s = stream;
     switch (s->type) {
         case stm_Src:
@@ -405,7 +405,7 @@ static size_t stm_read(ctlStreamCallbacks *cb, Stream *stream, char **ptr) {
     return 0; /* Suppress compiler warning */
 }
 
-static size_t stm_xml_read(ctlStreamCallbacks *cb, Stream *stream, xmlDocPtr *doc){
+static size_t stm_xml_read(ctlStreamCallbacks *cb, void *stream, xmlDocPtr *doc){
     int res;
     int readAmt = 0;
     xmlParserCtxtPtr ctxt;

--- a/c/shared/source/uforead/uforead.c
+++ b/c/shared/source/uforead/uforead.c
@@ -1240,7 +1240,7 @@ static void updateGLIFRec(ufoCtx h, char* glyphName, xmlNodePtr cur) {
     if (fileName == NULL) {
         /* this is basically muted for now, as the previous check will return and skip if not parseable.
            We'll add this back once we add verbosity flag */
-        message(h, ufoErrParse, "Encountered glyph reference %s in alternate layer's contents.plist with an empty file path. ", glyphName);
+        message(h, "Encountered glyph reference %s in alternate layer's contents.plist with an empty file path. ", glyphName);
         return;
     }
 
@@ -2004,7 +2004,7 @@ static long strtolCheck(ufoCtx h, char* keyValue, bool fail, char* msg, int base
             fatal(h, ufoErrParse, msg);
         else if (msg)
             message(h, msg);
-        return NULL;
+        return 0;
     }
 }
 
@@ -2019,7 +2019,7 @@ static unsigned long strtoulCheck(ufoCtx h, char* keyValue, bool fail, char* msg
             fatal(h, ufoErrParse, msg);
         else if (msg)
             message(h, msg);
-        return NULL;
+        return 0;
     }
 }
 

--- a/tests/tx_test.py
+++ b/tests/tx_test.py
@@ -1677,7 +1677,7 @@ def test_alt_missing_glyph():
     assert msg in output
     expected_path = generate_ps_dump(expected_path)
     output_path = generate_ps_dump(output_path)
-    assert differ([expected_path, output_path])
+    assert differ([expected_path, output_path, '-s', PFA_SKIP[0]])
 
 
 def test_parsing_attrs_bug1673():


### PR DESCRIPTION
## Description

Upcoming `gcc-14` enabled a few warnings into errors. This exposed build failures related to pointer type confusion.
