### PR TITLE
Fix handling of CID-keyed UFOs with no FDSelect

### DIFF
--- a/c/shared/ufowrite.cpp
+++ b/c/shared/ufowrite.cpp
@@ -740,7 +740,9 @@ static void writeLibPlist(ufwCtx h) {
         writeCIDMap(h, h->top, buffer, buflen);
         orderCIDKeyedGlyphs(h);
         removeUnusedFDicts(h);
-        writeFDArray(h, h->top, buffer, buflen);
+        if (h->top->FDArray.cnt > 1) {
+            writeFDArray(h, h->top, buffer, buflen);
+        }
     }
     writeLine(h, "\t<key>public.glyphOrder</key>");
     writeLine(h, "\t<array>");

--- a/docs/CIDKeyedUFOGuide.md
+++ b/docs/CIDKeyedUFOGuide.md
@@ -31,6 +31,9 @@ The following keys are required in `lib.plist` to make a UFO CID-keyed
 
 * `com.adobe.type.ROS`
 * `com.adobe.type.postscriptCIDMap`
+
+The postscriptFDArray key is only required if you define more than one hint dictionary 
+
 * `com.adobe.type.postscriptFDArray`
 
 
@@ -57,7 +60,7 @@ or building an OTF with `makeotf` the glyphs will be rearranged into CID order.
 ### com.adobe.type.postscriptCIDMap
 
 The glyph name to CID mapping must be a dict with the UFO glyph names as keys and 
-their corresponding CID numbers as values. When converting an existing CID-keyed 
+their corresponding CID numbers as integer values. When converting an existing CID-keyed 
 source (OTF, CFF, Type1) to UFO with a command like `tx -ufo -o source.ufo source.otf` 
 the glyph names will default to `cidXXXXX` because no names can be 
 stored in those source formats. If you change the names in the UFO be sure to update 
@@ -66,7 +69,7 @@ the CID mapping and groups.plist to use the new names.
 
 ### com.adobe.type.postscriptFDArray
 
-The FDArray is a list of font dictionaries containing hinting data. All keys are
+The FDArray is a list of font dictionaries containing hinting data for groups of glyphs. All keys are
 optional and will use default values if not specified, but there must be at 
 least one dict in the array and a corresponding group in groups.plist.
 
