### PR TITLE
Fix variable font test files and add comprehensive test coverage

### DIFF
--- a/tests/addfeatures_data/input/var/00_foundation/locationDef_basic.fea
+++ b/tests/addfeatures_data/input/var/00_foundation/locationDef_basic.fea
@@ -2,21 +2,25 @@
 # Level 0: Foundation test
 # Dependencies: None
 # Tests: Simple locationDef with single and multiple axes
+# ENHANCED: Added zero/max/min normalized patterns from repo
 
 languagesystem DFLT dflt;
 
-# Single axis locations
-locationDef wght=200d @Light;
-locationDef wght=400d @Regular;
+# Single axis locations (no @Regular since wght=400d is the default)
+locationDef wght=200d @ExtraLight;
 locationDef wght=700d @Bold;
 locationDef wght=900d @Black;
 
 # Single axis with different unit (normalized)
-locationDef wght=200n @LightN;
+locationDef wght=200n @ExtraLightN;
 locationDef wght=1000n @BlackN;
 
-# Multiple axes
-locationDef wght=400d,opsz=20d @RegularText;
+# Define locations using normalized units (n) - from repo
+locationDef wght=0n, opsz=0n @DefaultLocation;
+locationDef wght=1n @MaxWeight;
+locationDef wght=-1n @MinWeight;
+
+# Multiple axes (no @RegularText since wght=400d,opsz=20d is the full default)
 locationDef wght=700d,opsz=20d @BoldText;
 locationDef wght=400d,opsz=60d @RegularDisplay;
 locationDef wght=700d,opsz=60d @BoldDisplay;

--- a/tests/addfeatures_data/input/var/01_location_references/inline_location_single.fea
+++ b/tests/addfeatures_data/input/var/01_location_references/inline_location_single.fea
@@ -1,18 +1,18 @@
 # Test: Single inline location references
 # Level 1: Location references
 # Dependencies: 00_foundation/locationDef_basic.fea
-# Tests: Basic inline (axis=value:metric) syntax
+# Tests: Basic inline (axis=value:metric) syntax with complete min/default/max
 
 languagesystem DFLT dflt;
 
-# Single axis, single variation point
-valueRecordDef (wght=400d:50) VAL1;
-valueRecordDef (wght=700d:60) VAL2;
+# Single axis with design units - complete min/default/max
+valueRecordDef (50 wght=200d:45 wght=900d:60) VAL1;
+valueRecordDef (60 wght=200d:55 wght=900d:70) VAL2;
 
-# Using normalized units
-valueRecordDef (wght=0n:50) VAL3;
-valueRecordDef (wght=1000n:70) VAL4;
+# Using normalized units - complete min/default/max
+valueRecordDef (50 wght=-1n:45 wght=1n:60) VAL3;
+valueRecordDef (70 wght=-1n:60 wght=1n:85) VAL4;
 
-# In anchors
-anchorDef (250 wght=400d:240) 620 anc1;
-anchorDef (250 wght=700d:260) 620 anc2;
+# In anchors - complete min/default/max
+anchorDef (250 wght=200d:240 wght=900d:260) 620 anc1;
+anchorDef (260 wght=200d:250 wght=900d:270) 620 anc2;

--- a/tests/addfeatures_data/input/var/01_location_references/named_location_single.fea
+++ b/tests/addfeatures_data/input/var/01_location_references/named_location_single.fea
@@ -1,18 +1,20 @@
 # Test: Named location references
 # Level 1: Location references
 # Dependencies: 00_foundation/locationDef_basic.fea
-# Tests: Using @location labels in value records and anchors
+# Tests: Using @location labels in value records and anchors with complete min/default/max
 
 languagesystem DFLT dflt;
 
-# Define locations
-locationDef wght=400d @Regular;
-locationDef wght=700d @Bold;
+# Define locations at min, intermediate, and max (no @Regular since it's default)
+locationDef wght=200d @ExtraLight;
+locationDef wght=600d @Semibold;
+locationDef wght=900d @Black;
 
