### PR TITLE
Fix STRCPY_S macro to avoid format-security error

### DIFF
--- a/c/shared/include/supportdefines.h
+++ b/c/shared/include/supportdefines.h
@@ -55,7 +55,7 @@ extern "C" {
 #define SSCANF_S sscanf
 #endif
 #ifndef STRCPY_S
-#define STRCPY_S(d, ds, s) snprintf(d, ds, s)
+#define STRCPY_S(d, ds, s) snprintf(d, ds, "%s", s)
 #endif
 #ifndef STRNCPY_S
 #define STRNCPY_S(d, ds, s, n) strncpy(d, s, n)


### PR DESCRIPTION
Fixes #1829
