### PR TITLE
[makeinstancesufo] keep all public lib keys in instances

### DIFF
--- a/python/afdko/makeinstancesufo.py
+++ b/python/afdko/makeinstancesufo.py
@@ -112,7 +112,7 @@ def updateInstance(fontInstancePath, options):
 
 def clearCustomLibs(dFont):
     for key in list(dFont.lib.keys()):
-        if key not in ['public.glyphOrder', 'public.postscriptNames']:
+        if not key.startswith('public.'):
             del dFont.lib[key]
 
     libGlyphs = [g for g in dFont if len(g.lib)]


### PR DESCRIPTION
## Description

This slightly alters the behaviour of makeinstancesufo’s postProcessInstance. clearCustomLibs now keeps all lib keys that start with `public.`.

fixes adobe-type-tools/afdko#1746

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [ ] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