-# Use named locations in value records
-valueRecordDef (@Regular:50) VAL_REG;
-valueRecordDef (@Bold:60) VAL_BOLD;
-valueRecordDef (@Regular:50 @Bold:60) VAL_BOTH;
+# Use named locations in value records - complete min/default/max
+valueRecordDef (50 @ExtraLight:45 @Black:60) VAL_MIN_MAX;
+valueRecordDef (60 @ExtraLight:55 @Black:70) VAL_BOTH;
+valueRecordDef (55 @ExtraLight:50 @Semibold:57 @Black:65) VAL_ALL_THREE;
 
-# Use named locations in anchors
-anchorDef (250 @Regular:240 @Bold:260) 620 anc1;
+# Use named locations in anchors - complete min/default/max
+anchorDef (250 @ExtraLight:240 @Black:260) 620 anc1;
+anchorDef (260 @ExtraLight:250 @Semibold:265 @Black:270) 620 anc2;

--- a/tests/addfeatures_data/input/var/02_value_constructs/valueRecordDef_inline.fea
+++ b/tests/addfeatures_data/input/var/02_value_constructs/valueRecordDef_inline.fea
@@ -1,15 +1,15 @@
 # Test: Value records with inline locations
 # Level 2: Value constructs
 # Dependencies: 01_location_references/inline_location_single.fea
-# Tests: ValueRecordDef using inline location syntax
+# Tests: ValueRecordDef using inline location syntax with complete min/default/max
 
 languagesystem DFLT dflt;
 
-# Single value with variation
-valueRecordDef (50 wght=400d:47 wght=700d:53) KERN1;
+# Single value with variation - complete min/default/max
+valueRecordDef (50 wght=200d:45 wght=900d:55) KERN1;
 
-# Value record with multiple metrics
-valueRecordDef (<10 20 30 40> wght=400d:<8 18 28 38>) VAL_RECORD;
+# Value record with multiple metrics - complete min/default/max
+valueRecordDef (<10 20 30 40> wght=200d:<8 18 28 38> wght=900d:<12 22 32 42>) VAL_RECORD;
 
-# Multiple variations
-valueRecordDef (wght=200d:45 wght=400d:50 wght=900d:60) KERN2;
+# Multiple variations - complete min/default/max (was missing default!)
+valueRecordDef (50 wght=200d:45 wght=900d:60) KERN2;

--- a/tests/addfeatures_data/input/var/variable_comprehensive.fea
+++ b/tests/addfeatures_data/input/var/variable_comprehensive.fea
@@ -1,5 +1,6 @@
 # Comprehensive Variable Font Grammar Test
 # Tests all variable font features added to afdko4
+# FIXED: All variable values have complete min/default/max
 
 languagesystem DFLT dflt;
 
@@ -7,23 +8,23 @@ languagesystem DFLT dflt;
 # 1. LOCATIONDEF STATEMENTS (LocationDefMode)
 # ============================================================================
 
-# Single axis, design units
-locationDef wght=400d @Regular;
-locationDef wght=700d @Bold;
+# Single axis at min and max for design units (no @Regular since it's the default)
+locationDef wght=200d @ExtraLight;
+locationDef wght=900d @Black;
 
-# Single axis, user units
+# Single axis, user units (testing user unit syntax)
 locationDef wght=400u @RegularUser;
 
 # Single axis, normalized
+locationDef wght=-1n @Min;
 locationDef wght=0n @Default;
 locationDef wght=1n @Max;
 
-# Multiple axes
-locationDef wght=400d, opsz=20d @RegMid;
+# Multiple axes (no location at wght=400d,opsz=20d since that's the full default)
 locationDef wght=700d, opsz=8d @BoldSmall;
 
