### PR TITLE
Update Python version requirements and fix deprecations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,36 +5,43 @@ First, **thank you** for your interest in contributing! We welcome contributions
 Following are some guidelines and information about contributing, mostly so you know what to expect at various stages in the process.
 
 ## Project Goals
- - Maintain a _high-quality_, useful set of tools for working with OpenType fonts
- - Keep the toolset current with changes to related standards (Unicode, OpenType, etc.)
- - Promote the use of the AFDKO for creating, editing and testing OpenType fonts
+
+- Maintain a _high-quality_, useful set of tools for working with OpenType fonts
+- Keep the toolset current with changes to related standards (Unicode, OpenType, etc.)
+- Promote the use of the AFDKO for creating, editing and testing OpenType fonts
 
 ## How to contribute
 
 ### Code of Conduct
+
 Please review our [Code of Conduct](./CODE_OF_CONDUCT.md)
 statement which explains standards and responsibilities for all contributors and
 project maintainers.
 
 ### Suggested areas
+
 If you'd like to contribute but are not sure where or how, here are some suggestions to get started:
- - Fix [active LGTM alerts](https://lgtm.com/projects/g/adobe-type-tools/afdko/alerts/?mode=list). Many of these are simple fixes and working through them is a great way to get familiar with the codebase.
- - Address [compiler warnings](https://github.com/adobe-type-tools/afdko/issues/633) for all target platforms.
- - Work on [open Issues marked with the "help wanted" label](https://github.com/adobe-type-tools/afdko/issues?q=is%3Aissue+label%3A%22help+wanted%22+is%3Aopen).
- - Improve [test coverage](https://codecov.io/gh/adobe-type-tools/afdko/branch/develop), particularly modules that have very low or no coverage currently.
+
+- Fix [active LGTM alerts](https://lgtm.com/projects/g/adobe-type-tools/afdko/alerts/?mode=list). Many of these are simple fixes and working through them is a great way to get familiar with the codebase.
+- Address [compiler warnings](https://github.com/adobe-type-tools/afdko/issues/633) for all target platforms.
+- Work on [open Issues marked with the "help wanted" label](https://github.com/adobe-type-tools/afdko/issues?q=is%3Aissue+label%3A%22help+wanted%22+is%3Aopen).
+- Improve [test coverage](https://codecov.io/gh/adobe-type-tools/afdko/branch/develop), particularly modules that have very low or no coverage currently.
 
 ### What if I just have a question?
+
 First, **please check to see if [someone has already raised a similar question or issue](https://github.com/adobe-type-tools/afdko/issues?utf8=%E2%9C%93&q=is%3Aissue)**. If you don't see anything related to your question, open a new [Issue](https://github.com/adobe-type-tools/afdko/issues/new) and ask there.
 
 You can also ask questions on the [AFDKO room in Gitter](https://gitter.im/adobe-type-tools/afdko) which is monitored by the AFDKO maintainers.
 
 ### Code Style
+
 Please see the [Code Style wiki
 page](https://github.com/adobe-type-tools/afdko/wiki/Code-Style) for guidelines.
 Note that automated processes will run `cpplint` on C/C++ code and `flake8` on
 Python code.
 
 ### Testing, test code, and test data
+
 Contributions that add new functionality or substantially change existing
 functionality _must_ include test code and data that demonstrates that the
 contributed code functions as intended. But fonts and their interactions with
@@ -44,17 +51,20 @@ utilities, and applications outside of the AFDKO to ensure that your
 contribution produces font files that function correctly in real-world scenarios.
 
 ### Branches and Pull Requests
+
 All contributions are handled through the GitHub Pull Request process. You may do this directly via a branch of AFDKO's `develop` branch or via a fork of AFDKO.
 
 In either case, submitting a Pull Request triggers a number of automated actions (more detail on that below) and alerts the maintainers that there is a contribution to review. The maintainers will examine the submission and results of automated testing prior to accepting the contribution.
 
-If you are contributing code, you should run the test suite locally and ensure that all tests pass. If you are contributing _a lot of code_ or introducing major changes, it is *essential* that you also add test cases to the test suite to ensure that your code is getting tested (review the contents of the [`tests`](./tests/) folder to get an idea of how to write tests). 100% coverage is not required, but you should add tests that demonstrate that new features/major changes are actually working as intended (and don't break existing tests). If you are contributing Python code, please pass it through [`flake8`](http://flake8.pycqa.org/en/latest/). If you are contributing C/C++ code, check with [`cpplint`](https://github.com/cpplint/cpplint).
+If you are contributing code, you should run the test suite locally and ensure that all tests pass. If you are contributing _a lot of code_ or introducing major changes, it is _essential_ that you also add test cases to the test suite to ensure that your code is getting tested (review the contents of the [`tests`](./tests/) folder to get an idea of how to write tests). 100% coverage is not required, but you should add tests that demonstrate that new features/major changes are actually working as intended (and don't break existing tests). If you are contributing Python code, please pass it through [`flake8`](http://flake8.pycqa.org/en/latest/). If you are contributing C/C++ code, check with [`cpplint`](https://github.com/cpplint/cpplint).
 
 ### Automation
+
 There are two main triggers for running automated tests for AFDKO:
+
  1. When any commit to _any_ branch is pushed to the main AFDKO repository
  2. When a Pull Request is submitted
- 
+
 Branch commit testing basically runs the test suite on various platforms (Mac OS X, Windows, and Linux) as well as static analysis (`flake8` for Python and `cpplint` for C/C++ code). You can check test progress by clicking on the "Details" link next to each automated check listed in the Checks section.
 
 Pull Request testing is a bit more rigorous, and includes more detailed code analysis by [LGTM](https://lgtm.com/projects/g/adobe-type-tools/afdko/alerts/?mode=list) for security and other code problems beyond static analysis. If new issues are introduced, the maintainers will probably ask you to address them before proceeding with your contribution.
@@ -62,4 +72,5 @@ Pull Request testing is a bit more rigorous, and includes more detailed code ana
 A [handy chart in the wiki](https://github.com/adobe-type-tools/afdko/wiki/CI-Matrix) details what the various automated systems do.
 
 ### Skipping (some) automation
+
 It is possible to skip some of the automated tests by using the **[skip ci]** directive in the subject (first) line of a commit or Pull Request. It is appropriate to use this directive if you are contributing _non-code_ changes, like documentation. Please do _not_ use the directive if you have any code changes (including test code).

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ for additional information, such as links to reference materials and related
 projects.
 
 📣 Recent News
-------------
+--------------
+
 **AFDKO 5.0.0** is a major release featuring:
+
 - Unified command interface: `afdko <command>` syntax
 - Variable font support in `addfeatures` (replaces `makeotfexe`)
 - Extensive C→C++ codebase modernization
@@ -46,8 +48,8 @@ See [NEWS.md](NEWS.md) for full release notes and migration guide.
 Installation
 ------------
 
-The AFDKO requires [Python](http://www.python.org/download) 3.9
-or later. It should work with any Python > 3.9, but occasionally
+The AFDKO requires [Python](http://www.python.org/download) 3.10
+or later. It should work with any Python > 3.10, but occasionally
 tool-chain components and dependencies don't keep pace with major
 Python releases, so there might be some lag time while they catch up.
 
@@ -71,11 +73,11 @@ wrong `pip` being called, and the package landing in the wrong location.
 The combination of using a `venv` + `python -m pip install` helps to ensure
 that pip-managed packages land in the right place.
 
-Note for Linux users (and users of other platforms that are not macOS or Windows): When there is not a pre-built "wheel" for your platform `pip` will attempt to build the C and C++ portions of the package from source. This process will only succeed if both the C and C++ development tools and libuuid are installed. See [build from source](#Build-from-source) below.
+Note for Linux users (and users of other platforms that are not macOS or Windows): When there is not a pre-built "wheel" for your platform `pip` will attempt to build the C and C++ portions of the package from source. This process will only succeed if both the C and C++ development tools and libuuid are installed. See [build from source](#build-from-source) below.
 
 ### Installing
 
-**Option 1 (Recommended)**
+#### Option 1 (Recommended)
 
 - Create a virtual environment:
 
@@ -85,17 +87,17 @@ Note for Linux users (and users of other platforms that are not macOS or Windows
 
 - Activate the virtual environment:
 
-    - macOS & Linux
+  - macOS & Linux
 
-        ```sh
-        source afdko_env/bin/activate
-        ```
+    ```sh
+    source afdko_env/bin/activate
+    ```
 
-    - Windows
+  - Windows
 
-        ```sh
-        afdko_env\Scripts\activate.bat
-        ```
+    ```sh
+    afdko_env\Scripts\activate.bat
+    ```
 
 - Install [afdko](https://pypi.python.org/pypi/afdko):
 
@@ -106,28 +108,36 @@ Note for Linux users (and users of other platforms that are not macOS or Windows
 Installing the **afdko** inside a virtual environment prevents conflicts
 between its dependencies and other modules installed globally.
 
-**Option 2 (not recommended unless there is a global conflict)**
+#### Option 2 (not recommended unless there is a global conflict)
 
 Local user installation [afdko](https://pypi.python.org/pypi/afdko) ([info](https://pip.pypa.io/en/stable/user_guide/?highlight=%E2%80%93%20user#user-installs)):
 
-    python -m pip install --user afdko
+```sh
+python -m pip install --user afdko
+```
 
 ### Updating
 
 Use the `-U` (or `--upgrade`) option to update the afdko (and its
 dependencies) to the newest stable release:
 
-    python -m pip install -U afdko
+```sh
+python -m pip install -U afdko
+```
 
 To get pre-release and in-development versions, use the `--pre` flag:
 
-    python -m pip install -U afdko --pre
+```sh
+python -m pip install -U afdko --pre
+```
 
 ### Uninstalling
 
 To remove the afdko package use the command:
 
-    python -m pip uninstall afdko
+```sh
+python -m pip uninstall afdko
+```
 
 Build from source
 -----------------
@@ -136,14 +146,18 @@ First you must have installed the development tools for your platform.
 
 On macOS, install these with:
 
-    xcode-select --install
+```sh
+xcode-select --install
+```
 
 On Linux (Ubuntu 17.10 LTS or later), install these with:
 
-    apt-get -y install python3.9
-    apt-get -y install python-pip
-    apt-get -y install python-dev
-    apt-get -y install uuid-dev
+```sh
+apt-get -y install python3.9
+apt-get -y install python-pip
+apt-get -y install python-dev
+apt-get -y install uuid-dev
+```
 
 On other POSIX-like operating systems, `libuuid` and its header files
 may be in a package named `libuuid-devel`, `util-linux-libs` or `uuid-dev`. The
@@ -152,19 +166,23 @@ source code for `libuuid` is maintained in the
 
 On Windows, you need Visual Studio 2017 or later.
 
-
 To build the **afdko** from source, clone the [afdko GitHub
 repository](https://github.com/adobe-type-tools/afdko), ensure the `wheel`
 module is installed (`python -m pip install wheel`), then `cd` to the top-level
 directory of the afdko, and run:
 
-    python -m pip install .
+```sh
+python -m pip install .
+```
 
 Developing
 -----------------
+
 If you'd like to develop & debug AFDKO using Xcode, run:
 
-    CMake -G Xcode .
+```sh
+CMake -G Xcode .
+```
 
 For further information on building from source see
 [docs/FDK\_Build\_Notes.md](docs/FDK_Build_Notes.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "afdko"
 description = "Adobe Font Development Kit for OpenType"
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "Apache License, Version 2.0"}
+license = "Apache-2.0"
 keywords = ["font", "development", "tools"]
 authors = [
     {email = "afdko@adobe.com"},
@@ -22,7 +22,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -103,7 +102,7 @@ metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.setuptools_scm]
 
-[tool.pytest.ini_options]
+[tool.pytest]
 filterwarnings = [
     "ignore:tostring:DeprecationWarning",
     "ignore:fromstring:DeprecationWarning",


### PR DESCRIPTION
## Description

Enhancements include updating the Python version requirement from 3.9 to 3.10 in the README and `pyproject.toml`, addressing deprecated fields in the configuration, and improving documentation formatting. The changes ensure compatibility with the latest standards and improve clarity for users.

## Checklist:

- [x ] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ X] I have added **test code and data** to prove that my code functions correctly
- [x ] I have verified that new and existing tests pass locally with my changes

The same 31 tests fail on my system with either the old or the new pyproject file.

- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation

