### PR TITLE
Pass fetch_content_args to FetchContent_Declare for LibXml2

### DIFF
--- a/third_party/LibXml2/CMakeLists.txt
+++ b/third_party/LibXml2/CMakeLists.txt
@@ -12,6 +12,7 @@ FetchContent_Declare(LibXml2
         GIT_REPOSITORY https://gitlab.gnome.org/GNOME/libxml2.git
         GIT_TAG ${LIBXML2_TAG}
         EXCLUDE_FROM_ALL
+        ${fetch_content_args}
 )
 
 option(AFDKO_BUILD_LIBXML2_SHARED_LIB


### PR DESCRIPTION
## Description
`fetch_content_args` includes `FIND_PACKAGE_ARGS`, but it is never forwarded to `FetchContent_Declare()`, as a result, on CMake >= 3.24, `find_package(LibXml2)` is never attempted and the build always falls back to cloning libxml2 from git.

This also breaks `FORCE_SYSTEM_LIBXML2`, since `CMAKE_REQUIRE_FIND_PACKAGE_LibXml2 `only takes effect when `FIND_PACKAGE_ARGS `is passed to `FetchContent_Declare()`. 
In offline build environments (e.g. distro build systems such as Fedora Koji, which
have no network and no git in the buildroot), configuration fails because CMake tries to clone libxml2 instead of using the installed system library.

`CMake Error at /usr/share/cmake/Modules/ExternalProject/shared_internal_commands.cmake:928 (message):
  error: could not find git for clone of libxml2-populate`

**Note**: `${fetch_content_args}` is appended as the last argument intentionally bcz everything after the `FIND_PACKAGE_ARGS `keyword is forwarded to `find_package()`, so it must come after the other options.

With this change:
On CMake >= 3.24, the system libxml2 is preferred when available, with Git fallback otherwise.
- `FORCE_SYSTEM_LIBXML2 `correctly requires the system library.
- `FORCE_BUILD_LIBXML2 `continues to always build from source.

## Checklist:

- [X ] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
- [ ] I have added **test code and data** to prove that my code functions correctly
- [ ] I have verified that new and existing tests pass locally with my changes
- [X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