-# Negative values
-locationDef wght=-100d @ExtraLight;
+# Negative values (design units can be negative for extralight)
+locationDef wght=-100d @NegativeExample;
 
 # Decimal values
 locationDef wght=450.5d @Medium;
@@ -35,32 +36,35 @@ locationDef wght=450.5d @Medium;
 # Single value in parens (variable)
 valueRecordDef (50) VAL_SINGLE;
 
-# Single value with named location
-valueRecordDef (@Regular:50) VAL_NAMED;
+# Value with named location - complete min/default/max
+valueRecordDef (50 @ExtraLight:45 @Black:60) VAL_NAMED;
 
-# Single value with inline location WITHOUT SPACES (the key fix!)
-valueRecordDef (wght=400d:47) VAL_INLINE_NOSPACE;
+# Single value with inline location WITHOUT SPACES (the key fix!) - complete min/default/max
+valueRecordDef (47 wght=200d:42 wght=900d:54) VAL_INLINE_NOSPACE;
 
-# Single value with inline location WITH spaces
-valueRecordDef (wght=400d : 47) VAL_INLINE_SPACE;
+# Single value with inline location WITH spaces - complete min/default/max
+valueRecordDef (47 wght=200d : 42 wght=900d : 54) VAL_INLINE_SPACE;
 
-# Multiple location:value pairs WITHOUT SPACES
-valueRecordDef (wght=400d:47 wght=700d:54) VAL_MULTI_NOSPACE;
+# Multiple location:value pairs WITHOUT SPACES - complete min/default/max
+valueRecordDef (47 wght=200d:42 wght=900d:54) VAL_MULTI_NOSPACE;
 
-# Multiple location:value pairs WITH spaces
-valueRecordDef (wght=400d : 47 wght=700d : 54) VAL_MULTI_SPACE;
+# Multiple location:value pairs WITH spaces - complete min/default/max
+valueRecordDef (47 wght=200d : 42 wght=900d : 54) VAL_MULTI_SPACE;
 
-# Multiple location:value pairs MIXED spacing
-valueRecordDef (wght=400d:47 wght=700d : 54) VAL_MULTI_MIXED;
+# Multiple location:value pairs MIXED spacing - complete min/default/max
+valueRecordDef (47 wght=200d:42 wght=900d : 54) VAL_MULTI_MIXED;
 
-# Mixed inline and named locations
-valueRecordDef (wght=400d:47 @Bold:54) VAL_MIXED_INLINE_NAMED;
+# Mixed inline and named locations - complete min/default/max
+valueRecordDef (47 wght=200d:42 @Black:54) VAL_MIXED_INLINE_NAMED;
 
-# Value record literals (angle brackets) with named locations
-valueRecordDef (@Regular:<-80 0 -160 0>) VAL_RECORD;
+# Value record literals (angle brackets) with named locations - complete min/default/max
+valueRecordDef (<-80 0 -160 0> @ExtraLight:<-70 0 -150 0> @Black:<-90 0 -170 0>) VAL_RECORD;
 
-# Value record literals with inline locations
-valueRecordDef (wght=400d:<-80 0 -160 0>) VAL_RECORD_INLINE;
+# Four-value record with one variable component (from phase1) - complete min/default/max
+valueRecordDef <0 0 (20 @ExtraLight:15 @Black:25) 0> KERN_C;
+
+# Value record literals with inline locations - complete min/default/max
+valueRecordDef (<-80 0 -160 0> wght=200d:<-70 0 -150 0> wght=900d:<-90 0 -170 0>) VAL_RECORD_INLINE;
 
 # Plain number (static)
 valueRecordDef 100 VAL_PLAIN;
@@ -72,32 +76,36 @@ valueRecordDef 100 VAL_PLAIN;
 # Simple static anchor
 anchorDef 250 620 top;
 
-# Variable anchor with inline locations - NO SPACES
-anchorDef (250 wght=400d:240 wght=700d:260) 620 top_var;
+# Variable anchor with inline locations - NO SPACES - complete min/default/max
+anchorDef (250 wght=200d:240 wght=900d:260) 620 top_var;
 
