### PR TITLE
addfeatures/hmtx: avoid unsigned integer underflow

### DIFF
--- a/c/addfeatures/hotconv/hmtx.cpp
+++ b/c/addfeatures/hotconv/hmtx.cpp
@@ -52,12 +52,12 @@ int hmtxFill(hotCtx g) {
     /* Optimize metrics */
     FWord width = hmtx.advanceWidth.back();
     size_t i;
-    for (i = hmtx.advanceWidth.size() - 2; i >= 0; i--) {
-        if (hmtx.advanceWidth[i] != width)
+    for (i = hmtx.advanceWidth.size(); i >= 2; i--) {
+        if (hmtx.advanceWidth[i-2] != width)
             break;
     }
-    if (i + 2 != hmtx.advanceWidth.size())
-        hmtx.advanceWidth.resize(i+2);
+    if (i != hmtx.advanceWidth.size())
+        hmtx.advanceWidth.resize(i);
 
     return hmtx.Fill();
 }


### PR DESCRIPTION
## Description

Bugfix related to https://github.com/NixOS/nixpkgs/issues/535868, `afdko` tests didn't pass on MacOS.

Because `size_t` is unsigned, if `hmtx.advanceWidth.size()` is `1` or `0`, or if the `hmtx.advanceWidth[i] == width` condition is always satisfied, then `i` will underflow (which would pass the loop condition, leading to an attempted out-of-bounds array access, which is UB). This PR prevents that.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [x] I have verified that new and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
