### PR TITLE
Fix typing_extensions dependency and spot isprint locale issue

### DIFF
--- a/c/spot/name.c
+++ b/c/spot/name.c
@@ -2,12 +2,13 @@
    This software is licensed as OpenSource, under the Apache License, Version 2.0.
    This license is available at: http://opensource.org/licenses/Apache-2.0. */
 
-#include <ctype.h>
-
 #include "name.h"
 #include "desc.h"
 #include "sfnt_name.h"
 #include "sfnt.h"
+
+/* ASCII printable range (0x20-0x7e) - locale-independent alternative to isprint() */
+#define IS_ASCII_PRINT(c) ((c) >= 0x20 && (c) <= 0x7e)
 
 static nameTbl *name = NULL;
 static int loaded = 0;
@@ -75,7 +76,7 @@ static void dumpString(NameRecord *record, int level) {
         if (twoByte)
             code = code << 8 | *p++;
 
-        if ((code & 0xff00) == 0 && isprint(code))
+        if (IS_ASCII_PRINT(code))
             DL(3, (OUTPUTBUFF, "%c", (int)code));
         else
             DL(3, (OUTPUTBUFF, "\\%0*x", precision, code));
@@ -95,7 +96,7 @@ static void dumpLanguageTagString(LangTagRecord *langTagRec, int level) {
 
         code = code << 8 | *p++;
 
-        if ((code & 0xff00) == 0 && isprint(code))
+        if (IS_ASCII_PRINT(code))
             DL(3, (OUTPUTBUFF, "%c", (int)code));
         else
             DL(3, (OUTPUTBUFF, "\\%0*x", precision, code));
@@ -116,7 +117,7 @@ static void makeString(NameRecord *record, int8_t *str) {
         if (twoByte)
             code = code << 8 | *p++;
 
-        if ((code & 0xff00) == 0 && isprint(code)) {
+        if (IS_ASCII_PRINT(code)) {
             *strptr++ = (int8_t)code;
             len++;
         }

--- a/c/spot/sfnt.c
+++ b/c/spot/sfnt.c
@@ -6,10 +6,13 @@
  * sfnt reading/dumping.
  */
 
-#include <ctype.h>
 #include <string.h>
 
 #include "sfnt.h"
+
+/* ASCII printable range (0x20-0x7e) - locale-independent alternative to isprint() */
+#define IS_ASCII_PRINT(c) ((c) >= 0x20 && (c) <= 0x7e)
+
 #include "sfnt_sfnt.h"
 
 #include "BASE.h"
@@ -715,7 +718,7 @@ static void hexDump(uint32_t tag, int32_t start, uint32_t length) {
         fprintf(OUTPUTBUFF, " |");
         for (i = 0; i < 16; i++)
             if (i < left)
-                fprintf(OUTPUTBUFF, "%c", isprint(data[i]) ? data[i] : data[i] ? '?' : '.');
+                fprintf(OUTPUTBUFF, "%c", IS_ASCII_PRINT(data[i]) ? data[i] : data[i] ? '?' : '.');
             else
                 fprintf(OUTPUTBUFF, " ");
         fprintf(OUTPUTBUFF, "|\n");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
 ]
 dependencies = [
+    "typing_extensions >= 4.0; python_version < '3.11'",
     "lxml >= 6.0.0",
     "booleanOperations >= 0.9.0",
     "defcon[lxml,pens] >= 0.10.3",

--- a/python/afdko/otfautohint/glyphData.py
+++ b/python/afdko/otfautohint/glyphData.py
@@ -11,9 +11,11 @@ from math import sqrt
 from collections import defaultdict
 from builtins import tuple as _tuple
 from typing import Iterator, Any, Callable
-try:
+import sys
+
+if sys.version_info >= (3, 11):
     from typing import Self
-except ImportError:
+else:
     from typing_extensions import Self
 
 from fontTools.misc.bezierTools import (

--- a/python/afdko/otfautohint/glyphData.py
+++ b/python/afdko/otfautohint/glyphData.py
@@ -11,7 +11,10 @@ from math import sqrt
 from collections import defaultdict
 from builtins import tuple as _tuple
 from typing import Iterator, Any, Callable
-from typing_extensions import Self
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 from fontTools.misc.bezierTools import (
     solveQuadratic,

--- a/python/afdko/otfautohint/hinter.py
+++ b/python/afdko/otfautohint/hinter.py
@@ -18,7 +18,10 @@ from typing import (
     Iterable,
     NamedTuple,
 )
-from typing_extensions import Self
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 from fontTools.misc.bezierTools import solveCubic
 

--- a/python/afdko/otfautohint/hinter.py
+++ b/python/afdko/otfautohint/hinter.py
@@ -11,6 +11,7 @@ to an optimal set.
 import logging
 import bisect
 import math
+import sys
 from copy import copy, deepcopy
 from abc import abstractmethod, ABC
 from typing import (
@@ -18,9 +19,10 @@ from typing import (
     Iterable,
     NamedTuple,
 )
-try:
+
+if sys.version_info >= (3, 11):
     from typing import Self
-except ImportError:
+else:
     from typing_extensions import Self
 
 from fontTools.misc.bezierTools import solveCubic

--- a/python/afdko/otfautohint/hintstate.py
+++ b/python/afdko/otfautohint/hintstate.py
@@ -19,9 +19,11 @@ from typing import (
     Set,
     Protocol,
 )
-try:
+import sys
+
+if sys.version_info >= (3, 11):
     from typing import Self
-except ImportError:
+else:
     from typing_extensions import Self
 
 log: logging.Logger = logging.getLogger(__name__)

--- a/python/afdko/otfautohint/hintstate.py
+++ b/python/afdko/otfautohint/hintstate.py
@@ -19,7 +19,10 @@ from typing import (
     Set,
     Protocol,
 )
-from typing_extensions import Self
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 log: logging.Logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Fixes two bugs reported by Ken Lunde:

1. **otfautohint/otfstemhist fail with "No module named 'typing_extensions'"**
   - Add `typing_extensions` as conditional dependency for Python < 3.11
   - Use try/except import pattern to use stdlib `Self` on Python 3.11+
   - Prevents import errors on Python 3.10

2. **spot renders U+00A9 (copyright) as U+FFFD in name table output**
   - Replace locale-dependent `isprint()` with explicit ASCII range check (0x20-0x7e)
   - Add `IS_ASCII_PRINT` macro in name.c and sfnt.c
   - Remove unused `ctype.h` includes
   - Ensures consistent output across all locales and terminal configurations

## Test plan

- [x] Built locally with editable install
- [x] All 1615 tests pass (10 parallel workers, 3:04 runtime)
- [x] Verified `otfautohint` and `otfstemhist` commands load without errors
- [x] Verified `Self` type hint imports successfully

## Notes

Bug #2 is not a 5.0 regression - existed in 4.0.3 and earlier. The code logic is identical; only type names were modernized (Card8 → uint8_t, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)