### PR TITLE
Remove outdated macOS Python installation note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,6 @@ Releases are available on the [Python Package
 Index](https://pypi.python.org/pypi/afdko) (PyPI) and can be installed
 with [pip](https://pip.pypa.io).
 
-Note for macOS users: we recommend that you do **not** use the system
-Python. Among other reasons, some versions of macOS ship with Python 2
-and the latest version of the AFDKO is only available for Python 3. You
-can find instructions for using Brew to install Python 3 on macOS here:
-[Installing Python 3 on Mac OS X](https://docs.python-guide.org/starting/install3/osx/).
-Also: [pyenv](https://github.com/pyenv/pyenv) is a great tool for
-installing and managing multiple Python versions on macOS.
-
 Note for all users: we **STRONGLY** recommend the use of a Python virtual
 environment ([`venv`](https://docs.python.org/3/library/venv.html))
 and the use of `python -m pip install <package>` to install all packages


### PR DESCRIPTION
Current macOS versions no longer ship with Python 2, and Python 3 installers are readily available on python.org, so the advice about using Brew or pyenv to install Python is no longer necessary.

Closes adobe-type-tools/afdko#1835

## Description

Replace this text with a description of your changes, indicating whether
it is a bug fix, enhancement, etc. and which general area(s) are affected
(documentation, specific tool, group of tools, tests, etc.).

If the contribution closes (fixes, resolves) a specific open
[issue](https://github.com/adobe-type-tools/afdko/issues), please [link
the issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Checklist:

- [ ] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [ ] I have verified that new and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
