### PR TITLE
[rotatefont] support writing UFOs

### DIFF
--- a/c/rotatefont/source/rotateFont.c
+++ b/c/rotatefont/source/rotateFont.c
@@ -1025,8 +1025,8 @@ static void setupRotationCallbacks(txCtx h) {
     h->cb.glyph.curve = rotate_curve;
     if ((rotateInfo->flags & ROTATE_KEEP_HINTS) || (rotateInfo->origMatrix[1] == 0)) /* rotation is some multiple of 90 degrees */
     {
-        h->cb.glyph.stem = rotate_stem;
-        h->cb.glyph.flex = rotate_flex;
+        h->cb.glyph.stem = (rotateInfo->savedGlyphCB.stem != NULL) ? rotate_stem : NULL;
+        h->cb.glyph.flex = (rotateInfo->savedGlyphCB.flex != NULL) ? rotate_flex : NULL;
     } else {
         h->cb.glyph.stem = NULL;
         h->cb.glyph.flex = NULL;


### PR DESCRIPTION
## Description

Intended to fix #1802. Only rotateFont.c has been modified and it should not affect any other part of AFDKO.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [ ] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