-# Variable anchor with inline locations - WITH SPACES
-anchorDef (250 wght=400d : 240 wght=700d : 260) 620 top_var_space;
+# Variable anchor with inline locations - WITH SPACES - complete min/default/max
+anchorDef (250 wght=200d : 240 wght=900d : 260) 620 top_var_space;
 
-# Variable anchor with named locations
-anchorDef (250 @Regular:240 @Bold:260) 620 top_named;
+# Variable anchor with named locations - complete min/default/max
+anchorDef (250 @ExtraLight:240 @Black:260) 620 top_named;
 
-# Variable anchor with value records
-anchorDef (<250 620> @Regular:<240 620> @Bold:<260 620>) top_record;
+# Variable anchor with value records - complete min/default/max
+anchorDef (<250 620> @ExtraLight:<240 620> @Black:<260 620>) top_record;
+
+# Variable anchor with separate x and y values (from phase1) - complete min/default/max
+# Note: Using anchorDef instead of markClass to avoid missing glyph errors
+anchorDef (250 @ExtraLight:240 @Black:260) (620 @ExtraLight:610 @Black:630) top_separate_xy;
 
 # ============================================================================
 # 4. MARK CLASS - Variable Anchors in Mark Statements
 # ============================================================================
 
-@MARKS = [acute grave];
+@MARKS = [a e];
 
 # Static mark class
 markClass [a b c] <anchor 250 620> @BASE_MARKS;
 
-# Variable mark class - inline locations NO SPACES
-markClass acute <anchor (250 wght=400d:240 wght=700d:260) 620> @TOP_MARKS;
+# Variable mark class - inline locations NO SPACES - complete min/default/max
+markClass a <anchor (250 wght=200d:240 wght=900d:260) 620> @TOP_MARKS;
 
-# Variable mark class - inline locations WITH SPACES
-markClass grave <anchor (250 wght=400d : 240 wght=700d : 260) 620> @TOP_MARKS_SPACE;
+# Variable mark class - inline locations WITH SPACES - complete min/default/max
+markClass e <anchor (250 wght=200d : 240 wght=900d : 260) 620> @TOP_MARKS_SPACE;
 
 # ============================================================================
 # 5. GLYPH NAMES - d, u, n as glyphs (AXISUNIT removed from default mode)
@@ -107,7 +115,8 @@ markClass grave <anchor (250 wght=400d : 240 wght=700d : 260) 620> @TOP_MARKS_SP
 @AXIS_LETTERS = [d u n];
 
 # Extended names with colons (EXTNAME in default mode)
-@EXTENDED = [d:47 u:48 n:49];
+# Note: These glyphs don't exist in test font, commented out
+# @EXTENDED = [d:47 u:48 n:49];
 
 # ============================================================================
 # 6. VARIABLE METRICS - singleValueLiteral in table statements
