### PR TITLE
[ci] Enable Python v3.12 and drop v3.8

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: "3.11"
 
     - name: Install multilib packages
       run: sudo apt-get install gcc-multilib g++-multilib

--- a/.github/workflows/run_cvg.yml
+++ b/.github/workflows/run_cvg.yml
@@ -34,10 +34,10 @@ jobs:
       with:
         fetch-depth: 0  # unshallow fetch for setuptools-scm
 
-    - name: Set up Python 3.8
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.8"
+        python-version: "3.11"
 
     - name: Build AFDKO wheel
       env:

--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -28,20 +28,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         exclude:
           - os: macos-latest
-            python-version: "3.8"
-          - os: macos-latest
             python-version: "3.9"
           - os: macos-latest
             python-version: "3.10"
-          - os: windows-latest
-            python-version: "3.8"
+          - os: macos-latest
+            python-version: "3.11"
           - os: windows-latest
             python-version: "3.9"
           - os: windows-latest
             python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.11"
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ More information can be found in [docs/otfautohint_Notes.md](docs/otfautohint_No
 Installation
 ------------
 
-The AFDKO requires [Python](http://www.python.org/download) 3.8
-or later. It should work with any Python > 3.8, but occasionally
+The AFDKO requires [Python](http://www.python.org/download) 3.9
+or later. It should work with any Python > 3.9, but occasionally
 tool-chain components and dependencies don't keep pace with major
 Python releases, so there might be some lag time while they catch up.
 
@@ -132,7 +132,7 @@ On macOS, install these with:
 
 On Linux (Ubuntu 17.10 LTS or later), install these with:
 
-    apt-get -y install python3.8
+    apt-get -y install python3.9
     apt-get -y install python-pip
     apt-get -y install python-dev
     apt-get -y install uuid-dev

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ def main():
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',
@@ -194,7 +194,7 @@ def main():
               ],
           },
           zip_safe=False,
-          python_requires='>=3.8',
+          python_requires='>=3.9',
           setup_requires=[
               'wheel',
               'setuptools_scm',


### PR DESCRIPTION
With the imminent final release of Python v3.13, v3.8 is also reaching its EOL. See [status of Python versions](https://devguide.python.org/versions/).

Enables Python v3.12 and drops v3.8.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] ~~I have added **test code and data** to prove that my code functions correctly~~
- [ ] ~~I have verified that new and existing tests pass locally with my changes~~
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
