### PR TITLE
[docs] hhea.Descender should be negative for descent below the baseline

### DIFF
--- a/docs/OpenTypeFeatureFileSpecification.md
+++ b/docs/OpenTypeFeatureFileSpecification.md
@@ -3350,7 +3350,7 @@ For example:
 table hhea {
     CaretOffset -50;
     Ascender 800;
-    Descender 200;
+    Descender -200; # Note that Descender is negative for descent below the baseline.
     LineGap 200;
 } hhea;
 ```


### PR DESCRIPTION
## Description

Refer to: https://glyphsapp.com/learn/vertical-metrics

hhea:
hheaAscender: the height of the ascenders in units
hheaDescender: the depth of the descenders in units (negative value)     # <----- This
hheaLineGap: the recommended whitespace between lines


## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [ ] I have verified that new and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