@@ -118,16 +127,16 @@ table OS/2 {
     TypoAscender 750;
     TypoDescender -250;
 
-    # Variable values with named locations
-    XHeight (@Regular:500);
-    CapHeight (@Regular:700);
+    # Variable values with named locations - complete min/default/max
+    XHeight (500 @ExtraLight:480 @Black:520);
+    CapHeight (700 @ExtraLight:680 @Black:720);
 
-    # Variable values with inline locations
-    SubscriptXSize (wght=400d:100);
-    SubscriptYSize (wght=400d:100);
-    SuperscriptXSize (wght=400d:100);
-    SuperscriptYSize (wght=400d:100);
-    StrikeoutSize (wght=400d:50);
+    # Variable values with inline locations - complete min/default/max
+    SubscriptXSize (100 wght=200d:90 wght=900d:110);
+    SubscriptYSize (100 wght=200d:90 wght=900d:110);
+    SuperscriptXSize (100 wght=200d:90 wght=900d:110);
+    SuperscriptYSize (100 wght=200d:90 wght=900d:110);
+    StrikeoutSize (50 wght=200d:45 wght=900d:55);
 } OS/2;
 
 table hhea {
@@ -136,23 +145,23 @@ table hhea {
     Descender -250;
     LineGap 0;
 
-    # Variable values with named locations
-    CaretOffset (@Regular:0);
-    CaretSlopeRise (@Regular:1);
-    CaretSlopeRun (@Regular:0);
+    # Variable values with named locations - complete min/default/max
+    CaretOffset (0 @ExtraLight:0 @Black:0);
+    CaretSlopeRise (1 @ExtraLight:1 @Black:1);
+    CaretSlopeRun (0 @ExtraLight:0 @Black:0);
 } hhea;
 
 table vhea {
-    # Variable values with inline locations
-    VertTypoAscender (wght=400d:750);
-    VertTypoDescender (wght=400d:-250);
-    CaretOffset (wght=400d:0);
+    # Variable values with inline locations - complete min/default/max
+    VertTypoAscender (750 wght=200d:730 wght=900d:770);
+    VertTypoDescender (-250 wght=200d:-230 wght=900d:-270);
+    CaretOffset (0 wght=200d:0 wght=900d:0);
 } vhea;
 
 table vmtx {
-    # Variable vertical metrics
-    VertOriginY A (wght=400d:750);
-    VertAdvanceY A (wght=400d:1000);
+    # Variable vertical metrics - complete min/default/max
+    VertOriginY A (750 wght=200d:730 wght=900d:770);
+    VertAdvanceY A (1000 wght=200d:980 wght=900d:1020);
 } vmtx;
 
 # ============================================================================
@@ -169,11 +178,11 @@ feature test {
     # Note: these glyphs don't exist in our test font, but tests the grammar
     # sub d:47 by A;
 
-    # Single positioning with inline variable value - NO SPACES
-    pos A (wght=400d:10);
+    # Single positioning with inline variable value - NO SPACES - complete min/default/max
+    pos A (10 wght=200d:8 wght=900d:12);
 
-    # Pair positioning with inline variable value - WITH SPACES
-    pos A b (wght=400d : 20);
+    # Pair positioning with inline variable value - WITH SPACES - complete min/default/max
+    pos A b (20 wght=200d : 18 wght=900d : 22);
 } test;
 
 # ============================================================================
@@ -184,6 +193,6 @@ table GDEF {
     # Static ligature caret
     LigatureCaretByPos A 500;
 
-    # Variable ligature caret with inline location
-    LigatureCaretByPos b (wght=400d:500);
+    # Variable ligature caret with inline location - complete min/default/max
+    LigatureCaretByPos b (500 wght=200d:480 wght=900d:520);
 } GDEF;

--- a/tests/addfeatures_data/input/var/variable_whitespace_test.fea
+++ b/tests/addfeatures_data/input/var/variable_whitespace_test.fea
@@ -1,5 +1,6 @@
 # Variable Font Whitespace Variation Tests
 # Tests where whitespace is/isn't required with lexer modes
+# FIXED: All variable values have complete min/default/max
 
 languagesystem DFLT dflt;
 
@@ -7,53 +8,53 @@ languagesystem DFLT dflt;
 # TEST 1: locationDef spacing (LocationDefMode)
 # ============================================================================
 
-# No spaces around operators (should work)
-locationDef wght=400d @Loc1;
-locationDef wght=400d,opsz=20d @Loc2;
+# No spaces around operators (should work) - testing various non-default points
+locationDef wght=200d @Loc1;
+locationDef wght=700d,opsz=8d @Loc2;
+locationDef wght=900d @Loc8;
 
-# Spaces around = (should work)
-locationDef wght = 400d @Loc3;
-locationDef wght =400d @Loc4;
-locationDef wght= 400d @Loc5;
+# Spaces around = (should work) - at intermediate points, not default
+locationDef wght = 600d @Loc3;
+locationDef wght =700d @Loc4;
+locationDef wght= 800d @Loc5;
 
-# Spaces around , (should work)
-locationDef wght=400d , opsz=20d @Loc6;
-locationDef wght=400d, opsz=20d @Loc7;
-locationDef wght=400d ,opsz=20d @Loc8;
+# Spaces around , (should work) - at non-default multi-axis points
+locationDef wght=700d , opsz=8d @Loc6;
+locationDef wght=700d, opsz=60d @Loc7;
 
 # ============================================================================
 # TEST 2: valueRecordDef with inline locations - THE KEY FIX
 # ============================================================================
 
-# NO SPACES around colon (should work - this is the fix!)
-valueRecordDef (wght=400n:50) VAL_NOSPACE;
-valueRecordDef (wght=400n:50 wght=700n:60) VAL_MULTI_NOSPACE;
+# NO SPACES around colon (should work - this is the fix!) - complete min/default/max
+valueRecordDef (50 wght=-1n:45 wght=1n:60) VAL_NOSPACE;
+valueRecordDef (50 wght=-1n:45 wght=1n:60) VAL_MULTI_NOSPACE;
 
-# SPACES around colon (should work)
-valueRecordDef (wght=400n : 50) VAL_SPACE;
-valueRecordDef (wght=400n : 50 wght=700n : 60) VAL_MULTI_SPACE;
+# SPACES around colon (should work) - complete min/default/max
+valueRecordDef (50 wght=-1n : 45 wght=1n : 60) VAL_SPACE;
+valueRecordDef (50 wght=-1n : 45 wght=1n : 60) VAL_MULTI_SPACE;
 
-# Space before colon only (should work?)
-valueRecordDef (wght=400n :50) VAL_SPACE_BEFORE;
+# Space before colon only (should work?) - complete min/default/max
+valueRecordDef (50 wght=-1n :45 wght=1n :60) VAL_SPACE_BEFORE;
 
-# Space after colon only (should work?)
-valueRecordDef (wght=400n: 50) VAL_SPACE_AFTER;
+# Space after colon only (should work?) - complete min/default/max
+valueRecordDef (50 wght=-1n: 45 wght=1n: 60) VAL_SPACE_AFTER;
 
-# Mixed spacing (should work)
-valueRecordDef (wght=400n:50 wght=700n : 60) VAL_MIXED;
+# Mixed spacing (should work) - complete min/default/max
+valueRecordDef (50 wght=-1n:45 wght=1n : 60) VAL_MIXED;
 
 # ============================================================================
 # TEST 3: anchorDef with inline locations
 # ============================================================================
 
-# NO SPACES around colon in anchors (should work - the fix!)
-anchorDef (250 wght=400n:240 wght=700n:260) 620 anc1;
+# NO SPACES around colon in anchors (should work - the fix!) - complete min/default/max
+anchorDef (250 wght=-1n:240 wght=1n:260) 620 anc1;
 
-# WITH SPACES around colon in anchors
-anchorDef (250 wght=400n : 240 wght=700n : 260) 620 anc2;
+# WITH SPACES around colon in anchors - complete min/default/max
+anchorDef (250 wght=-1n : 240 wght=1n : 260) 620 anc2;
 
-# Mixed spacing in anchors
-anchorDef (250 wght=400n:240 wght=700n : 260) 620 anc3;
+# Mixed spacing in anchors - complete min/default/max
+anchorDef (250 wght=-1n:240 wght=1n : 260) 620 anc3;
 
 # ============================================================================
 # TEST 4: Axis unit letters as glyphs (default mode - AXISUNIT removed)
@@ -81,43 +82,43 @@ feature test {
 # TEST 6: Nested parentheses (mode recursion)
 # ============================================================================
 
-# Value records in parens (should work)
-valueRecordDef (@Loc1:<-80 0 -160 0>) VAL_RECORD;
+# Value records in parens (should work) - complete min/default/max
+valueRecordDef (<-80 0 -160 0> @Loc1:<-70 0 -150 0> @Loc8:<-90 0 -170 0>) VAL_RECORD;
 
-# Nested with inline locations - NO SPACES
-valueRecordDef (wght=400n:<-80 0 -160 0>) VAL_RECORD_INLINE;
+# Nested with inline locations - NO SPACES - complete min/default/max
+valueRecordDef (<-80 0 -160 0> wght=-1n:<-70 0 -150 0> wght=1n:<-90 0 -170 0>) VAL_RECORD_INLINE;
 
-# Nested with inline locations - WITH SPACES
-valueRecordDef (wght=400n : <-80 0 -160 0>) VAL_RECORD_SPACE;
+# Nested with inline locations - WITH SPACES - complete min/default/max
+valueRecordDef (<-80 0 -160 0> wght=-1n : <-70 0 -150 0> wght=1n : <-90 0 -170 0>) VAL_RECORD_SPACE;
 
 # ============================================================================
 # TEST 7: locationDef axis value spacing
 # ============================================================================
 
-# No space before unit (should work)
-locationDef wght=400d @Loc9;
+# No space before unit (should work) - at non-default point
+locationDef wght=700d @Loc9;
 
-# Space before unit (should work?)
-locationDef wght=400 d @Loc10;
+# Space before unit (should work?) - at non-default point
+locationDef wght=700 d @Loc10;
 
-# No space after equals (should work)
-locationDef wght=400d @Loc11;
+# No space after equals (should work) - at non-default point
+locationDef wght=700d @Loc11;
 
-# Multiple axes, no spaces at all (should work)
-locationDef wght=400d,opsz=20d @Loc12;
+# Multiple axes, no spaces at all (should work) - at non-default multi-axis
+locationDef wght=700d,opsz=8d @Loc12;
 
 # ============================================================================
 # TEST 8: Inline location axis value spacing
 # ============================================================================
 
-# No space before unit in inline location (should work)
-valueRecordDef (wght=400d:50) VAL_UNIT_NOSPACE;
+# No space before unit in inline location (should work) - complete min/default/max
+valueRecordDef (50 wght=200d:45 wght=900d:60) VAL_UNIT_NOSPACE;
 
-# Space before unit in inline location (should work?)
-valueRecordDef (wght=400 d:50) VAL_UNIT_SPACE;
+# Space before unit in inline location (should work?) - complete min/default/max
+valueRecordDef (50 wght=200 d:45 wght=900 d:60) VAL_UNIT_SPACE;
 
-# No space after equals in inline location (should work)
-valueRecordDef (wght=400d:50) VAL_EQ_NOSPACE;
+# No space after equals in inline location (should work) - complete min/default/max
+valueRecordDef (50 wght=200d:45 wght=900d:60) VAL_EQ_NOSPACE;
 
-# Space after equals in inline location (should work?)
-valueRecordDef (wght= 400d:50) VAL_EQ_SPACE;
+# Space after equals in inline location (should work?) - complete min/default/max
+valueRecordDef (50 wght= 200d:45 wght= 900d:60) VAL_EQ_SPACE;

--- a/tests/addfeatures_test.py
+++ b/tests/addfeatures_test.py
@@ -1260,6 +1260,101 @@ def test_var_mark_positioning():
             f"c+acute {description} wght={wght}, opsz={opsz}: expected y offset {exp_y_off}, got {mark_y_offset}"
 
 
+def test_var_inline_location_single():
+    """Test inline location syntax with single axis."""
+    input_filename = "var/font_var.otf"
+    feat_filename = "var/01_location_references/inline_location_single.fea"
+    ds_filename = "var/font.designspace"
+    actual_path = get_temp_file_path()
+
+    runner(CMD + ['-o',
+                  'f', f'_{get_input_path(input_filename)}',
+                  'ff', f'_{get_input_path(feat_filename)}',
+                  'ds', f'_{get_input_path(ds_filename)}',
+                  'o', f'_{actual_path}'])
+    assert os.path.exists(actual_path)
+
+
+def test_var_named_location_single():
+    """Test named location references with single axis."""
+    input_filename = "var/font_var.otf"
+    feat_filename = "var/01_location_references/named_location_single.fea"
+    ds_filename = "var/font.designspace"
+    actual_path = get_temp_file_path()
+
+    runner(CMD + ['-o',
+                  'f', f'_{get_input_path(input_filename)}',
+                  'ff', f'_{get_input_path(feat_filename)}',
+                  'ds', f'_{get_input_path(ds_filename)}',
+                  'o', f'_{actual_path}'])
+    assert os.path.exists(actual_path)
+
+
+def test_var_valueRecordDef_inline():
+    """Test valueRecordDef statements with inline locations."""
+    input_filename = "var/font_var.otf"
+    feat_filename = "var/02_value_constructs/valueRecordDef_inline.fea"
+    ds_filename = "var/font.designspace"
+    actual_path = get_temp_file_path()
+
+    runner(CMD + ['-o',
+                  'f', f'_{get_input_path(input_filename)}',
+                  'ff', f'_{get_input_path(feat_filename)}',
+                  'ds', f'_{get_input_path(ds_filename)}',
+                  'o', f'_{actual_path}'])
+    assert os.path.exists(actual_path)
+
+
+def test_var_variable_comprehensive():
+    """Test comprehensive variable font features including valueRecordDef, anchors, and table metrics."""
+    input_filename = "var/font_var.otf"
+    feat_filename = "var/variable_comprehensive.fea"
+    ds_filename = "var/font.designspace"
+    actual_path = get_temp_file_path()
+
+    runner(CMD + ['-o',
+                  'f', f'_{get_input_path(input_filename)}',
+                  'ff', f'_{get_input_path(feat_filename)}',
+                  'ds', f'_{get_input_path(ds_filename)}',
+                  'o', f'_{actual_path}'])
+    assert os.path.exists(actual_path)
+
+
+def test_var_whitespace_test():
+    """Test whitespace variations in variable value syntax."""
+    input_filename = "var/font_var.otf"
+    feat_filename = "var/variable_whitespace_test.fea"
+    ds_filename = "var/font.designspace"
+    actual_path = get_temp_file_path()
+
+    runner(CMD + ['-o',
+                  'f', f'_{get_input_path(input_filename)}',
+                  'ff', f'_{get_input_path(feat_filename)}',
+                  'ds', f'_{get_input_path(ds_filename)}',
+                  'o', f'_{actual_path}'])
+    assert os.path.exists(actual_path)
+
+
+def test_var_error_undefined_location():
+    """Test that referencing an undefined location produces proper error."""
+    input_filename = "var/font_var.otf"
+    feat_filename = "var/99_errors/error_undefined_location.fea"
+    ds_filename = "var/font.designspace"
+    actual_path = get_temp_file_path()
+
+    stderr_path = runner(CMD + ['-s', '-e', '-o',
+                                'f', f'_{get_input_path(input_filename)}',
+                                'ff', f'_{get_input_path(feat_filename)}',
+                                'ds', f'_{get_input_path(ds_filename)}',
+                                'o', f'_{actual_path}'])
+
+    with open(stderr_path, 'rb') as f:
+        output = f.read()
+
+    # Should mention the undefined location
+    assert b'DoesNotExist' in output or b'not in list' in output.lower()
+
+
 # ---------------------------------
 # Backwards Compatibility Tests
 # ---------------------------------


### PR DESCRIPTION
Some of the tests added to the repository for variable syntax were never actually hooked up, and as a result were not correct. This corrects the files and hooks them up to our test infrastructure. 