### PR TITLE
Add GitHub Action to notify Slack on new issues

### DIFF
--- a/.github/workflows/automated_issue_triage_pipeline.yml
+++ b/.github/workflows/automated_issue_triage_pipeline.yml
@@ -1,0 +1,47 @@
+name: Automated issue triage pipeline
+
+# Requires two repository secrets: SLACK_WEBHOOK_URL and SLACK_TRIAGE_MESSAGE.
+# In SLACK_TRIAGE_MESSAGE, the literal token __ISSUE_URL__ is replaced with the
+# new issue's URL at run time.
+
+on:
+  issues:
+    types: [opened]
+
+# This job only calls out to Slack; it needs no access to the repo.
+permissions: {}
+
+jobs:
+  notify:
+    runs-on: 'ubuntu-latest'
+
+    steps:
+
+    - name: Post new issue to Slack
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        # Values below are passed through the environment (never interpolated
+        # into the shell) so an attacker-controlled issue cannot inject script.
+        MESSAGE_TEMPLATE: ${{ secrets.SLACK_TRIAGE_MESSAGE }}
+        ISSUE_URL: ${{ github.event.issue.html_url }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${SLACK_WEBHOOK_URL}" ]; then
+          echo "SLACK_WEBHOOK_URL is not configured; skipping Slack notification." >&2
+          exit 0
+        fi
+
+        # Fall back to a minimal, non-sensitive message if the secret template
+        # is unset, so we are still notified of the new issue.
+        template="${MESSAGE_TEMPLATE:-New AFDKO issue: __ISSUE_URL__}"
+        message="${template//__ISSUE_URL__/${ISSUE_URL}}"
+
+        # Build the JSON with jq so the text is correctly escaped.
+        payload="$(jq -n --arg text "${message}" '{text: $text}')"
+
+        curl --silent --show-error --fail \
+          --request POST \
+          --header 'Content-Type: application/json' \
+          --data "${payload}" \
+          "${SLACK_WEBHOOK_URL}"


### PR DESCRIPTION
## What
Adds a workflow that posts a Slack notification when a new issue is opened.

## Why
Surfaces new issues to the maintainer team for triage.

## Checklist:

- [x] I have followed the [Contribution Guidelines](https://github.com/adobe-type-tools/afdko/blob/develop/CONTRIBUTING.md)
~~[ ] I have added **test code and data** to prove that my code functions correctly~~
~~[ ] I have verified that new and existing tests pass locally with my changes~~
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