@@ -95,9 +98,11 @@ An example of one FontDict in Python dumped from Source Han Serif JP ExtraLight
                   'postscriptStemSnapV': [28, 50, 60]}}]
 ```
 
+#### Note: If you only require one set of values for hinting data it should be provided in the fontinfo.plist as described in the [UFO Specification](https://unifiedfontobject.org/versions/ufo3/fontinfo.plist/#postscript-specific-data)
+
 ### FDArraySelect groups in groups.plist 
 
-In addition to the lib.plist keys there must be a groups.plist file 
+If `com.adobe.type.postscriptFDArray` is defined then there must be a groups.plist file 
 containing one group for each FontDict in `com.adobe.type.postscriptFDArray`. 
 Each group must be named in the following format
 
@@ -131,7 +136,9 @@ font.lib['com.adobe.type.ROS'] = 'Adobe-Japan1-7'
 # Set up a preliminary CID mapping based on the current glyph order
 font.lib['com.adobe.type.postscriptCIDMap'] = {name: i for i, name in enumerate(font.lib['public.glyphOrder'])}
 
-# Set up a basic FDArray until you are ready to add hinting data
+# ---------Optional Steps For Hint Data---------
+
+# Set up a a single FDArray until you are ready to add hinting data
 fontname = font.info.familyName.replace(" ", "")
 font.lib['com.adobe.type.postscriptFDArray'] = [{'FontName': f'{fontname}-FD0'}]
 
@@ -146,3 +153,5 @@ font.save()
 #### Document Version History
 
 Version 1.0 — April 10 2023
+
+Version 1.1 — April 10 2025

--- a/tests/tx_data/expected_output/cid_roundtrip/testCID-noFDSelect.ufo/fontinfo.plist
+++ b/tests/tx_data/expected_output/cid_roundtrip/testCID-noFDSelect.ufo/fontinfo.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>postscriptFontName</key>
+	<string>SourceHanSansVF-Heavy</string>
+	<key>styleName</key>
+	<string>Heavy</string>
+	<key>familyName</key>
+	<string>Source Han Sans</string>
+	<key>trademark</key>
+	<string>Copyright 2014-2020 Adobe (http://www.adobe.com/), with Reserved Font Name 'Source'. Source is a trademark of Adobe in the United States and/or other countries.</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>postscriptFullName</key>
+	<string>Source Han Sans Heavy</string>
+	<key>postscriptWeightName</key>
+	<string>Heavy</string>
+	<key>postscriptUnderlinePosition</key>
+	<integer>-150</integer>
+	<key>postscriptBlueValues</key>
+	<array>
+		<integer>0</integer>
+		<integer>0</integer>
+	</array>
+	<key>postscriptBlueScale</key>
+	<real>0.039625</real>
+	<key>postscriptBlueShift</key>
+	<integer>7</integer>
+	<key>postscriptBlueFuzz</key>
+	<integer>1</integer>
+	<key>ExpansionFactor</key>
+	<real>0.06</real>
+</dict>
+</plist>

--- a/tests/tx_data/expected_output/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/cid00000.glif
+++ b/tests/tx_data/expected_output/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/cid00000.glif
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="cid00000" format="1" >
+	<advance width="1000"/>
+	<outline>
+		<contour>
+			<point x="100" y="-120" type="line"/>
+			<point x="900" y="-120" type="line"/>
+			<point x="900" y="880" type="line"/>
+			<point x="100" y="880" type="line"/>
+		</contour>
+		<contour>
+			<point x="500" y="421" type="line"/>
+			<point x="182" y="830" type="line"/>
+			<point x="818" y="830" type="line"/>
+		</contour>
+		<contour>
+			<point x="532" y="380" type="line"/>
+			<point x="850" y="789" type="line"/>
+			<point x="850" y="-29" type="line"/>
+		</contour>
+		<contour>
+			<point x="182" y="-70" type="line"/>
+			<point x="500" y="339" type="line"/>
+			<point x="818" y="-70" type="line"/>
+		</contour>
+		<contour>
+			<point x="150" y="789" type="line"/>
+			<point x="468" y="380" type="line"/>
+			<point x="150" y="-29" type="line"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/tx_data/expected_output/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/cid17899.glif
+++ b/tests/tx_data/expected_output/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/cid17899.glif
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="cid17899" format="1" >
+	<advance width="1000"/>
+	<outline>
+		<contour>
+			<point x="135" y="855" type="line"/>
+			<point x="135" y="-95" type="line"/>
+			<point x="266" y="-95" type="line"/>
+			<point x="266" y="855" type="line"/>
+		</contour>
+		<contour>
+			<point x="58" y="654" type="line"/>
+			<point x="52" y="573" />
+			<point x="36" y="459" />
+			<point x="15" y="389" type="curve"/>
+			<point x="101" y="361" type="line"/>
+			<point x="123" y="440" />
+			<point x="139" y="561" />
+			<point x="141" y="644" type="curve"/>
+		</contour>
+		<contour>
+			<point x="242" y="657" type="line"/>
+			<point x="262" y="590" />
+			<point x="282" y="501" />
+			<point x="291" y="449" type="curve"/>
+			<point x="376" y="476" type="line"/>
+			<point x="366" y="526" />
+			<point x="343" y="613" />
+			<point x="322" y="678" type="curve"/>
+		</contour>
+		<contour>
+			<point x="499" y="562" type="line"/>
+			<point x="751" y="562" type="line"/>
+			<point x="751" y="527" type="line"/>
+			<point x="499" y="527" type="line"/>
+		</contour>
+		<contour>
+			<point x="499" y="703" type="line"/>
+			<point x="751" y="703" type="line"/>
+			<point x="751" y="668" type="line"/>
+			<point x="499" y="668" type="line"/>
+		</contour>
+		<contour>
+			<point x="360" y="817" type="line"/>
+			<point x="360" y="413" type="line"/>
+			<point x="897" y="413" type="line"/>
+			<point x="897" y="817" type="line"/>
+		</contour>
+		<contour>
+			<point x="437" y="314" type="line"/>
+			<point x="437" y="193" type="line"/>
+			<point x="631" y="193" type="line"/>
+			<point x="631" y="314" type="line"/>
+		</contour>
+		<contour>
+			<point x="371" y="-96" type="line"/>
+			<point x="397" y="-78" />
+			<point x="438" y="-60" />
+			<point x="647" y="4" type="curve"/>
+			<point x="639" y="34" />
+			<point x="630" y="88" />
+			<point x="627" y="125" type="curve"/>
+			<point x="406" y="65" type="line"/>
+			<point x="357" y="23" type="line"/>
+		</contour>
+		<contour>
+			<point x="662" y="392" type="line"/>
+			<point x="662" y="74" type="line"/>
+			<point x="662" y="-40" />
+			<point x="685" y="-78" />
+			<point x="789" y="-78" type="curve"/>
+			<point x="809" y="-78" />
+			<point x="837" y="-78" />
+			<point x="857" y="-78" type="curve"/>
+			<point x="937" y="-78" />
+			<point x="970" y="-39" />
+			<point x="982" y="91" type="curve"/>
+			<point x="946" y="99" />
+			<point x="891" y="120" />
+			<point x="864" y="141" type="curve"/>
+			<point x="861" y="54" />
+			<point x="857" y="38" />
+			<point x="843" y="38" type="curve"/>
+			<point x="837" y="38" />
+			<point x="821" y="38" />
+			<point x="816" y="38" type="curve"/>
+			<point x="801" y="38" />
+			<point x="800" y="41" />
+			<point x="800" y="75" type="curve"/>
+			<point x="800" y="392" type="line"/>
+		</contour>
+		<contour>
+			<point x="727" y="314" type="line"/>
+			<point x="727" y="193" type="line"/>
+			<point x="952" y="193" type="line"/>
+			<point x="952" y="314" type="line"/>
+		</contour>
+		<contour>
+			<point x="371" y="-96" type="curve"/>
+			<point x="371" y="-54" />
+			<point x="510" y="-9" />
+			<point x="510" y="-9" type="curve"/>
+			<point x="510" y="391" type="line"/>
+			<point x="367" y="391" type="line"/>
+			<point x="367" y="91" type="line"/>
+			<point x="367" y="55" />
+			<point x="351" y="44" />
+			<point x="330" y="37" type="curve"/>
+			<point x="349" y="6" />
+			<point x="366" y="-59" />
+		</contour>
+	</outline>
+</glyph>

--- a/tests/tx_data/expected_output/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/cid17900.glif
+++ b/tests/tx_data/expected_output/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/cid17900.glif
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="cid17900" format="1" >
+	<advance width="1000"/>
+	<outline>
+		<contour>
+			<point x="291" y="208" type="line"/>
+			<point x="291" y="82" type="line"/>
+			<point x="291" y="-37" />
+			<point x="323" y="-77" />
+			<point x="463" y="-77" type="curve"/>
+			<point x="491" y="-77" />
+			<point x="569" y="-77" />
+			<point x="598" y="-77" type="curve"/>
+			<point x="702" y="-77" />
+			<point x="740" y="-44" />
+			<point x="757" y="86" type="curve"/>
+			<point x="718" y="94" />
+			<point x="657" y="115" />
+			<point x="629" y="136" type="curve"/>
+			<point x="624" y="62" />
+			<point x="617" y="51" />
+			<point x="585" y="51" type="curve"/>
+			<point x="562" y="51" />
+			<point x="500" y="51" />
+			<point x="482" y="51" type="curve"/>
+			<point x="442" y="51" />
+			<point x="435" y="54" />
+			<point x="435" y="84" type="curve"/>
+			<point x="435" y="208" type="line"/>
+		</contour>
+		<contour>
+			<point x="371" y="250" type="line"/>
+			<point x="423" y="212" />
+			<point x="485" y="156" />
+			<point x="511" y="117" type="curve"/>
+			<point x="613" y="198" type="line"/>
+			<point x="583" y="238" />
+			<point x="519" y="290" />
+			<point x="467" y="324" type="curve"/>
+		</contour>
+		<contour>
+			<point x="673" y="172" type="line"/>
+			<point x="743" y="104" />
+			<point x="814" y="8" />
+			<point x="840" y="-58" type="curve"/>
+			<point x="970" y="14" type="line"/>
+			<point x="939" y="84" />
+			<point x="863" y="173" />
+			<point x="792" y="237" type="curve"/>
+		</contour>
+		<contour>
+			<point x="158" y="211" type="line"/>
+			<point x="135" y="135" />
+			<point x="89" y="66" />
+			<point x="26" y="22" type="curve"/>
+			<point x="146" y="-62" type="line"/>
+			<point x="219" y="-7" />
+			<point x="260" y="77" />
+			<point x="288" y="165" type="curve"/>
+		</contour>
+		<contour>
+			<point x="513" y="822" type="line"/>
+			<point x="513" y="704" type="line"/>
+			<point x="833" y="704" type="line"/>
+			<point x="833" y="822" type="line"/>
+		</contour>
+		<contour>
+			<point x="50" y="660" type="line"/>
+			<point x="50" y="544" type="line"/>
+			<point x="528" y="544" type="line"/>
+			<point x="528" y="660" type="line"/>
+		</contour>
+		<contour>
+			<point x="283" y="803" type="line"/>
+			<point x="283" y="691" type="line"/>
+			<point x="486" y="691" type="line"/>
+			<point x="486" y="803" type="line"/>
+		</contour>
+		<contour>
+			<point x="798" y="822" type="line"/>
+			<point x="798" y="799" type="line"/>
+			<point x="765" y="594" />
+			<point x="656" y="433" />
+			<point x="494" y="365" type="curve"/>
+			<point x="521" y="339" />
+			<point x="557" y="289" />
+			<point x="574" y="255" type="curve"/>
+			<point x="768" y="351" />
+			<point x="888" y="520" />
+			<point x="934" y="799" type="curve"/>
+			<point x="847" y="826" type="line"/>
+			<point x="823" y="822" type="line"/>
+		</contour>
+		<contour>
+			<point x="657" y="707" type="curve"/>
+			<point x="536" y="676" type="line"/>
+			<point x="605" y="478" />
+			<point x="715" y="331" />
+			<point x="897" y="255" type="curve"/>
+			<point x="916" y="289" />
+			<point x="955" y="341" />
+			<point x="985" y="368" type="curve"/>
+			<point x="820" y="425" />
+			<point x="710" y="552" />
+		</contour>
+		<contour>
+			<point x="217" y="855" type="line"/>
+			<point x="217" y="576" type="line"/>
+			<point x="355" y="576" type="line"/>
+			<point x="355" y="855" type="line"/>
+		</contour>
+		<contour>
+			<point x="223" y="604" type="line"/>
+			<point x="223" y="353" type="line"/>
+			<point x="223" y="344" />
+			<point x="220" y="341" />
+			<point x="211" y="341" type="curve"/>
+			<point x="202" y="341" />
+			<point x="176" y="341" />
+			<point x="156" y="342" type="curve"/>
+			<point x="171" y="309" />
+			<point x="188" y="260" />
+			<point x="193" y="224" type="curve"/>
+			<point x="244" y="224" />
+			<point x="284" y="225" />
+			<point x="318" y="244" type="curve"/>
+			<point x="353" y="263" />
+			<point x="360" y="294" />
+			<point x="360" y="349" type="curve"/>
+			<point x="360" y="604" type="line"/>
+		</contour>
+		<contour>
+			<point x="102" y="530" type="line"/>
+			<point x="87" y="464" />
+			<point x="57" y="394" />
+			<point x="19" y="349" type="curve"/>
+			<point x="49" y="336" />
+			<point x="102" y="308" />
+			<point x="127" y="290" type="curve"/>
+			<point x="165" y="341" />
+			<point x="203" y="424" />
+			<point x="223" y="503" type="curve"/>
+		</contour>
+		<contour>
+			<point x="358" y="494" type="line"/>
+			<point x="383" y="445" />
+			<point x="407" y="379" />
+			<point x="414" y="336" type="curve"/>
+			<point x="530" y="383" type="line"/>
+			<point x="521" y="425" />
+			<point x="496" y="489" />
+			<point x="468" y="536" type="curve"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/tx_data/expected_output/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/cid17901.glif
+++ b/tests/tx_data/expected_output/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/cid17901.glif
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="cid17901" format="1" >
+	<advance width="1000"/>
+	<outline>
+		<contour>
+			<point x="513" y="822" type="line"/>
+			<point x="513" y="704" type="line"/>
+			<point x="833" y="704" type="line"/>
+			<point x="833" y="822" type="line"/>
+		</contour>
+		<contour>
+			<point x="45" y="660" type="line"/>
+			<point x="45" y="544" type="line"/>
+			<point x="523" y="544" type="line"/>
+			<point x="523" y="660" type="line"/>
+		</contour>
+		<contour>
+			<point x="283" y="807" type="line"/>
+			<point x="283" y="695" type="line"/>
+			<point x="486" y="695" type="line"/>
+			<point x="486" y="807" type="line"/>
+		</contour>
+		<contour>
+			<point x="798" y="822" type="line"/>
+			<point x="798" y="799" type="line"/>
+			<point x="765" y="594" />
+			<point x="656" y="433" />
+			<point x="494" y="365" type="curve"/>
+			<point x="521" y="339" />
+			<point x="557" y="289" />
+			<point x="574" y="255" type="curve"/>
+			<point x="768" y="351" />
+			<point x="888" y="520" />
+			<point x="934" y="799" type="curve"/>
+			<point x="847" y="826" type="line"/>
+			<point x="823" y="822" type="line"/>
+		</contour>
+		<contour>
+			<point x="173" y="855" type="line"/>
+			<point x="173" y="576" type="line"/>
+			<point x="311" y="576" type="line"/>
+			<point x="311" y="855" type="line"/>
+		</contour>
+		<contour>
+			<point x="102" y="530" type="line"/>
+			<point x="87" y="464" />
+			<point x="57" y="394" />
+			<point x="19" y="349" type="curve"/>
+			<point x="49" y="336" />
+			<point x="102" y="308" />
+			<point x="127" y="290" type="curve"/>
+			<point x="165" y="341" />
+			<point x="203" y="424" />
+			<point x="223" y="503" type="curve"/>
+		</contour>
+		<contour>
+			<point x="356" y="494" type="line"/>
+			<point x="390" y="450" />
+			<point x="424" y="388" />
+			<point x="438" y="348" type="curve"/>
+			<point x="549" y="408" type="line"/>
+			<point x="532" y="448" />
+			<point x="497" y="504" />
+			<point x="461" y="546" type="curve"/>
+		</contour>
+		<contour>
+			<point x="247" y="223" type="line"/>
+			<point x="247" y="86" type="line"/>
+			<point x="247" y="-37" />
+			<point x="286" y="-77" />
+			<point x="442" y="-77" type="curve"/>
+			<point x="473" y="-77" />
+			<point x="578" y="-77" />
+			<point x="610" y="-77" type="curve"/>
+			<point x="733" y="-77" />
+			<point x="773" y="-41" />
+			<point x="790" y="107" type="curve"/>
+			<point x="751" y="115" />
+			<point x="688" y="137" />
+			<point x="658" y="159" type="curve"/>
+			<point x="652" y="67" />
+			<point x="644" y="54" />
+			<point x="599" y="54" type="curve"/>
+			<point x="568" y="54" />
+			<point x="482" y="54" />
+			<point x="458" y="54" type="curve"/>
+			<point x="403" y="54" />
+			<point x="394" y="57" />
+			<point x="394" y="89" type="curve"/>
+			<point x="394" y="223" type="line"/>
+		</contour>
+		<contour>
+			<point x="398" y="243" type="line"/>
+			<point x="445" y="193" />
+			<point x="497" y="122" />
+			<point x="516" y="75" type="curve"/>
+			<point x="636" y="144" type="line"/>
+			<point x="613" y="193" />
+			<point x="557" y="259" />
+			<point x="509" y="305" type="curve"/>
+		</contour>
+		<contour>
+			<point x="731" y="214" type="line"/>
+			<point x="773" y="138" />
+			<point x="815" y="38" />
+			<point x="827" y="-26" type="curve"/>
+			<point x="969" y="31" type="line"/>
+			<point x="953" y="97" />
+			<point x="906" y="192" />
+			<point x="862" y="265" type="curve"/>
+		</contour>
+		<contour>
+			<point x="118" y="246" type="line"/>
+			<point x="97" y="171" />
+			<point x="60" y="85" />
+			<point x="26" y="25" type="curve"/>
+			<point x="163" y="-39" type="line"/>
+			<point x="192" y="24" />
+			<point x="224" y="119" />
+			<point x="248" y="193" type="curve"/>
+		</contour>
+		<contour>
+			<point x="527" y="622" type="line"/>
+			<point x="642" y="511" />
+			<point x="804" y="356" />
+			<point x="878" y="264" type="curve"/>
+			<point x="987" y="340" type="line"/>
+			<point x="904" y="433" />
+			<point x="737" y="581" />
+			<point x="626" y="684" type="curve"/>
+		</contour>
+		<contour>
+			<point x="223" y="587" type="line"/>
+			<point x="223" y="254" type="line"/>
+			<point x="361" y="254" type="line"/>
+			<point x="361" y="587" type="line"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/tx_data/expected_output/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/contents.plist
+++ b/tests/tx_data/expected_output/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/contents.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>cid00000</key>
+	<string>cid00000.glif</string>
+	<key>cid17899</key>
+	<string>cid17899.glif</string>
+	<key>cid17900</key>
+	<string>cid17900.glif</string>
+	<key>cid17901</key>
+	<string>cid17901.glif</string>
+</dict>
+</plist>

--- a/tests/tx_data/expected_output/cid_roundtrip/testCID-noFDSelect.ufo/lib.plist
+++ b/tests/tx_data/expected_output/cid_roundtrip/testCID-noFDSelect.ufo/lib.plist
@@ -3,25 +3,28 @@
 <plist version="1.0">
 <dict>
 	<key>com.adobe.type.CIDFontName</key>
-	<string>TestFont-Regular</string>
+	<string>SourceHanSansVF-Heavy</string>
 	<key>com.adobe.type.FSType</key>
-	<integer>4</integer>
+	<integer>0</integer>
 	<key>com.adobe.type.ROS</key>
 	<string>Adobe-Identity-0</string>
 	<key>com.adobe.type.postscriptCIDMap</key>
 	<dict>
 		<key>cid00000</key>
 		<integer>0</integer>
-		<key>cid00001</key>
-		<integer>1</integer>
-		<key>cid00002</key>
-		<integer>2</integer>
+		<key>cid17899</key>
+		<integer>17899</integer>
+		<key>cid17900</key>
+		<integer>17900</integer>
+		<key>cid17901</key>
+		<integer>17901</integer>
 	</dict>
 	<key>public.glyphOrder</key>
 	<array>
 		<string>cid00000</string>
-		<string>cid00001</string>
-		<string>cid00002</string>
+		<string>cid17899</string>
+		<string>cid17900</string>
+		<string>cid17901</string>
 	</array>
 </dict>
 </plist>

--- a/tests/tx_data/expected_output/cid_roundtrip/testCID-noFDSelect.ufo/metainfo.plist
+++ b/tests/tx_data/expected_output/cid_roundtrip/testCID-noFDSelect.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>creator</key>
+	<string>com.adobe.type.tx</string>
+	<key>formatVersion</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/fontinfo.plist
+++ b/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/fontinfo.plist
@@ -1,0 +1,48 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>750</integer>
+    <key>capHeight</key>
+    <integer>750</integer>
+    <key>descender</key>
+    <integer>-250</integer>
+    <key>familyName</key>
+    <string>Source Han Sans</string>
+    <key>guidelines</key>
+    <array/>
+    <key>postscriptBlueValues</key>
+    <array/>
+    <key>postscriptFamilyBlues</key>
+    <array/>
+    <key>postscriptFamilyOtherBlues</key>
+    <array/>
+    <key>postscriptFontName</key>
+    <string>SourceHanSansVF-Heavy</string>
+    <key>postscriptFullName</key>
+    <string>Source Han Sans Heavy</string>
+    <key>postscriptOtherBlues</key>
+    <array/>
+    <key>postscriptStemSnapH</key>
+    <array/>
+    <key>postscriptStemSnapV</key>
+    <array/>
+    <key>postscriptUnderlinePosition</key>
+    <integer>-150</integer>
+    <key>postscriptWeightName</key>
+    <string>Heavy</string>
+    <key>styleName</key>
+    <string>Heavy</string>
+    <key>trademark</key>
+    <string>Copyright 2014-2020 Adobe (http://www.adobe.com/), with Reserved Font Name 'Source'. Source is a trademark of Adobe in the United States and/or other countries.</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>versionMajor</key>
+    <integer>2</integer>
+    <key>versionMinor</key>
+    <integer>3</integer>
+    <key>xHeight</key>
+    <integer>500</integer>
+  </dict>
+</plist>

--- a/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/cid00000.glif
+++ b/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/cid00000.glif
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="cid00000" format="2">
+  <advance width="1000"/>
+  <outline>
+    <contour>
+      <point x="100" y="-120" type="line"/>
+      <point x="900" y="-120" type="line"/>
+      <point x="900" y="880" type="line"/>
+      <point x="100" y="880" type="line"/>
+    </contour>
+    <contour>
+      <point x="500" y="421" type="line"/>
+      <point x="182" y="830" type="line"/>
+      <point x="818" y="830" type="line"/>
+    </contour>
+    <contour>
+      <point x="532" y="380" type="line"/>
+      <point x="850" y="789" type="line"/>
+      <point x="850" y="-29" type="line"/>
+    </contour>
+    <contour>
+      <point x="182" y="-70" type="line"/>
+      <point x="500" y="339" type="line"/>
+      <point x="818" y="-70" type="line"/>
+    </contour>
+    <contour>
+      <point x="150" y="789" type="line"/>
+      <point x="468" y="380" type="line"/>
+      <point x="150" y="-29" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/cid17899.glif
+++ b/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/cid17899.glif
@@ -1,0 +1,113 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="cid17899" format="2">
+  <advance width="1000"/>
+  <outline>
+    <contour>
+      <point x="135" y="855" type="line"/>
+      <point x="135" y="-95" type="line"/>
+      <point x="266" y="-95" type="line"/>
+      <point x="266" y="855" type="line"/>
+    </contour>
+    <contour>
+      <point x="58" y="654" type="line"/>
+      <point x="52" y="573"/>
+      <point x="36" y="459"/>
+      <point x="15" y="389" type="curve"/>
+      <point x="101" y="361" type="line"/>
+      <point x="123" y="440"/>
+      <point x="139" y="561"/>
+      <point x="141" y="644" type="curve"/>
+    </contour>
+    <contour>
+      <point x="242" y="657" type="line"/>
+      <point x="262" y="590"/>
+      <point x="282" y="501"/>
+      <point x="291" y="449" type="curve"/>
+      <point x="376" y="476" type="line"/>
+      <point x="366" y="526"/>
+      <point x="343" y="613"/>
+      <point x="322" y="678" type="curve"/>
+    </contour>
+    <contour>
+      <point x="499" y="562" type="line"/>
+      <point x="751" y="562" type="line"/>
+      <point x="751" y="527" type="line"/>
+      <point x="499" y="527" type="line"/>
+    </contour>
+    <contour>
+      <point x="499" y="703" type="line"/>
+      <point x="751" y="703" type="line"/>
+      <point x="751" y="668" type="line"/>
+      <point x="499" y="668" type="line"/>
+    </contour>
+    <contour>
+      <point x="360" y="817" type="line"/>
+      <point x="360" y="413" type="line"/>
+      <point x="897" y="413" type="line"/>
+      <point x="897" y="817" type="line"/>
+    </contour>
+    <contour>
+      <point x="437" y="314" type="line"/>
+      <point x="437" y="193" type="line"/>
+      <point x="631" y="193" type="line"/>
+      <point x="631" y="314" type="line"/>
+    </contour>
+    <contour>
+      <point x="371" y="-96" type="line"/>
+      <point x="397" y="-78"/>
+      <point x="438" y="-60"/>
+      <point x="647" y="4" type="curve"/>
+      <point x="639" y="34"/>
+      <point x="630" y="88"/>
+      <point x="627" y="125" type="curve"/>
+      <point x="406" y="65" type="line"/>
+      <point x="357" y="23" type="line"/>
+    </contour>
+    <contour>
+      <point x="662" y="392" type="line"/>
+      <point x="662" y="74" type="line"/>
+      <point x="662" y="-40"/>
+      <point x="685" y="-78"/>
+      <point x="789" y="-78" type="curve"/>
+      <point x="809" y="-78"/>
+      <point x="837" y="-78"/>
+      <point x="857" y="-78" type="curve"/>
+      <point x="937" y="-78"/>
+      <point x="970" y="-39"/>
+      <point x="982" y="91" type="curve"/>
+      <point x="946" y="99"/>
+      <point x="891" y="120"/>
+      <point x="864" y="141" type="curve"/>
+      <point x="861" y="54"/>
+      <point x="857" y="38"/>
+      <point x="843" y="38" type="curve"/>
+      <point x="837" y="38"/>
+      <point x="821" y="38"/>
+      <point x="816" y="38" type="curve"/>
+      <point x="801" y="38"/>
+      <point x="800" y="41"/>
+      <point x="800" y="75" type="curve"/>
+      <point x="800" y="392" type="line"/>
+    </contour>
+    <contour>
+      <point x="727" y="314" type="line"/>
+      <point x="727" y="193" type="line"/>
+      <point x="952" y="193" type="line"/>
+      <point x="952" y="314" type="line"/>
+    </contour>
+    <contour>
+      <point x="371" y="-96" type="curve"/>
+      <point x="371" y="-54"/>
+      <point x="510" y="-9"/>
+      <point x="510" y="-9" type="curve"/>
+      <point x="510" y="391" type="line"/>
+      <point x="367" y="391" type="line"/>
+      <point x="367" y="91" type="line"/>
+      <point x="367" y="55"/>
+      <point x="351" y="44"/>
+      <point x="330" y="37" type="curve"/>
+      <point x="349" y="6"/>
+      <point x="366" y="-59"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/cid17900.glif
+++ b/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/cid17900.glif
@@ -1,0 +1,155 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="cid17900" format="2">
+  <advance width="1000"/>
+  <outline>
+    <contour>
+      <point x="291" y="208" type="line"/>
+      <point x="291" y="82" type="line"/>
+      <point x="291" y="-37"/>
+      <point x="323" y="-77"/>
+      <point x="463" y="-77" type="curve"/>
+      <point x="491" y="-77"/>
+      <point x="569" y="-77"/>
+      <point x="598" y="-77" type="curve"/>
+      <point x="702" y="-77"/>
+      <point x="740" y="-44"/>
+      <point x="757" y="86" type="curve"/>
+      <point x="718" y="94"/>
+      <point x="657" y="115"/>
+      <point x="629" y="136" type="curve"/>
+      <point x="624" y="62"/>
+      <point x="617" y="51"/>
+      <point x="585" y="51" type="curve"/>
+      <point x="562" y="51"/>
+      <point x="500" y="51"/>
+      <point x="482" y="51" type="curve"/>
+      <point x="442" y="51"/>
+      <point x="435" y="54"/>
+      <point x="435" y="84" type="curve"/>
+      <point x="435" y="208" type="line"/>
+    </contour>
+    <contour>
+      <point x="371" y="250" type="line"/>
+      <point x="423" y="212"/>
+      <point x="485" y="156"/>
+      <point x="511" y="117" type="curve"/>
+      <point x="613" y="198" type="line"/>
+      <point x="583" y="238"/>
+      <point x="519" y="290"/>
+      <point x="467" y="324" type="curve"/>
+    </contour>
+    <contour>
+      <point x="673" y="172" type="line"/>
+      <point x="743" y="104"/>
+      <point x="814" y="8"/>
+      <point x="840" y="-58" type="curve"/>
+      <point x="970" y="14" type="line"/>
+      <point x="939" y="84"/>
+      <point x="863" y="173"/>
+      <point x="792" y="237" type="curve"/>
+    </contour>
+    <contour>
+      <point x="158" y="211" type="line"/>
+      <point x="135" y="135"/>
+      <point x="89" y="66"/>
+      <point x="26" y="22" type="curve"/>
+      <point x="146" y="-62" type="line"/>
+      <point x="219" y="-7"/>
+      <point x="260" y="77"/>
+      <point x="288" y="165" type="curve"/>
+    </contour>
+    <contour>
+      <point x="513" y="822" type="line"/>
+      <point x="513" y="704" type="line"/>
+      <point x="833" y="704" type="line"/>
+      <point x="833" y="822" type="line"/>
+    </contour>
+    <contour>
+      <point x="50" y="660" type="line"/>
+      <point x="50" y="544" type="line"/>
+      <point x="528" y="544" type="line"/>
+      <point x="528" y="660" type="line"/>
+    </contour>
+    <contour>
+      <point x="283" y="803" type="line"/>
+      <point x="283" y="691" type="line"/>
+      <point x="486" y="691" type="line"/>
+      <point x="486" y="803" type="line"/>
+    </contour>
+    <contour>
+      <point x="798" y="822" type="line"/>
+      <point x="798" y="799" type="line"/>
+      <point x="765" y="594"/>
+      <point x="656" y="433"/>
+      <point x="494" y="365" type="curve"/>
+      <point x="521" y="339"/>
+      <point x="557" y="289"/>
+      <point x="574" y="255" type="curve"/>
+      <point x="768" y="351"/>
+      <point x="888" y="520"/>
+      <point x="934" y="799" type="curve"/>
+      <point x="847" y="826" type="line"/>
+      <point x="823" y="822" type="line"/>
+    </contour>
+    <contour>
+      <point x="657" y="707" type="curve"/>
+      <point x="536" y="676" type="line"/>
+      <point x="605" y="478"/>
+      <point x="715" y="331"/>
+      <point x="897" y="255" type="curve"/>
+      <point x="916" y="289"/>
+      <point x="955" y="341"/>
+      <point x="985" y="368" type="curve"/>
+      <point x="820" y="425"/>
+      <point x="710" y="552"/>
+    </contour>
+    <contour>
+      <point x="217" y="855" type="line"/>
+      <point x="217" y="576" type="line"/>
+      <point x="355" y="576" type="line"/>
+      <point x="355" y="855" type="line"/>
+    </contour>
+    <contour>
+      <point x="223" y="604" type="line"/>
+      <point x="223" y="353" type="line"/>
+      <point x="223" y="344"/>
+      <point x="220" y="341"/>
+      <point x="211" y="341" type="curve"/>
+      <point x="202" y="341"/>
+      <point x="176" y="341"/>
+      <point x="156" y="342" type="curve"/>
+      <point x="171" y="309"/>
+      <point x="188" y="260"/>
+      <point x="193" y="224" type="curve"/>
+      <point x="244" y="224"/>
+      <point x="284" y="225"/>
+      <point x="318" y="244" type="curve"/>
+      <point x="353" y="263"/>
+      <point x="360" y="294"/>
+      <point x="360" y="349" type="curve"/>
+      <point x="360" y="604" type="line"/>
+    </contour>
+    <contour>
+      <point x="102" y="530" type="line"/>
+      <point x="87" y="464"/>
+      <point x="57" y="394"/>
+      <point x="19" y="349" type="curve"/>
+      <point x="49" y="336"/>
+      <point x="102" y="308"/>
+      <point x="127" y="290" type="curve"/>
+      <point x="165" y="341"/>
+      <point x="203" y="424"/>
+      <point x="223" y="503" type="curve"/>
+    </contour>
+    <contour>
+      <point x="358" y="494" type="line"/>
+      <point x="383" y="445"/>
+      <point x="407" y="379"/>
+      <point x="414" y="336" type="curve"/>
+      <point x="530" y="383" type="line"/>
+      <point x="521" y="425"/>
+      <point x="496" y="489"/>
+      <point x="468" y="536" type="curve"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/cid17901.glif
+++ b/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/cid17901.glif
@@ -1,0 +1,139 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="cid17901" format="2">
+  <advance width="1000"/>
+  <outline>
+    <contour>
+      <point x="513" y="822" type="line"/>
+      <point x="513" y="704" type="line"/>
+      <point x="833" y="704" type="line"/>
+      <point x="833" y="822" type="line"/>
+    </contour>
+    <contour>
+      <point x="45" y="660" type="line"/>
+      <point x="45" y="544" type="line"/>
+      <point x="523" y="544" type="line"/>
+      <point x="523" y="660" type="line"/>
+    </contour>
+    <contour>
+      <point x="283" y="807" type="line"/>
+      <point x="283" y="695" type="line"/>
+      <point x="486" y="695" type="line"/>
+      <point x="486" y="807" type="line"/>
+    </contour>
+    <contour>
+      <point x="798" y="822" type="line"/>
+      <point x="798" y="799" type="line"/>
+      <point x="765" y="594"/>
+      <point x="656" y="433"/>
+      <point x="494" y="365" type="curve"/>
+      <point x="521" y="339"/>
+      <point x="557" y="289"/>
+      <point x="574" y="255" type="curve"/>
+      <point x="768" y="351"/>
+      <point x="888" y="520"/>
+      <point x="934" y="799" type="curve"/>
+      <point x="847" y="826" type="line"/>
+      <point x="823" y="822" type="line"/>
+    </contour>
+    <contour>
+      <point x="173" y="855" type="line"/>
+      <point x="173" y="576" type="line"/>
+      <point x="311" y="576" type="line"/>
+      <point x="311" y="855" type="line"/>
+    </contour>
+    <contour>
+      <point x="102" y="530" type="line"/>
+      <point x="87" y="464"/>
+      <point x="57" y="394"/>
+      <point x="19" y="349" type="curve"/>
+      <point x="49" y="336"/>
+      <point x="102" y="308"/>
+      <point x="127" y="290" type="curve"/>
+      <point x="165" y="341"/>
+      <point x="203" y="424"/>
+      <point x="223" y="503" type="curve"/>
+    </contour>
+    <contour>
+      <point x="356" y="494" type="line"/>
+      <point x="390" y="450"/>
+      <point x="424" y="388"/>
+      <point x="438" y="348" type="curve"/>
+      <point x="549" y="408" type="line"/>
+      <point x="532" y="448"/>
+      <point x="497" y="504"/>
+      <point x="461" y="546" type="curve"/>
+    </contour>
+    <contour>
+      <point x="247" y="223" type="line"/>
+      <point x="247" y="86" type="line"/>
+      <point x="247" y="-37"/>
+      <point x="286" y="-77"/>
+      <point x="442" y="-77" type="curve"/>
+      <point x="473" y="-77"/>
+      <point x="578" y="-77"/>
+      <point x="610" y="-77" type="curve"/>
+      <point x="733" y="-77"/>
+      <point x="773" y="-41"/>
+      <point x="790" y="107" type="curve"/>
+      <point x="751" y="115"/>
+      <point x="688" y="137"/>
+      <point x="658" y="159" type="curve"/>
+      <point x="652" y="67"/>
+      <point x="644" y="54"/>
+      <point x="599" y="54" type="curve"/>
+      <point x="568" y="54"/>
+      <point x="482" y="54"/>
+      <point x="458" y="54" type="curve"/>
+      <point x="403" y="54"/>
+      <point x="394" y="57"/>
+      <point x="394" y="89" type="curve"/>
+      <point x="394" y="223" type="line"/>
+    </contour>
+    <contour>
+      <point x="398" y="243" type="line"/>
+      <point x="445" y="193"/>
+      <point x="497" y="122"/>
+      <point x="516" y="75" type="curve"/>
+      <point x="636" y="144" type="line"/>
+      <point x="613" y="193"/>
+      <point x="557" y="259"/>
+      <point x="509" y="305" type="curve"/>
+    </contour>
+    <contour>
+      <point x="731" y="214" type="line"/>
+      <point x="773" y="138"/>
+      <point x="815" y="38"/>
+      <point x="827" y="-26" type="curve"/>
+      <point x="969" y="31" type="line"/>
+      <point x="953" y="97"/>
+      <point x="906" y="192"/>
+      <point x="862" y="265" type="curve"/>
+    </contour>
+    <contour>
+      <point x="118" y="246" type="line"/>
+      <point x="97" y="171"/>
+      <point x="60" y="85"/>
+      <point x="26" y="25" type="curve"/>
+      <point x="163" y="-39" type="line"/>
+      <point x="192" y="24"/>
+      <point x="224" y="119"/>
+      <point x="248" y="193" type="curve"/>
+    </contour>
+    <contour>
+      <point x="527" y="622" type="line"/>
+      <point x="642" y="511"/>
+      <point x="804" y="356"/>
+      <point x="878" y="264" type="curve"/>
+      <point x="987" y="340" type="line"/>
+      <point x="904" y="433"/>
+      <point x="737" y="581"/>
+      <point x="626" y="684" type="curve"/>
+    </contour>
+    <contour>
+      <point x="223" y="587" type="line"/>
+      <point x="223" y="254" type="line"/>
+      <point x="361" y="254" type="line"/>
+      <point x="361" y="587" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/contents.plist
+++ b/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/contents.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>cid00000</key>
+    <string>cid00000.glif</string>
+    <key>cid17899</key>
+    <string>cid17899.glif</string>
+    <key>cid17900</key>
+    <string>cid17900.glif</string>
+    <key>cid17901</key>
+    <string>cid17901.glif</string>
+  </dict>
+</plist>

--- a/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/layerinfo.plist
+++ b/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/glyphs/layerinfo.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>color</key>
+    <string>0.5,0,0.5,0.7</string>
+  </dict>
+</plist>

--- a/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/layercontents.plist
+++ b/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>foreground</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/lib.plist
+++ b/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/lib.plist
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.adobe.type.CIDFontName</key>
+    <string>SourceHanSansVF-Heavy</string>
+    <key>com.adobe.type.FSType</key>
+    <integer>0</integer>
+    <key>com.adobe.type.ROS</key>
+    <string>Adobe-Identity-0</string>
+    <key>com.adobe.type.postscriptCIDMap</key>
+    <dict>
+      <key>cid00000</key>
+      <integer>0</integer>
+      <key>cid17899</key>
+      <integer>17899</integer>
+      <key>cid17900</key>
+      <integer>17900</integer>
+      <key>cid17901</key>
+      <integer>17901</integer>
+   </dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>cid00000</string>
+      <string>cid17899</string>
+      <string>cid17900</string>
+      <string>cid17901</string>
+   </array>
+  </dict>
+</plist>

--- a/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/metainfo.plist
+++ b/tests/tx_data/input/cid_roundtrip/testCID-noFDSelect.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/tests/tx_test.py
+++ b/tests/tx_test.py
@@ -1111,6 +1111,8 @@ def test_cffread_bug1343():
     (('t1', 'ufo'), 'testCID.ufo', 'cidfont_subset.ufo', 'testCID.ufo'),
     (('t1', 'ufo'), 'groups-100-fdselect.ufo', 'groups-100-fdselect.ufo',
      'groups-100-fdselect.ufo'),
+    (('t1', 'ufo'), 'testCID-noFDSelect.ufo', 'testCID-noFDSelect.ufo',
+     'testCID-noFDSelect.ufo'),
 ])
 def test_cidkeyed_read_write(arg, input, output, expected):
     """
@@ -1120,6 +1122,7 @@ def test_cidkeyed_read_write(arg, input, output, expected):
     CID -> UFO -> CID (round-trip test)
     UFO -> CID -> UFO (round-trip test)
     UFO -> CID -> UFO (round-trip test with 100 FDArrays)
+    UFO -> CID -> UFO (round-trip test with no FDSelect)
     """
     folder = "cid_roundtrip/"
     input_path = get_input_path(folder + input)


### PR DESCRIPTION
Originally we based the CID-keyed UFO workflow on all of the Adobe CJK fonts which have multiple font dicts, but we failed to account for the possibility of a totally valid CID-keyed file with no font dicts (no FDSelect because there are no FDArrays to point to). This adjusts the reading and writing of UFOs to properly handle this. The documentation is also updated so that we do not absolutely require the postscriptFDArray key in the lib.plist since it's actually optional. 