### PR TITLE
Fix UB in prepLookupList: don't dereference or iterate past end()

### DIFF
--- a/c/addfeatures/hotconv/otl.cpp
+++ b/c/addfeatures/hotconv/otl.cpp
@@ -673,18 +673,21 @@ void OTL::prepLookupList() {
     std::stable_sort(subtables.begin(), subtables.end(), Subtable::ltLookupList);
 
     auto prevl = subtables.begin();
-    for (auto sl = prevl + 1; sl <= subtables.end(); sl++) {
+    auto sl = prevl + 1;
+    for (; sl != subtables.end(); sl++) {
         auto &slr = *sl;
         auto &prevlr = *prevl;
-        if (sl == subtables.end() || slr->isRef() || slr->isParam() ||
+        if (slr->isRef() || slr->isParam() ||
             slr->index.lookup != prevlr->index.lookup) {
             /* Lookup index change */
             prevlr->span.lookup = sl;
             prevl = sl;
         }
-        if (sl != subtables.end() && (slr->isRef() || slr->isParam()))
+        if (slr->isRef() || slr->isParam())
             break;
     }
+    if (sl == subtables.end())
+        (*prevl)->span.lookup = subtables.end();
 }
 
 Offset OTL::fillLookupList() {


### PR DESCRIPTION
## Summary

- Restructures the loop in `OTL::prepLookupList()` to avoid two instances of undefined behavior: dereferencing `end()` to form a reference, and incrementing past `end()`
- Uses idiomatic `sl != end()` loop termination with post-loop finalization of the last lookup group
- Fixes the abort seen with `_GLIBCXX_DEBUG` and MSVC debug iterators

Based on the analysis in #1840 by @caolanm — this is an alternative approach that avoids the nullable raw pointer / iterator mixing by restructuring the loop instead.

Supersedes #1840.

## Test plan

- [x] Verified the change compiles
- [ ] Existing test suite (no new tests needed — same fix as #1840, different approach)

🤖 Generated with [Claude Code](https://claude.com/claude-code)