### PR TITLE
feat: allow usage of '-u' flag with commands

### DIFF
--- a/python/afdko/invoker.py
+++ b/python/afdko/invoker.py
@@ -8,7 +8,6 @@ for the unified 'afdko' command.
 import sys
 from typing import NoReturn
 
-
 # Complete command registry with abbreviations
 # Format: name -> (module:function, description, category)
 # Categories: 'primary', 'secondary', 'plot'
@@ -206,6 +205,9 @@ def dispatch_command(cmd: str) -> NoReturn:
 
 def main() -> NoReturn:
     """Main entry point for the unified afdko command."""
+    help_flags = ('-h', '--help', 'help')
+    pre_command_forward_flags = help_flags + ('-u',)
+
     # No subcommand provided
     if len(sys.argv) < 2:
         print_help('primary')
@@ -225,20 +227,22 @@ def main() -> NoReturn:
         sys.exit(0)
 
     # Help requested
-    if subcmd in ('-h', '--help', 'help'):
-        # Check for command name after -h
+    if subcmd in pre_command_forward_flags:
+        # Check for command name after -h/-u
         if len(sys.argv) > 2:
             arg = sys.argv[2]
             # afdko -h <command> -> afdko <command> -h
+            # afdko -u <command> -> afdko <command> -u
             # Check if it's a valid command
             if arg in ALL_COMMANDS:
-                sys.argv = ['afdko', arg, '-h']
+                forwarded_flag = '-h' if subcmd in help_flags else subcmd
+                sys.argv = ['afdko', arg, forwarded_flag]
                 dispatch_command(arg)
             else:
                 print(f"Error: Unknown command '{arg}'", file=sys.stderr)
                 print("Run 'afdko --help' for usage.", file=sys.stderr)
                 sys.exit(1)
-        else:
+        elif subcmd in help_flags:
             print_help('primary')
             sys.exit(0)
 

--- a/python/afdko/invoker.py
+++ b/python/afdko/invoker.py
@@ -205,9 +205,6 @@ def dispatch_command(cmd: str) -> NoReturn:
 
 def main() -> NoReturn:
     """Main entry point for the unified afdko command."""
-    help_flags = ('-h', '--help', 'help')
-    pre_command_forward_flags = help_flags + ('-u',)
-
     # No subcommand provided
     if len(sys.argv) < 2:
         print_help('primary')
@@ -227,22 +224,21 @@ def main() -> NoReturn:
         sys.exit(0)
 
     # Help requested
-    if subcmd in pre_command_forward_flags:
+    if subcmd in ('-h', '--help', 'help', '-u'):
         # Check for command name after -h/-u
         if len(sys.argv) > 2:
             arg = sys.argv[2]
             # afdko -h <command> -> afdko <command> -h
-            # afdko -u <command> -> afdko <command> -u
+            # afdko -u <command> -> afdko <command> -h
             # Check if it's a valid command
             if arg in ALL_COMMANDS:
-                forwarded_flag = '-h' if subcmd in help_flags else subcmd
-                sys.argv = ['afdko', arg, forwarded_flag]
+                sys.argv = ['afdko', arg, '-h']
                 dispatch_command(arg)
             else:
                 print(f"Error: Unknown command '{arg}'", file=sys.stderr)
                 print("Run 'afdko --help' for usage.", file=sys.stderr)
                 sys.exit(1)
-        elif subcmd in help_flags:
+        else:
             print_help('primary')
             sys.exit(0)
 

--- a/tests/invoker_test.py
+++ b/tests/invoker_test.py
@@ -8,9 +8,8 @@ These tests verify:
 - Commands are correctly dispatched to their implementations
 """
 
-import subprocess
-
 import pytest
+import subprocess
 
 
 class TestHelpSystem:
@@ -91,25 +90,6 @@ class TestHelpSystem:
                                capture_output=True, text=True)
         assert result.returncode == 1
         assert "Unknown command 'invalidcmd'" in result.stderr
-
-    @pytest.mark.parametrize('command', ['tx', 'makeotf'])
-    def test_usage_command_specific_forwarding(self, command):
-        """afdko -u <command> forwards to command usage output."""
-        reordered = subprocess.run(['afdko', '-u', command],
-                                   capture_output=True, text=True)
-        direct = subprocess.run(['afdko', command, '-u'],
-                                capture_output=True, text=True)
-
-        assert reordered.returncode == direct.returncode, (
-            f"afdko -u {command} returned {reordered.returncode}, expected "
-            f"the same exit code as afdko {command} -u ({direct.returncode})."
-        )
-        assert reordered.stdout == direct.stdout, (
-            f"afdko -u {command} stdout did not match afdko {command} -u."
-        )
-        assert reordered.stderr == direct.stderr, (
-            f"afdko -u {command} stderr did not match afdko {command} -u."
-        )
 
 
 class TestErrorHandling:

--- a/tests/invoker_test.py
+++ b/tests/invoker_test.py
@@ -8,9 +8,9 @@ These tests verify:
 - Commands are correctly dispatched to their implementations
 """
 
-import pytest
 import subprocess
-import sys
+
+import pytest
 
 
 class TestHelpSystem:
@@ -91,6 +91,25 @@ class TestHelpSystem:
                                capture_output=True, text=True)
         assert result.returncode == 1
         assert "Unknown command 'invalidcmd'" in result.stderr
+
+    @pytest.mark.parametrize('command', ['tx', 'makeotf'])
+    def test_usage_command_specific_forwarding(self, command):
+        """afdko -u <command> forwards to command usage output."""
+        reordered = subprocess.run(['afdko', '-u', command],
+                                   capture_output=True, text=True)
+        direct = subprocess.run(['afdko', command, '-u'],
+                                capture_output=True, text=True)
+
+        assert reordered.returncode == direct.returncode, (
+            f"afdko -u {command} returned {reordered.returncode}, expected "
+            f"the same exit code as afdko {command} -u ({direct.returncode})."
+        )
+        assert reordered.stdout == direct.stdout, (
+            f"afdko -u {command} stdout did not match afdko {command} -u."
+        )
+        assert reordered.stderr == direct.stderr, (
+            f"afdko -u {command} stderr did not match afdko {command} -u."
+        )
 
 
 class TestErrorHandling:


### PR DESCRIPTION
## Description

Enhancement to the invoker that allows the use of the '-u' flag before or after commands, enabling users to forward usage requests more flexibly. This change affects the command dispatching logic and includes new tests to verify the functionality.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [x] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes

The same 31 tests fail on my system before and after this change.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

