### PR TITLE
Fix Windows CI: stop hardcoding Visual Studio 17 2022 generator

### DIFF
--- a/.github/workflows/testpythonpackage.yml
+++ b/.github/workflows/testpythonpackage.yml
@@ -70,11 +70,9 @@ jobs:
         vs-version: '[17.0,]'
         msbuild-architecture: x64
 
-    - name: Set Windows generator to Visual Studio
+    - name: Set Windows build options
       if: matrix.os == 'windows-latest'
       run: |
-        echo "CMAKE_GENERATOR=Visual Studio 17 2022" >> $GITHUB_ENV
-        echo "CMAKE_GENERATOR_PLATFORM=x64" >> $GITHUB_ENV
         echo "FORCE_BUILD_LIBXML2=ON" >> $GITHUB_ENV
       shell: bash
 


### PR DESCRIPTION
## Summary

- The `windows-latest` GHA runner now ships VS 18 (2025), breaking the hardcoded `CMAKE_GENERATOR=Visual Studio 17 2022`
- Remove the hardcoded `CMAKE_GENERATOR` and `CMAKE_GENERATOR_PLATFORM` env vars — scikit-build-core auto-detects the installed Visual Studio version and architecture
- Keep `FORCE_BUILD_LIBXML2=ON` which is still needed

This is blocking CI on all open PRs (e.g. #1843, #1844).

## Test plan

- [ ] Windows CI job passes (this PR is its own test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)