### PR TITLE
Stop binding glyph metrics callbacks to the first GlyphMetrics instance

### DIFF
--- a/c/addfeatures/hotconv/glyphmetrics.cpp
+++ b/c/addfeatures/hotconv/glyphmetrics.cpp
@@ -294,7 +294,7 @@ void GlyphMetrics::processGlyphs(const std::vector<uint16_t> &gids,
 }
 
 void GlyphMetrics::processGlyphs(const std::vector<uint16_t> &gids) {
-    static abfGlyphCallbacks glyphcb = {
+    abfGlyphCallbacks glyphcb = {
         (void *)this,
         NULL,
         NULL,


### PR DESCRIPTION
The function-local static in processGlyphs captures "this" once, so a second conversion in the same process runs the glyph callbacks against the first, already-deleted instance.

## Description

seen in a debugging build that issues arise on reusing a this beyond its lifetime

## Checklist:

- [X ] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [X] I have verified that new and existing tests pass locally with my changes
- [X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
