### PR TITLE
Fix a couple otfautohint bugs found by testing with Momochidori

### DIFF
--- a/python/afdko/otfautohint/__main__.py
+++ b/python/afdko/otfautohint/__main__.py
@@ -343,6 +343,7 @@ class HintOptions(ACOptions):
         self.writeToDefaultLayer = pargs.write_to_default_layer
         self.maxSegments = pargs.max_segments
         self.verbose = pargs.verbose
+        self.looseOverlapMapping = pargs.loose_overlap_mapping
         if pargs.force_overlap:
             self.overlapForcing = True
         elif pargs.force_no_overlap:
@@ -580,6 +581,14 @@ def add_common_options(parser, term, name):
         help='Do not correct for potential overlap on any glyphs (the '
              'default when hinting individual, non-variable fonts and not '
              'supplying an overlap list)'
+    )
+    overlap_parser.add_argument(
+        '--loose-overlap-mapping',
+        action='store_true',
+        help='Some fonts see high numbers of "Unable to map derived path '
+             'element from ..." warnings when processing overlap. This flag '
+             'loosens the matching heuristics and should lower (but not '
+             'eliminate) the number of those warnings'
     )
     parser.add_argument(
         '--log',
@@ -865,6 +874,7 @@ class ReportOptions(ACOptions):
         self.report_zones = pargs.alignment_zones
         self.report_all_stems = pargs.all_stems
         self.verbose = pargs.verbose
+        self.looseOverlapMapping = pargs.loose_overlap_mapping
         if pargs.force_overlap:
             self.overlapForcing = True
         elif pargs.force_no_overlap:

--- a/python/afdko/otfautohint/autohint.py
+++ b/python/afdko/otfautohint/autohint.py
@@ -37,6 +37,7 @@ class ACOptions(object):
         self.excludeGlyphList = False
         self.overlapList = []
         self.overlapForcing = None
+        self.looseOverlapMapping = False
         self.hintAll = False
         self.readHints = True
         self.allowChanges = False

--- a/python/afdko/otfautohint/glyphData.py
+++ b/python/afdko/otfautohint/glyphData.py
@@ -515,6 +515,7 @@ class pathElement:
     """
     assocMatchFactor = 93
     tSlop = .005
+    middleMult = 2
 
     def __init__(self, *args, is_close=False, masks=None, flex=False,
                  position=None):
@@ -625,12 +626,13 @@ class pathElement:
         """Returns the fontTools cubic parameters for this pathElement"""
         return calcCubicParameters(self.s, self.cs, self.ce, self.e)
 
-    def getAssocFactor(self):
+    def getAssocFactor(self, loose=False):
         if self.is_line:
             l = sqrt(self.s.distsq(self.e))
         else:
             l = approximateCubicArcLength(self.s, self.cs, self.ce, self.e)
-        return l / self.assocMatchFactor
+        return l / (self.assocMatchFactor / 2
+                    if loose else self.assocMatchFactor)
 
     def containsPoint(self, p, factor, returnT=False):
         if self.is_line:
@@ -1264,11 +1266,12 @@ class glyphData(BasePen):
 
     # utility
 
-    def checkAssocPoint(self, segs, spe, ope, sp, op, mapEnd, factor=None):
+    def checkAssocPoint(self, segs, spe, ope, sp, op, mapEnd, loose,
+                        factor=None):
         if factor is None:
-            factor = ope.getAssocFactor()
+            factor = ope.getAssocFactor(loose)
         if sp == op or ope.containsPoint(sp, factor):
-            if not ope.containsPoint(spe.atT(.5), factor):
+            if not ope.containsPoint(spe.atT(.5), factor * ope.middleMult):
                 return False
             spe.association = ope
             return True
@@ -1276,7 +1279,8 @@ class glyphData(BasePen):
             does, t = spe.containsPoint(op, factor, True)
             if does and spe.tSlop < t < 1 - spe.tSlop:
                 midMapped = (1 - (1 - t) / 2) if mapEnd else t / 2
-                if not ope.containsPoint(spe.atT(midMapped), factor):
+                if not ope.containsPoint(spe.atT(midMapped),
+                                         factor * ope.middleMult):
                     return False
                 following = spe.splitAt(t)
                 if mapEnd:
@@ -1293,7 +1297,7 @@ class glyphData(BasePen):
                 return True
         return False
 
-    def associatePath(self, orig):
+    def associatePath(self, orig, loose=False):
         peMap = defaultdict(list)
         for oc in orig:
             peMap[tuple(oc.e.round(1))].append(oc)
@@ -1309,13 +1313,14 @@ class glyphData(BasePen):
             oepel = peMap.get(tuple(c.e.round(1)), [])
             if oepel:
                 for oepe in oepel:
-                    if self.checkAssocPoint(segs, c, oepe, c.s, oepe.s, True):
+                    if self.checkAssocPoint(segs, c, oepe, c.s, oepe.s, True,
+                                            loose):
                         done = True
                         break
                     else:
                         oepen = orig.nextInSubpath(oepe)
                         if self.checkAssocPoint(segs, c, oepen, c.s, oepen.e,
-                                                True):
+                                                True, loose):
                             done = True
                             break
                 if done:
@@ -1325,24 +1330,24 @@ class glyphData(BasePen):
                 for ospe in ospel:
                     ospen = orig.nextInSubpath(ospe)
                     if self.checkAssocPoint(segs, c, ospen, c.e, ospen.e,
-                                            False):
+                                            False, loose):
                         done = True
                         break
                     elif self.checkAssocPoint(segs, c, ospe, c.e, ospe.s,
-                                              False):
+                                              False, loose):
                         done = True
                         break
                 if done:
                     continue
             cBounds = c.getBounds()
             for oc in orig:
-                factor = oc.getAssocFactor()
+                factor = oc.getAssocFactor(loose)
                 if cBounds.intersects(oc.getBounds(), factor):
                     if (oc.containsPoint(c.s, factor) and
                             (self.checkAssocPoint(segs, c, oc, c.e, oc.e,
-                                                  False, factor) or
+                                                  False, loose, factor) or
                              self.checkAssocPoint(segs, c, oc, c.e, oc.s,
-                                                  False, factor))):
+                                                  False, loose, factor))):
                         done = True
                         break
             if done:
@@ -1351,13 +1356,13 @@ class glyphData(BasePen):
             # was very close to but not quite identical to another start point.
             # Try again from the other end.
             for oc in orig:
-                factor = oc.getAssocFactor()
+                factor = oc.getAssocFactor(loose)
                 if cBounds.intersects(oc.getBounds(), factor):
                     if (oc.containsPoint(c.e, factor) and
                             (self.checkAssocPoint(segs, c, oc, c.s, oc.s,
-                                                  True, factor) or
+                                                  True, loose, factor) or
                              self.checkAssocPoint(segs, c, oc, c.s, oc.e,
-                                                  True, factor))):
+                                                  True, loose, factor))):
                         done = True
                         break
             if done:

--- a/python/afdko/otfautohint/hinter.py
+++ b/python/afdko/otfautohint/hinter.py
@@ -667,8 +667,7 @@ class dimensionHinter:
         of the segment are within ExtremaDist of pe
         """
         a, b, c, d = pe.cubicParameters()
-        loc = round(extp.o) + (-self.ExtremaDist
-                               if isMn else self.ExtremaDist)
+        loc = extp.o + (-self.ExtremaDist if isMn else self.ExtremaDist)
 
         horiz = not self.isV()  # When finding vertical stems solve for x
         sl = solveCubic(a[horiz], b[horiz], c[horiz], d[horiz] - loc)
@@ -776,7 +775,8 @@ class dimensionHinter:
                 origGlyph = None
                 self.hs.overlapRemoved = False
             else:
-                self.glyph.associatePath(origGlyph)
+                self.glyph.associatePath(origGlyph,
+                                         self.options.looseOverlapMapping)
 
         self.prepForSegs()
         self.Bonus = 0
@@ -2446,11 +2446,10 @@ class glyphHinter:
                 gp = g.subpaths[si]
                 dpl, gpl = len(dp), len(gp)
                 if gpl != dpl:
-                    # XXX decide on warning message for these
                     if (gpl == dpl + 1 and gp[-1].isClose() and
                             not dp[-1].isClose()):
                         for _gi in range(i + 1):
-                            gllist[i].addNullClose(si)
+                            gllist[_gi].addNullClose(si)
                         continue
                     if (dpl == gpl + 1 and dp[-1].isClose() and
                             not gp[-1].isClose()):


### PR DESCRIPTION
This fixes two bugs found by hinting Momochidori. One fix removes a misguided rounding, the other fixes the use of an index variable.

This also adds a new "loose-overlap-mapping" to make the reverse mapping of path-elements-with-overlap-removed back onto original-path-elements less strict. This helps with path elements that are big "loops", which booleanOperations doesn't always preserve the shape of as well. 

There are some other things we could try to avoid these kinds of heuristics, including switching from booleanOperations to Skia PathOps for overlap removal. However, the autohinter is just sort of OK, so I'm wary of putting hours into part A for superficial reasons just to avoid "formal" errors that may not have much of an impact on output. This flag was easy to add and mostly works around the problem. (You'll still get some missed mappings with the flag, just fewer of them. They're mostly harmless -- a bunch of things have to stack up for a given unmapped segment to make a difference.)

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
