### PR TITLE
mergefonts can crash with an all whitespace value

### DIFF
--- a/c/mergefonts/source/mergeFonts.c
+++ b/c/mergefonts/source/mergeFonts.c
@@ -1177,6 +1177,14 @@ static void stringStrip(char *str) {
     if (end == 0)
         return;
 
+    while (end >= 0) {
+        if ((str[end] == ' ') || (str[end] == '\t') || (str[end] == ')') || (str[end] == '\r') || (str[end] == '\n'))
+            end--;
+        else
+            break;
+    }
+    str[end + 1] = 0;
+
     while (start < MAX_DICT_ENTRY_LEN) {
         if ((str[start] == ' ') || (str[start] == '\t') || (str[start] == '(') || (str[start] == '\r') || (str[start] == '\n'))
             start++;
@@ -1184,14 +1192,6 @@ static void stringStrip(char *str) {
             break;
     }
 
-    while (end >= 0) {
-        if ((str[end] == ' ') || (str[end] == '\t') || (str[end] == ')') || (str[end] == '\r') || (str[end] == '\n'))
-            end--;
-        else
-            break;
-    }
-
-    str[end + 1] = 0;
     if (start > 0)
         memmove(str, &str[start], (end - start) + 2);
     if (strlen(str) == 0) {

--- a/tests/mergefonts_data/input/cidwhitespace/cidfontinfo.txt
+++ b/tests/mergefonts_data/input/cidwhitespace/cidfontinfo.txt
@@ -1,0 +1,9 @@
+FontName	(  )
+Registry	Adobe
+Ordering	Identity
+Supplement	0
+FSType	4
+Weight	(Regular)
+FamilyName	(Source Sans)
+version	(2.20)
+AdobeCopyright	(Copyright 2010, 2012, 2014 Adobe Systems Incorporated (http://www.adobe.com/), with Reserved Font Name 'Source'.)

--- a/tests/mergefonts_test.py
+++ b/tests/mergefonts_test.py
@@ -83,3 +83,21 @@ def test_camel_case():
     expected_path = generate_ps_dump(expected_path)
 
     assert differ([expected_path, actual_path, '-s', r'%ADOt1write:'])
+
+
+def test_cidwhitespace():
+    font1_filename = 'font1.pfa'
+    font2_filename = 'font2.pfa'
+    font3_filename = 'font3.pfa'
+    alias1_filename = 'alias1.txt'
+    alias2_filename = 'alias2.txt'
+    alias3_filename = 'alias3.txt'
+    fontinfo_filename = 'cidwhitespace/cidfontinfo.txt'
+    actual_path = get_temp_file_path()
+
+    # without fix this dies with <Signals.SIGSEGV: 11...>
+    runner(CMD + ['-o', 'cid', '-f', fontinfo_filename, actual_path,
+                  alias1_filename, font1_filename,
+                  alias2_filename, font2_filename,
+                  alias3_filename, font3_filename])
+


### PR DESCRIPTION
echo | mergefonts -cid tests/mergefonts_data/input/cidwhitespace/cidfontinfo.txt Segmentation fault (core dumped)

As a minimal fix if the start/end searchs are swapped so that the search for the end of whitespace is done before searching for the start then the new null terminator set by the end search will stop the start search going past the buffer end.

## Description

Replace this text with a description of your changes, indicating whether
it is a bug fix, enhancement, etc. and which general area(s) are affected
(documentation, specific tool, group of tools, tests, etc.).

If the contribution closes (fixes, resolves) a specific open
[issue](https://github.com/adobe-type-tools/afdko/issues), please [link
the issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [x] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
