### PR TITLE
Suppress outdated warnings in addfeatures

### DIFF
--- a/c/addfeatures/hotconv/FeatCtx.cpp
+++ b/c/addfeatures/hotconv/FeatCtx.cpp
@@ -1218,7 +1218,7 @@ void FeatCtx::startTable(Tag tag) {
 void FeatCtx::setGDEFGlyphClassDef(GPat::ClassRec &simple, GPat::ClassRec &ligature,
                                    GPat::ClassRec &mark, GPat::ClassRec &component) {
     gFlags |= seenGDEFGC;
-    g->ctx.GDEFp->setGlyphClass(simple, ligature, mark, component);
+    g->ctx.GDEFp->setGlyphClass(simple, ligature, mark, component, true);
 }
 
 void FeatCtx::createDefaultGDEFClasses() {

--- a/c/addfeatures/hotconv/GDEF.cpp
+++ b/c/addfeatures/hotconv/GDEF.cpp
@@ -112,7 +112,8 @@ void GDEFFree(hotCtx g) {
 }
 
 void GDEF::GlyphClassTable::set(GPat::ClassRec &simple, GPat::ClassRec &ligature,
-                                GPat::ClassRec &mark, GPat::ClassRec &component) {
+                                GPat::ClassRec &mark, GPat::ClassRec &component,
+                                bool isExplicit) {
     // Mark is first because glyphs there take presidence.
     glyphClasses[0] = mark;
     glyphClasses[1] = simple;
@@ -132,7 +133,7 @@ void GDEF::GlyphClassTable::set(GPat::ClassRec &simple, GPat::ClassRec &ligature
             if (!b) {
                 // Don't complain if overriding mark class
                 // or duplicate is part of same class
-                if (seeni->second != 0 && seeni->second != i) {
+                if (isExplicit && seeni->second != 0 && seeni->second != i) {
                     hadConflictingClassDef = true;
                     if (h.g->convertFlags & HOT_VERBOSE) {
                         h.g->ctx.feat->dumpGlyph(gid, 0, 0);

--- a/c/addfeatures/hotconv/GDEF.h
+++ b/c/addfeatures/hotconv/GDEF.h
@@ -35,7 +35,8 @@ class GDEF {
         GlyphClassTable() = delete;
         explicit GlyphClassTable(GDEF &h) : cac(h.g), h(h) {}
         void set(GPat::ClassRec &simple, GPat::ClassRec &ligature,
-                 GPat::ClassRec &mark, GPat::ClassRec &component);
+                 GPat::ClassRec &mark, GPat::ClassRec &component,
+                 bool isExplicit = false);
         static const char *names[4];
         static const uint16_t classIDmap[4];
         Offset fill(Offset offset);
@@ -235,8 +236,9 @@ class GDEF {
         return sizeof(Fixed) + 4 * sizeof(Offset);
     }
     void setGlyphClass(GPat::ClassRec &simpl, GPat::ClassRec &ligature,
-                       GPat::ClassRec &mark, GPat::ClassRec &component) {
-        glyphClassTable.set(simpl, ligature, mark, component);
+                       GPat::ClassRec &mark, GPat::ClassRec &component,
+                       bool isExplicit = false) {
+        glyphClassTable.set(simpl, ligature, mark, component, isExplicit);
     }
     bool addAttachEntry(GID gid, uint16_t contour) {
         return attachTable.add(gid, contour);

--- a/c/addfeatures/hotconv/hot.cpp
+++ b/c/addfeatures/hotconv/hot.cpp
@@ -658,11 +658,6 @@ static void prepWinData(hotCtx g) {
         }
     }
 
-    /* warn if the override values don't sum correctly. */
-    if ((font->TypoAscender.getDefault() - font->TypoDescender.getDefault()) != font->unitsPerEm) {
-        /* can happen only if overrides are used */
-        g->logger->log(sWARNING, "The feature file OS/2 overrides TypoAscender and TypoDescender do not sum to the font em-square.");
-    }
 
     if (!font->TypoLineGap.isInitialized()) {
         font->TypoLineGap.addValue(IS_ROS(g)


### PR DESCRIPTION
## Summary

- Only emit GDEF GlyphClass override warnings when an explicit `GlyphClassDef` statement is present in the feature file. When classes are inferred automatically (from mark attachment rules, ligature substitutions, etc.), conflicts are expected and the resolution order is well-defined — warning about them is just noise.
- Remove the outdated warning that `TypoAscender` and `TypoDescender` must sum to the font em-square. Modern font development (USE_TYPO_METRICS, Google Fonts guidelines, CJK fonts) routinely sets these independently of UPM.

## Test plan

- [x] Full test suite passes (1621 passed, 8 skipped, 8 xfailed)
- [ ] Verify that fonts with explicit `GlyphClassDef` conflicts still produce the warning (with `-v`)
- [ ] Verify that fonts relying on automatic GDEF class inference no longer produce spurious override warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)