### PR TITLE
Don't form a reference to *end() in prepLookupList

### DIFF
--- a/c/addfeatures/hotconv/otl.cpp
+++ b/c/addfeatures/hotconv/otl.cpp
@@ -674,15 +674,15 @@ void OTL::prepLookupList() {
 
     auto prevl = subtables.begin();
     for (auto sl = prevl + 1; sl <= subtables.end(); sl++) {
-        auto &slr = *sl;
+        Subtable *slr = sl == subtables.end() ? nullptr : sl->get();
         auto &prevlr = *prevl;
-        if (sl == subtables.end() || slr->isRef() || slr->isParam() ||
+        if (slr == nullptr || slr->isRef() || slr->isParam() ||
             slr->index.lookup != prevlr->index.lookup) {
             /* Lookup index change */
             prevlr->span.lookup = sl;
             prevl = sl;
         }
-        if (sl != subtables.end() && (slr->isRef() || slr->isParam()))
+        if (slr != nullptr && (slr->isRef() || slr->isParam()))
             break;
     }
 }


### PR DESCRIPTION
The final loop pass binds slr to *subtables.end(). Nothing is ever read through the reference, but it is undefined behavior and checked STL implementations (_GLIBCXX_DEBUG, MSVC debug iterators) abort there.

## Description

We build with -D_GLIBCXX_DEBUG so this tripped up in a test build

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
